### PR TITLE
CL-02: Curate O*NET occupation-skill mapping

### DIFF
--- a/data/lexicons/onet.json
+++ b/data/lexicons/onet.json
@@ -1,0 +1,39896 @@
+[
+  {
+    "job_zone": 3,
+    "sector": "Construction Managers",
+    "skills": [
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.5,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.5,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.88,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.25,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.25,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.25,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.62,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.75,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.5,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.25,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.12,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.25,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.12,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.62,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.25,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.88,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Maintenance Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Services Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conference Center Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Electrical Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Maintenance Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Operations Director (Facilities Ops Director)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Operations Manager (Facilities Ops Manager)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Operations Specialist (Facilities Ops Specialist)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facility Administrator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial Production Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operations Administrator (Ops Administrator)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Property Disposal Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Property Disposal Officer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Property Utilization Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Regional Facilities Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Space Officer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stadium Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Unclaimed Property Officer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "University Housing Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Allocate physical resources within organizations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduct employee training programs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop organizational goals or objectives.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct facility maintenance or repair activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage construction activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage inventories of products or organizational resources.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor facilities or operational systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan facility layouts or designs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational budgets.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational progress or status reports.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Purchase materials, equipment, or other resources.",
+        "type": "dwa"
+      },
+      {
+        "importance": 4.21,
+        "level": 4.57,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.31,
+        "level": 3.99,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.11,
+        "level": 2.01,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.32,
+        "level": 3.45,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.77,
+        "level": 3.35,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.63,
+        "level": 2.28,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 4.06,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.37,
+        "level": 5.05,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.39,
+        "level": 2.5,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.9,
+        "level": 2.65,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.27,
+        "level": 4.41,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.05,
+        "level": 3.49,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.77,
+        "level": 3.7,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.26,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 1.26,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.74,
+        "level": 1.18,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.28,
+        "level": 2.38,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.44,
+        "level": 0.9,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.06,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.11,
+        "level": 3.3,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.36,
+        "level": 3.97,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.98,
+        "level": 1.29,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.41,
+        "level": 3.98,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.68,
+        "level": 1.74,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.47,
+        "level": 2.48,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.64,
+        "level": 2.86,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.29,
+        "level": 4.13,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.47,
+        "level": 4.11,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.22,
+        "level": 2.02,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.46,
+        "level": 2.32,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.47,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.67,
+        "level": 2.96,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.99,
+        "level": 2.35,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.38,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 3.25,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.5,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.38,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.12,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.75,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.62,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.75,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.75,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.25,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acquire, distribute and store supplies.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduct classes to teach procedures to staff.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dispose of, or oversee the disposal of, surplus or unclaimed property.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage leasing of facility space.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor the facility to ensure that it remains safe, secure, and well-maintained.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oversee construction and renovation projects to improve efficiency and to ensure that facilities meet environmental, health, and security standards, and comply with government regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oversee the maintenance and repair of machinery, equipment, and electrical and mechanical systems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Participate in architectural and engineering planning and design, including space and installation management.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan, administer, and control budgets for contracts, equipment, and supplies.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare and review operational reports and schedules to ensure accuracy and efficiency.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Set goals and deadlines for the department.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ADP Enterprise HR",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ADP Workforce Now",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe PageMaker",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Revit",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blackbaud The Raiser's Edge",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Delphi Technology",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Email software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "FileMaker Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fund accounting software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Docs",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Drive",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Workspace software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "GroupMe",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Human resource management software HRMS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Maximo Asset Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Notes",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Power Systems software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Intuit QuickBooks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "MicroFocus GroupWise",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Access",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics GP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Internet Explorer",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Publisher",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft SharePoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visio",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Windows XP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Hyperion",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle PeopleSoft",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle PeopleSoft Financials",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP Business Objects",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP BusinessObjects Crystal Reports",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 300 Construction and Real Estate",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 50 Accounting",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage MAS 200 ERP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervisory control and data acquisition SCADA software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Teradata Database",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Yardi software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "10-key calculators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laptop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser facsimile machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mobile phones",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multi-line telephone systems",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Photocopying equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scanners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "11-3013.00",
+    "title": "Facilities Managers"
+  },
+  {
+    "job_zone": 4,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 2.25,
+        "level": 1.38,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.88,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.38,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.62,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.25,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.62,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.62,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.38,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.5,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.5,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.12,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.25,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.25,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.75,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.75,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.62,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.25,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.5,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.25,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.5,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.75,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.38,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.62,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.38,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.12,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridges and Buildings Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Construction Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Construction Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Area Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Management Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Services Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Energy Efficient Site Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Environmental Construction Program Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "General Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Job Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance of Way Superintendent (MOW Superintendent)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Masonry Contractor Administrator (Masonry Construction Admin)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multifamily Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railroad Construction Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Site Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Site Supervision Technical Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Solar Commercial Installation Electrician Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility Division Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weatherization Operations Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze data to determine project feasibility.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze forecasting data to improve business decisions.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate organizational information to customers or other stakeholders.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate organizational policies and procedures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Determine operational compliance with regulations or standards.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop environmental remediation or protection plans.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop operating strategies, plans, or procedures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop procedures to evaluate organizational activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop sustainable organizational policies or practices.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct facility maintenance or repair activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate green project costs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate labor requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate green operations or programs for compliance with standards or regulations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implement organizational process or policy changes.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Investigate industrial or transportation accidents.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage construction activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Model operational processes.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Negotiate project specifications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare financial documents, reports, or budgets.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare forms or applications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational budgets for green energy or other green operations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Purchase materials, equipment, or other resources.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Recruit personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or other instructions to determine operational methods or sequences.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervise employees.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Train employees on environmental awareness, conservation, or safety topics.",
+        "type": "dwa"
+      },
+      {
+        "importance": 4.25,
+        "level": 4.95,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.45,
+        "level": 4.9,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.9,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.7,
+        "level": 5.75,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.45,
+        "level": 3.25,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.9,
+        "level": 2.7,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.4,
+        "level": 4.4,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.9,
+        "level": 4.7,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.7,
+        "level": 4.65,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.15,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.4,
+        "level": 4.55,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.95,
+        "level": 4.75,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.7,
+        "level": 3.9,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.55,
+        "level": 1.05,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.55,
+        "level": 0.95,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.15,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.3,
+        "level": 2.9,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.7,
+        "level": 1.3,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.15,
+        "level": 3.6,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.4,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.8,
+        "level": 4.8,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.35,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.7,
+        "level": 4.4,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.65,
+        "level": 1.3,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.9,
+        "level": 3.65,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.79,
+        "level": 4.65,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.8,
+        "level": 3.85,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.4,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.05,
+        "level": 3.9,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.1,
+        "level": 2.0,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.9,
+        "level": 2.95,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.55,
+        "level": 2.9,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.5,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.38,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.38,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.12,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.75,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.12,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.88,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.5,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.38,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.88,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.38,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.88,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.12,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.88,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.88,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.38,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply for and obtain all necessary permits or licenses.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply green building strategies to reduce energy costs or minimize carbon output or other sources of harm to the environment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with supervisory personnel, owners, contractors, or design professionals to discuss and resolve matters, such as work procedures, complaints, or construction problems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Contract or oversee craft work, such as painting or plumbing.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Determine labor requirements for dispatching workers to construction sites.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop construction budgets to compare green and non-green construction alternatives, in terms of short-term costs, long-term costs, or environmental impacts.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or implement environmental protection programs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or implement quality control programs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct acquisition of land for construction projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct and supervise construction or related workers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate construction methods and determine cost-effectiveness of plans, using computer models.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implement new or modified plans in response to delays, bad weather, or construction site emergencies.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implement training programs on environmentally responsible building topics to update employee skills and knowledge.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect or review projects to monitor compliance with building and safety codes or other regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect or review projects to monitor compliance with environmental regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Interpret and explain plans and contract terms to representatives of the owner or developer, including administrative staff, workers, or clients.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Investigate damage, accidents, or delays at construction sites to ensure that proper construction procedures are being followed.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform, or contract others to perform, pre-building assessments, such as conceptual cost estimating, rough order of magnitude estimating, feasibility, or energy efficiency, environmental, and sustainability assessments.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan, organize, or direct activities concerned with the construction or maintenance of structures, facilities, or systems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan, schedule, or coordinate construction project activities to meet deadlines.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare and submit budget estimates, progress reports, or cost tracking reports.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare contracts or negotiate revisions to contractual agreements with architects, consultants, clients, suppliers, or subcontractors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Requisition supplies or materials to complete construction projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Secure third-party verification from sources, such as Leadership in Energy Efficient Design (LEED), to ensure responsible design and building activities or to achieve favorable LEED ratings for building projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Study job specifications to determine appropriate construction methods.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "3M Post-it App",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "AEC Software FastTrack Schedule",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Creative Cloud software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ArenaSoft Estimating",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD Civil 3D",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Revit",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Axios Systems assyst",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bechtel Software SETROUTE",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "CBS ProLog Manager",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "CSI WSE CodeBuddy",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cadsoft Design/Build",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design and drafting software CADD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Daily Manager",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Database software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drone image capturing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dropbox",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Email software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Explorer Engineer",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Docs",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Drive",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HCSS HeavyBid",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HCSS HeavyJob",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IMPACT software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ISS Construction Manager",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Integrated construction management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Internet browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jobber Computer Plus",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "LinkedIn",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lombardi Teamworks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Loom",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Access",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Internet Explorer",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft SharePoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visio",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle JD Edwards EnterpriseOne",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Presentation software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Procore software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Profitool GearWatch",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Profitool software (human resources feature)",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Profitool software (time accounting feature)",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quantum Software Solutions Quantum Project Manager",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "QuickBase business management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SRC Cash Flow Forecasting",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 100 Contractor",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 300 Construction and Real Estate",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Site Manager",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervisory control and data acquisition SCADA software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimble SketchUp Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "UDA Technologies ConstructionSuite",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "VirtualBoss",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Yardi software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "DroneDeploy",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fixed wing unmanned aerial vehicles UAV",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas detection sensors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laptop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Large-format scanners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser imaging detection and ranging LIDAR systems",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lasers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multi-rotor unmanned aerial vehicles UAV",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pocket personal computers PC",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "RGB cameras",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Thermal imaging cameras",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "11-9021.00",
+    "title": "Construction Managers"
+  },
+  {
+    "job_zone": 5,
+    "sector": "Construction Managers",
+    "skills": [
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.12,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.62,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.25,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.12,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 4.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.75,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.75,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.12,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.5,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.75,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.25,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.5,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 4.25,
+        "level": 4.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.62,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Architect Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Architectural Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Civil Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Civil Project Manager (Civil PM)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Data Engineering Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Data Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Engineering Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Project Manager (Electrical PM)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electronics Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Design Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Group Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Program Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Research Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Environmental Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Global Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mechanical Engineering Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mechanical Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Process Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Product Development Director",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Engineering Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prototype Engineer Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Research Development Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Research Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Research and Development Manager (R&D Manager)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transmitter Engineer-in-Charge",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze data to determine project feasibility.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze impact of legal or regulatory changes.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze market research data.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Approve expenditures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate organizational information to customers or other stakeholders.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate with government agencies.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with organizational members to accomplish work activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop operating strategies, plans, or procedures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop organizational goals or objectives.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop organizational policies or programs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop sustainable organizational policies or practices.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct facility maintenance or repair activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate demand for products or services.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate environmental impact of operational or development activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Identify environmental concerns.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implement organizational process or policy changes.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage construction activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage human resources activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage operations, research, or logistics projects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Negotiate project specifications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare financial documents, reports, or budgets.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational budgets.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Present information to the public.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Promote products, services, or programs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Purchase materials, equipment, or other resources.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.89,
+        "level": 4.46,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.16,
+        "level": 4.22,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.58,
+        "level": 1.46,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.02,
+        "level": 3.59,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.39,
+        "level": 2.92,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.36,
+        "level": 2.45,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.38,
+        "level": 4.48,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.82,
+        "level": 5.21,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.32,
+        "level": 5.45,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.85,
+        "level": 2.92,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.4,
+        "level": 3.54,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.29,
+        "level": 5.35,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.87,
+        "level": 4.33,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.85,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.03,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.68,
+        "level": 1.17,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.27,
+        "level": 3.08,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.57,
+        "level": 1.13,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.94,
+        "level": 3.36,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.92,
+        "level": 4.91,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.66,
+        "level": 3.93,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 1.06,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.77,
+        "level": 3.78,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.61,
+        "level": 1.39,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.18,
+        "level": 3.89,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.21,
+        "level": 4.13,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.86,
+        "level": 1.93,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.06,
+        "level": 3.43,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.82,
+        "level": 3.08,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.66,
+        "level": 1.45,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.39,
+        "level": 2.28,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.3,
+        "level": null,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.53,
+        "level": 2.59,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.25,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.25,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.88,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 1.12,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.75,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.12,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.38,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.62,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assess project feasibility by analyzing technology, resource needs, or market demand.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with management, production, or marketing staff to discuss project specifications or procedures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Consult or negotiate with clients to prepare project specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or implement policies, standards, or procedures for engineering and technical work.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or implement programs to improve sustainability or reduce the environmental impacts of engineering or architecture activities or operations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct recruitment, placement, and evaluation of architecture or engineering project staff.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct, review, or approve project design changes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Establish scientific or technical goals within broad outlines provided by top management.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate environmental regulations or social pressures related to environmental issues to inform strategic or operational decision-making.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate the environmental impacts of engineering, architecture, or research and development activities.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Identify environmental threats or opportunities associated with the development and launch of new technologies.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage the coordination and overall integration of technical activities in architecture or engineering projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform administrative functions, such as reviewing or writing reports, approving expenditures, enforcing rules, or purchasing of materials or services.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan or direct the installation, testing, operation, maintenance, or repair of facilities or equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan, direct, or coordinate survey work with other project activities.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare budgets, bids, or contracts.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Present and explain proposals, reports, or findings to clients.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review, recommend, or approve contracts or cost estimates.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Solicit project support by conferring with officials or providing information to the public.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat Pro Extended",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe LifeCycle ES",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Agile Product Lifecyle Management PLM",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amazon DynamoDB",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amazon Elastic Compute Cloud EC2",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amazon Redshift",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amazon Web Services AWS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ansible software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Cassandra",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Groovy",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Hadoop",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Hive",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Kafka",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Maven",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Pig",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Solr",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apple macOS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aptean Made2Manage",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Atlassian Confluence",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Atlassian JIRA",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD Civil 3D",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Revit",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk VIZ",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backbone.js",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bash",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley MicroStation",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "C",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "C#",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "C++",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chef",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cisco IOS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Citrix cloud computing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design and drafting software CADD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided manufacturing CAM software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Customer information control system CICS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dassault Systemes CATIA",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dassault Systemes SolidWorks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Delcam PowerMILL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Django",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Docker",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drawing and drafting software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ESRI ArcGIS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ESRI ArcView",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elasticsearch",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Extensible markup language XML",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Geographic information system GIS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Geometric CAMWorks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Git",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "GitHub",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Go",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HEC-1",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HEC-RAS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hewlett Packard LoadRunner",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hewlett-Packard HP SolidDesigner",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Notes",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM SPSS Statistics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inventory management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "JavaScript",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "JavaScript Object Notation JSON",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Kronos Workforce Timekeeper",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "LAMP Stack",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "LSA Visual Easy Lean",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Linux",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "MicroStrategy",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Access",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Azure software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics NAV",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Exchange",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft SQL Server",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visio",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visual Basic",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Minitab",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "MongoDB",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "MySQL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nagios",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "National Instruments LabVIEW",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "NoSQL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Node.js",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Objective C",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Open Mind hyperMILL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle JD Edwards EnterpriseOne",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Java",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Solaris",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PHP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PTC Creo Parametric",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perforce Helix software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perl",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PostgreSQL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Puppet",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Python",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Qlik Tech QlikView",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "R",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "RTA Fleet Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "React",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Realization Streamliner",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Relational database management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ruby",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ruby on Rails",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 50 Accounting",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scala",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shell script",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Splunk Enterprise",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structured query language SQL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervisory control and data acquisition SCADA software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swift",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Teradata Database",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "The Gordian Group PROGEN Online",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "The MathWorks MATLAB",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimble SketchUp Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "UNIX",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ubuntu",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verilog",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Virtual private networking VPN software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water surface pressure gradient WSPG software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wireshark",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Workflow software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drawing tablets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal digital assistants PDA",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scanners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "11-9041.00",
+    "title": "Architectural & Engineering Managers"
+  },
+  {
+    "job_zone": 4,
+    "sector": "Construction Managers",
+    "skills": [
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design Project Management Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grant Assistant",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Human Resources Project Manager (HR Project Manager)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implementation Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implementations Management Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Movie Project Management Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Planning Development Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Administrator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Communications Officer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Controller",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Delivery Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Management Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Management Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Management Technical Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Management Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Scheduler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Technical Project Manager (Technical PM)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assign duties or work schedules to employees.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Collaborate with others to resolve information technology issues.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate resource procurement activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop detailed project plans.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop operating strategies, plans, or procedures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Discuss business strategies, practices, or policies with managers.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gather organizational performance information.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage construction activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage information technology projects or system activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage operations, research, or logistics projects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor flow of cash or other resources.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Participate in staffing decisions.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare financial documents, reports, or budgets.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational reports or records.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare scientific or technical reports or presentations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Present work to clients for approval.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Report information to managers or other personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select resources needed to accomplish tasks.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervise information technology personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assign duties or responsibilities to project personnel.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate with key stakeholders to determine project requirements and objectives.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with project personnel to identify and resolve problems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Create project status presentations for delivery to customers or project personnel.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or update project plans including information such as objectives, technologies, schedules, funding, and staffing.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Identify project needs such as resources, staff, or finances by reviewing project objectives and schedules.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Identify, review, or select vendors or consultants to meet project needs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor costs incurred by project staff to identify budget issues.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor project milestones and deliverables.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor the performance of project team members to provide performance feedback.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Negotiate with project stakeholders or suppliers to obtain resources or materials.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan, schedule, or coordinate project activities to meet deadlines.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare and submit budget estimates, progress reports, or cost tracking reports.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Produce and distribute project documents.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Propose, review, or approve modifications to project plans.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Recruit or hire project personnel.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Report project status, such as budget, resources, technical issues, or customer satisfaction, to managers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Request and review project updates to ensure deadlines are met.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Schedule or facilitate project meetings.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Submit project deliverables to clients, ensuring adherence to quality standards.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "3M Post-it App",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ADP Workforce Now",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe InDesign",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Photoshop",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Airtable",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apple Keynote",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apple macOS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asana",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Atlassian Bamboo",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Atlassian Confluence",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Atlassian JIRA",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD Civil 3D",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley MicroStation",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blackboard software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blink",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cisco Webex",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dropbox",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Eko",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evernote",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flipgrid",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Git",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "GitHub",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Classroom",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Docs",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Drive",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Meet",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Sites",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Slides",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Google Workspace software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "GroupMe",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Cognos Impromptu",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Notes",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM SPSS Statistics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Intuit QuickBooks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "JamBoard",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "LinkedIn",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Linux",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "LogMeIn GoToMeeting",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "LogMeIn GoToWebinar",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Loom",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Management information systems MIS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marketo Marketing Automation",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Access",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Azure software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics GP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Exchange",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft OneNote",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft SharePoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Teams",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visio",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visual Basic",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visual Basic for Applications VBA",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Windows",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Moodle",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nearpod",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "NetSuite ERP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Business Intelligence Enterprise Edition",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Database",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Hyperion",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle JD Edwards EnterpriseOne",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle PeopleSoft",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Padlet",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Planview Clarizen",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Poll Everywhere",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Procore software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Qlik Tech QlikView",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP Crystal Reports",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Salesforce software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screencast-O-Matic",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screencastify",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skype",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slack",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slido interaction software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Smartsheet",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Social media sites",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tableau",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimble SketchUp Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "YouTube",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Zoom",
+        "type": "technology"
+      }
+    ],
+    "soc_code": "13-1082.00",
+    "title": "Project Management Specialists"
+  },
+  {
+    "job_zone": 4,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.12,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.88,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.62,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.62,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.12,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.75,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 5.0,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 5.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 4.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.75,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.0,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.62,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.75,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.5,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 5.0,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Airport Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Architectural Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Base Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Construction Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cadastral Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cartographic Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "City Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Civil Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Civil Engineering Intern",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Civil Project Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Condemnation Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Project Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Contracting Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "County Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Demolition Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "District Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drainage Design Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drainage Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Energy Infrastructure Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Environmental Construction Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Erecting Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forest Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forestry Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Foundation Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Geodetic Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Geotechnical Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Civil Project Manager",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Research Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Safety Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydroelectric Plant Structural Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydrographic Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Irrigation Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Land Development Civil Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Licensed Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mapping Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Municipal Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Process Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railroad Design Consultant",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railroad Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reclamation Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Research Hydraulic Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Resident Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Resource Recovery Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roadway Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sanitary Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stress Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Designer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Steel Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Topographical Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Production Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traveling Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wastewater Plant Civil Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Zoning Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate safety or regulatory compliance activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Create graphical representations of civil structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design systems to reduce harmful emissions.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop technical methods or processes.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate operational costs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate technical or resource requirements for development or production projects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate technical data to determine effect on designs or plans.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Explain project details to the general public.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Implement design or process improvements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Incorporate green features into the design of structures or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect facilities or sites to determine if they meet specifications or standards.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Investigate the environmental impact of projects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare proposal documents.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Recommend technical design or process changes to improve efficiency, quality, or performance.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Survey land or bodies of water to measure or determine features.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test characteristics of materials or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.48,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.71,
+        "level": 3.29,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 1.48,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.53,
+        "level": 5.33,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.29,
+        "level": 2.9,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.14,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.14,
+        "level": 4.1,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.43,
+        "level": 4.62,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.7,
+        "level": 5.95,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.81,
+        "level": 3.2,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.4,
+        "level": 3.38,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.67,
+        "level": 6.43,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.38,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.14,
+        "level": 0.43,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 1.0,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.57,
+        "level": 3.43,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.57,
+        "level": 1.29,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.24,
+        "level": 3.86,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.48,
+        "level": 5.1,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.52,
+        "level": 2.85,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.14,
+        "level": 0.24,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.55,
+        "level": 3.48,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.9,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.71,
+        "level": 4.29,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.1,
+        "level": 2.0,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.71,
+        "level": 1.38,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.24,
+        "level": 3.81,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.86,
+        "level": 3.81,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.48,
+        "level": 1.05,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 1.1,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.14,
+        "level": 0.33,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.05,
+        "level": 3.43,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 4.62,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.12,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.75,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.62,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.88,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 4.0,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.62,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.38,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.5,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.75,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.5,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.5,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.88,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.5,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 5.0,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.62,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.5,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 4.0,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.5,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze survey reports, maps, drawings, blueprints, aerial photography, or other topographical or geologic data.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compute load and grade requirements, water flow rates, or material stress factors to determine design specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduct studies of traffic patterns or environmental conditions to identify engineering problems and assess potential project impact.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design energy-efficient or environmentally sound civil structures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design or engineer systems to efficiently dispose of chemical, biological, or other toxic wastes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or implement engineering solutions to clean up industrial accidents or other contaminated sites.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct engineering activities, ensuring compliance with environmental, safety, or other governmental regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct or participate in surveying to lay out installations or establish reference points, grades, or elevations to guide construction.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate quantities and cost of materials, equipment, or labor to determine project feasibility.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Identify environmental risks and develop risk management strategies for civil engineering projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect project sites to monitor progress and ensure conformance to design specifications and safety or sanitation standards.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manage and direct the construction, operations, or maintenance activities at project site.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan and design transportation or hydraulic systems or structures, using computer-assisted design or drawing tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare or present public reports on topics such as bid proposals, deeds, environmental impact statements, or property and right-of-way descriptions.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Provide technical advice to industrial or managerial personnel regarding design, construction, program modifications, or structural repairs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test soils or materials to determine the adequacy and strength of foundations, concrete, asphalt, or steel.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apache Subversion SVN",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD Civil 3D",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Land Desktop",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Revit",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley GeoPak Bridge",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley Haestad Methods CivilStorm",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley InRoads Suite",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley MicroStation",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley STAAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge design software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "C",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cartography software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design and drafting software CADD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Corel WordPerfect Office Suite",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cost estimating software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dassault Systemes Abaqus",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dassault Systemes CATIA",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dassault Systemes SolidWorks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ESRI ArcGIS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ESRI ArcInfo",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ESRI ArcView",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Eagle Point Site Design",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Email software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Extensible markup language XML",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Finite element analysis FEA software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Formula translation/translator FORTRAN",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "GT STRUDL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Geographic information system GIS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graphics software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HEC-1",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HEC-HMS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic analysis software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic modeling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HydroCAD Software Solutions HydroCAD Stormwater Modeling System",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Intergraph MGE",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "MAYA Nastran",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mathsoft Mathcad",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Access",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft ActiveX",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Dynamics",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Exchange",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Internet Explorer",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Visual Basic",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Minitab",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "National Instruments LabVIEW",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Business Intelligence Enterprise Edition",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle JD Edwards EnterpriseOne",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PTC Creo Parametric",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Procore software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road design software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shell script",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SmugMug Flickr",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stormwater hydrology software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervisory control and data acquisition SCADA software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "The Gordian Group PROGEN Online",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "The MathWorks MATLAB",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimble Geomatics Office",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimble SketchUp Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimble Terramodel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verilog",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "WinTR-55",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Anemometers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blueprint copiers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital cameras",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dividers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drafting scales",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drafting triangles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electronic distance measuring devices",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Global positioning system GPS receivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laptop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microfilm readers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Planimeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Precision levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Radar guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rhodes arcs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rolling scales",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel rules",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Surveying rods",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Surveying wheels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Theodolites",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Thickness gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Total stations",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic counters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "17-2051.00",
+    "title": "Civil Engineers"
+  },
+  {
+    "job_zone": 4,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.88,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.75,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.25,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.38,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.75,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.75,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.62,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.12,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.12,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.25,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.12,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Airport Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Civil Transportation Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Civil Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Project Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roadway Designer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roadway Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "State Roadway Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Operations Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Analyst",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Consultant",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Design Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Engineering Intern",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Planning Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Project Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Advise others on health and safety issues.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with technical personnel to prepare designs or operational plans.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Create graphical representations of civil structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Create models of engineering designs or methods.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design civil structures or systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design environmental control systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Determine operational criteria or specifications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop software or computer applications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct equipment maintenance or repair activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct surveying activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate operational costs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate characteristics of equipment or systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate designs or specifications to ensure quality.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate plans or specifications to determine technological or environmental implications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate technical data to determine effect on designs or plans.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Explain project details to the general public.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Incorporate green features into the design of structures or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect facilities or sites to determine if they meet specifications or standards.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Investigate the environmental impact of projects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Negotiate contracts for transportation, distribution, or logistics services.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Negotiate contracts with clients or service providers.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare detailed work plans.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare project budgets.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare technical or operational reports.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Schedule operational activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test characteristics of materials or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.5,
+        "level": 4.45,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.55,
+        "level": 3.41,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.91,
+        "level": 2.0,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.23,
+        "level": 5.05,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.29,
+        "level": 2.82,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.86,
+        "level": 2.95,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.45,
+        "level": 4.55,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.5,
+        "level": 4.41,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.77,
+        "level": 6.14,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.68,
+        "level": 2.95,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.0,
+        "level": 4.27,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.9,
+        "level": 6.45,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.73,
+        "level": 3.86,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": 0.14,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": 0.27,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.18,
+        "level": 0.32,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.77,
+        "level": 3.86,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.82,
+        "level": 2.23,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.38,
+        "level": 4.0,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.18,
+        "level": 5.05,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 3.14,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.14,
+        "level": 0.27,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.24,
+        "level": 2.91,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.91,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.68,
+        "level": 4.45,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.68,
+        "level": 3.18,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.18,
+        "level": 2.32,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.32,
+        "level": 3.68,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.45,
+        "level": 3.0,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.77,
+        "level": 1.68,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.05,
+        "level": 1.82,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.32,
+        "level": 0.82,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.55,
+        "level": 5.14,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.38,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.25,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.75,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.62,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.25,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.88,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.62,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 2.12,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.38,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze environmental impact statements for transportation projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Check construction plans, design calculations, or cost estimations to ensure completeness, accuracy, or conformity to engineering standards or practices.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with contractors, utility companies, or government agencies to discuss plans, specifications, or work schedules.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design or engineer drainage, erosion, or sedimentation control systems for transportation projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design or prepare plans for new transportation systems or parts of systems, such as airports, commuter trains, highways, streets, bridges, drainage structures, or roadway lighting.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Design transportation systems or structures with sustainable materials or products, such as porous pavement or bioretention structures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop or assist in the development of transportation-related computer software or computer processes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Develop plans to deconstruct damaged or obsolete roadways or other transportation structures in a manner that is environmentally sound or prepares the land for sustainable development.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct the surveying, staking, or laying-out of construction projects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate transportation project costs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate construction project materials for compliance with environmental standards.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate traffic control devices or lighting systems to determine need for modification or expansion.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate transportation systems or traffic control devices or lighting systems to determine need for modification or expansion.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect completed transportation projects to ensure compliance with environmental regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect completed transportation projects to ensure safety or compliance with applicable standards or regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Investigate or test specific construction project materials to determine compliance to specifications or standards.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Investigate traffic problems and recommend methods to improve traffic flow or safety.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Model transportation scenarios to evaluate the impacts of activities such as new development or to identify possible solutions to transportation problems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Participate in contract bidding, negotiation, or administration.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan alteration or modification of existing transportation structures to improve safety or function.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare administrative, technical, or statistical reports on traffic-operation matters, such as accidents, safety measures, or pedestrian volume or practices.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare final project layout drawings that include details such as stress calculations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare project budgets, schedules, or specifications for labor or materials.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Present data, maps, or other information at construction-related public hearings or meetings.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review development plans to determine potential traffic impact.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervise the maintenance or repair of transportation systems or system components.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD Civil 3D",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Land Desktop",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley GEOPAK Civil Engineering Suite",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley InRoads Suite",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley MicroStation",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Citilabs Cube",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design and drafting software CADD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cubic Synchro Studio",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ESRI ArcGIS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "McTrans Center TSIS-CORSIM",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "McTrans HCS+",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "McTrans TRANSYT-7F",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "OpenRoads Designer",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PTV Vissim",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Python",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SIDRA INTERSECTION",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structured query language SQL",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trafficware SimTraffic",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trafficware SynchroGreen",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transoft Solutions AutoTURN",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Visual Solutions VisSIM",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Warehouse management system WMS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer laser printers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital cameras",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laptop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser facsimile machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mobile radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multi-line telephone systems",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Photocopying equipment",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "17-2051.01",
+    "title": "Transportation Engineers"
+  },
+  {
+    "job_zone": 3,
+    "sector": "Construction Managers",
+    "skills": [
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.5,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.25,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.38,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.5,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.25,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.12,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acoustical Tile Carpenters' Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable Steel Joist Setting Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asbestos Removal Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Paving Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Awning Hanger Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bailer Operators' Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bailer Tenders' Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Billposting Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brick Chimney Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bricklayer Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brickmason Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Construction Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Insulation Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Repair Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenter Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenter Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenters' Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpentry Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cement Finishing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chimney Construction Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clearing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coal Mine Production Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Construction Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Roofing Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Finishing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concreting Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Coordinator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Core Drilling Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crew Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dike Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dimension Stone Quarry Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Doping Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dredge Operator Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drilling Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drilling Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Application Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrician Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Excavating Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Face Boss",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fence Erector Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Field Assembly Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Field Operations Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Field Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gang Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Line Installer Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "General Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Glazier Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Harvesting Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "House Mover Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "House Moving Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Work Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joiners' Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Labor Crew Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Labor Gang Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lathing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lock Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Longwall Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marble Installer Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marble Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Masonry Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mine Boss",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mine Captain",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mine Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Miners' Boss",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mining Captain",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mixing Place Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mold Construction Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multifamily Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil Well Services Field Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil Well Services Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Open Pit Quarry Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ornamental Ironworking Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Painter Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Painting Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paperhanger Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driving Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Fitter Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipeline Gang Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipeline Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipelines Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pit Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plastering Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumber Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumbing Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prefabricated Homes Field Assembly Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quarry Boss",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railroad Track Repair Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reclamation Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforced Steel Placing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rig Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rig Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rigging Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Right-of-Way Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Riprap Placing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Boss",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Gang Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roofing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roustabout Crew Leader",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roustabout Field Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sanitary Landfill Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Segmental Paving Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Service Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer Systems Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Metal Duct Worker Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Metal Foreman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shipyard Painting Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Builder Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Hanger Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Site Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Site Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Solar Panel Installation Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Distribution Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steamfitter Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Pan Form Placing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Post Installer Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Work Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stonemason Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Steel Erection Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Suction Dredge Pipe Line Placing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Surface Boss",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Surface Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swimming Pool Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tank Builder Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tankage Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Taping Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Terrazzo Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test Boring Crew Chief",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tile Layer Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Laying Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Repair Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Subway Repair Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Superintendent",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Sign Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tunnel Heading Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utilities Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utilities and Maintenance Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Softener Service Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Systems Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Waterproofing Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Boat Builder Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wrecking Supervisor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assist skilled construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate with other construction or extraction personnel to discuss project details.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate construction project activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate construction project labor requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate materials requirements for projects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate projects to determine compliance with technical specifications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect equipment or tools to be used in construction or excavation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure work site dimensions.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor construction operations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Order construction or extraction materials or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Record operational or environmental data.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Train construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": 4.1,
+        "level": 4.53,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.09,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.64,
+        "level": 1.05,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.1,
+        "level": 4.9,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.01,
+        "level": 2.17,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.96,
+        "level": 1.56,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.23,
+        "level": 2.02,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.73,
+        "level": 4.34,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.45,
+        "level": 4.04,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.9,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.82,
+        "level": 3.13,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.14,
+        "level": 3.72,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.72,
+        "level": 3.4,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.02,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.37,
+        "level": 0.64,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.41,
+        "level": 2.24,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.31,
+        "level": 0.38,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.34,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.3,
+        "level": 3.74,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.97,
+        "level": 5.02,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.86,
+        "level": 1.04,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.04,
+        "level": 2.86,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.24,
+        "level": 0.55,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.7,
+        "level": 2.66,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.84,
+        "level": 2.94,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.83,
+        "level": 3.02,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.45,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.53,
+        "level": 2.26,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.69,
+        "level": 1.17,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.08,
+        "level": 1.65,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.91,
+        "level": 1.65,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.32,
+        "level": 2.33,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.62,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.38,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.25,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.88,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.38,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.75,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.5,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analyze worker or production problems and recommend solutions, such as improving production methods or implementing motivational plans.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Arrange for repairs of equipment or machinery.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assign work to employees, based on material or worker requirements of specific jobs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Confer with managerial or technical personnel, other departments, or contractors to resolve problems or to coordinate activities.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate work activities with other construction project activities.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate material or worker requirements to complete jobs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect work progress, equipment, or construction sites to verify safety or to ensure that specifications are met.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate, measure, and mark site locations or placement of structures or equipment, using measuring and marking equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Order or requisition materials or supplies.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Provide assistance to workers engaged in construction or extraction activities, using hand tools or other equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Read specifications, such as blueprints, to determine construction requirements or to plan procedures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Record information, such as personnel, production, or operational data on specified forms or reports.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Suggest or initiate personnel actions, such as promotions, transfers, or hires.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervise, coordinate, or schedule the activities of construction or extractive workers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Train workers in construction methods, operation of equipment, safety procedures, or company policies.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facilities management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "FranklinCovey TabletPlanner",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graphics software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HCSS HeavyJob",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inventory tracking software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mi-Co Mi-Forms",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft NetMeeting",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Project",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Enterprise Project Portfolio Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera P6 Enterprise Portfolio Project Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oracle Primavera Systems",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Procore software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prolog",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "QuickBase business management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 300 Construction and Real Estate",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acetylene welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aerial personnel lifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Allen wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ammeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Analog temperature analyzers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Arc welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Band saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bench vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Biscuit joiners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blasting machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brick trowels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bubble levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Calipers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chalk lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Channel lock pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clamp-on meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Claw hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Combination squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete floats",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crowbars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Detonators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital cameras",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital temperature analyzers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fish tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flat head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flatbed truck trailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flow meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fuel-burning kettles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas-powered generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Glass cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Glass gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Glass holders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Glass lifters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Glass tongs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Humidity meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic crimping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic knock-out punches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated adjustable widemouth pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lathes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Layout squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manlifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marking gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Megohm meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal inert gas MIG welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mortar mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multimeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nut drivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oxyfuel gas welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pallet jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phillips head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Planers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Planes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumb bobs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pointing trowels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power lockouts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power nailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power polishers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power washers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Precision levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pressure meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective ear muffs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective ear plugs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pry bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Putty knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Refrigerant leak detectors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Refrigerant reclamation equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rubber mallets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Saber saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety glasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety goggles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety lanyards",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scoring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screeds",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Single-cut mill saw files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skid steer loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slickline fishing tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel chisels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Surveying rods",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swing stages",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Table saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Theodolites",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tracked excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trenchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tungsten inert gas TIG welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vacuum cups",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vacuum pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Voltmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wattmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding masks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheel loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheeled bulldozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire crimpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire pulling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood chisels",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-1011.00",
+    "title": "First-Line Supervisors"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.5,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.62,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.5,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.88,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.25,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.5,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.5,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.38,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.62,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.25,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.5,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.5,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.88,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aluminum Siding Applicator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aluminum Siding Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aluminum Siding Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amusement and Recreational Prop Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asbestos Siding Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assembled Wood Products Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Beam Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boat Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boat Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boat Carpenter Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boat Finisher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boat Joiner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boat Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boatwright",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bowling Alley Floors Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bracer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Braddisher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brattice Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cabinet Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cabinet Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Canoe Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenter Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenter Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpentry Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Casket Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ceiler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Closet Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Composition Siding Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Composition Weatherboard Applier",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Framer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cooper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Counter Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Custom Applicator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Custom Framing Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Custom Wood Stair Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dock Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Door Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Door Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Doormaker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Finish Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flume Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Builder Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Raiser",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Garage Door Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Garage Door Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammerer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammerman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hardwood Floor Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hardwood Floor Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hardwood Flooring Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hewer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hogshead Cooper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "House Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "House Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inside Finisher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Interior Paneler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Interior Systems Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jalousies Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jointer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Journeyman Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lathing Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Masonry Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mast Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Tile Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Weather Stripper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Miniature Set Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Model Set Artist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mold Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mold Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Molder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Molding Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Motion Picture Scene Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Overhead Garage Door Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Panel Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Partition Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Picture Framer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driver Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Platform Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pole Frame Construction Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prefabricated Houses Trimmer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Production Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prop Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prototype Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railcar Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Refinisher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Finish Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Framing Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roof Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roofer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rough Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sash Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffold Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffold Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scenery Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Set Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shingler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship Ceiler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship Joiner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship and Boat Joiner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shipwright",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sider",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sider Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Siding Applicator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Siding Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Siding Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Siding Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sparmaker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stage Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stage Rigger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stair Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stopping Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Storm Window Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stull Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Subassembly Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tank Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tank Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tank Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Timber Framer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Timberman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trestle Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trestle Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trim Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trim Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Union Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ventilation Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weather Strip Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weather Strip Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weather Stripper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wharf Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Window Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Window Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Window Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Window Sash Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Boat Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Boatbuilder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Car Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Floor Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Flooring Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Tank Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wooden Tank Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Woodworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply decorative or textured finishes or coverings.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply material to fill gaps in surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble products or production equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble temporary equipment or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Build construction forms or molds.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean work sites.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate construction project activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut wood components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dig holes or trenches.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill holes in construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate construction project costs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect work sites to determine condition or necessary repairs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install building fixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install carpet or flooring.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install doors or windows.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install safety or support equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install trim or paneling.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install wooden structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure materials or objects for installation or assembly.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mix substances or compounds needed for work activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Order construction or extraction materials or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position construction forms or molds.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position safety or support equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare hazardous waste for processing or disposal.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational reports.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Record operational or environmental data.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove worn, damaged or outdated materials from work areas.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verify alignment of structures or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.91,
+        "level": 3.83,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.52,
+        "level": 2.61,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.37,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.66,
+        "level": 5.56,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.19,
+        "level": 2.25,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.05,
+        "level": 2.0,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.54,
+        "level": 2.43,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.08,
+        "level": 3.05,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.86,
+        "level": 4.01,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.33,
+        "level": 1.67,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.23,
+        "level": 4.04,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.6,
+        "level": 3.63,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.93,
+        "level": 3.17,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.3,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.48,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.19,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.89,
+        "level": 1.98,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.46,
+        "level": 0.98,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.09,
+        "level": 1.99,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.91,
+        "level": 4.24,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.3,
+        "level": 4.2,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.65,
+        "level": 1.23,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.53,
+        "level": 2.18,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.6,
+        "level": 1.01,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.05,
+        "level": 3.55,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.9,
+        "level": 2.72,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.03,
+        "level": 2.11,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.48,
+        "level": 3.71,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.21,
+        "level": 1.81,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.63,
+        "level": 1.36,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.22,
+        "level": 1.82,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.59,
+        "level": 1.11,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.7,
+        "level": 2.48,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": null,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 3.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.5,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.5,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.62,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.75,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Anchor and brace forms and other structures in place, using nails, bolts, anchor rods, steel cables, planks, wedges, and timbers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply shock-absorbing, sound-deadening, or decorative paneling to ceilings or walls.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Arrange for subcontractors to deal with special areas, such as heating or electrical wiring work.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble and fasten materials to make frameworks or props, using hand tools and wood screws, nails, dowel pins, or glue.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bore boltholes in timber, masonry or concrete walls, using power drill.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Build or repair cabinets, doors, frameworks, floors, or other wooden fixtures used in buildings, using woodworking machines, carpenter's hand tools, or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Build sleds from logs and timbers for use in hauling camp buildings and machinery through wooded areas.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construct forms or chutes for pouring concrete.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cover subfloors with building paper to keep out moisture and lay hardwood, parquet, or wood-strip-block floors by nailing floors to subfloor or cementing them to mastic or asphalt base.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dig or direct digging of post holes and set poles to support structures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Erect scaffolding or ladders for assembling structures above ground level.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Examine structural timbers and supports to detect decay, and replace timbers as required, using hand tools, nuts, and bolts.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fill cracks or other defects in plaster or plasterboard and sand patch, using patching plaster, trowel, and sanding tool.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Finish surfaces of woodwork or wallboard in houses or buildings, using paint, hand tools, or paneling.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Follow established safety rules and regulations and maintain a safe and clean environment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect ceiling or floor tile, wall coverings, siding, glass, or woodwork to detect broken or damaged structures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install rough door and window frames, subflooring, fixtures, or temporary supports in structures undergoing construction or repair.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install structures or fixtures, such as windows, frames, floorings, trim, or hardware, using carpenters' hand or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain job records and schedule work crew.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain records, document actions, and present written progress reports.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure and mark cutting lines on materials, using a ruler, pencil, chalk, and marking gauge.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform minor plumbing, welding, or concrete mixing work.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare cost estimates for clients or employers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove damaged or defective parts or sections of structures and repair or replace, using hand tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select and order lumber or other required materials.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shape or cut materials to specified measurements, using hand tools, machines, or power saws.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Study specifications in blueprints, sketches, or building plans to prepare project layout and determine dimensions and materials required.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verify trueness of structure, using plumb bob and level.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Work with or remove hazardous material.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bosch Punch List",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Craftsman CD Estimator",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drawing and drafting software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimating software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Intuit QuickBooks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Job costing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Windows",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quicken",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Renaissance MasterCarpenter",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turtle Creek Software Goldenseal",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "VirtualBoss",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web page creation and editing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wilhelm Publishing Threshold",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "A-frame levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Auger bits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Baluster jigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Band saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bandsaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Beam saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Beam-lifting jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Belt sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Biscuit joiners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brad tackers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bubble levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bullseye levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Calibrating electronic levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Calipers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpenters' levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Carpentry transits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cat's paws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain saw jigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chainsaw jigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circular saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Combination squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compound miter saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cordless drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cross-curve tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dado blades",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Disc grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Draw chisels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill presses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drum sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric impact wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric planers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Extension ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fall arrest systems",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fold-up ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammer staplers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand planers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Handheld calculators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Handheld rotary tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hard hats",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Impact wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Infrared laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joiners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladder jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladder levelers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser measuring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Layout bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Level jigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lock levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Magnetized levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marking gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mini pry bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Miter saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Moisture meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Morticers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mortise jigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multi-tip screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nail guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Needlenose pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Non-conducting ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pencil compasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal digital assistants PDA",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pettibones",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phillips head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Planes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumb bobs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumb lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plunge routers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic nail guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable routers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power routers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pry bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pump jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Push sticks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rabbet planes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Radial arm saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Random orbital sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reciprocating saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Right triangles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rotary hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rough terrain forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rulers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Saw guides",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screw jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-stopping levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shapers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sledgehammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sliding t-bevels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spirit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Story pole tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Straight screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Table saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Templates",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Theodolites",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torpedo levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trim routers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Visible beam laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wall-lifting jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood chisels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Work boots",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Worm-drive saws",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2031.00",
+    "title": "Carpenters"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.88,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.25,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.5,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.38,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 4.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 2.88,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.5,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.62,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.0,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Distributor Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Distributor Tender",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Equipment Crew Member",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Paver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Paver Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Paving Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Paving Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Plant Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Raker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Roller Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Screed Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Screedman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Spreader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Surface Heater Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Tamping Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bituminous Paving Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Black Top Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Black Top Paver Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Black Top Roller",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Black Top Spreader Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blacktop Paver Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Equipment Crew Member",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Finishing Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Paving Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete and Asphalt Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crew Member",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Curb Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment Operator (EO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Grader",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Tamper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Tamper Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heater Planer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joint Cleaning Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joint Grooving Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joint Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Loader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Equipment Operator (MEO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mechanical Spreader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mud Jack Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paver Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving Crew Member",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforcing Steel Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Mixer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Oiling Truck Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Packer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Roller Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roller Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roller Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screed Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Roller Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stone Spreader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Strike Off Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tamping Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply material to fill gaps in surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble temporary equipment or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Break up rock, asphalt, or concrete.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Build construction forms or molds.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean equipment or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compact materials to create level bases.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate construction project activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut tile, stone, or other masonry materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct vehicle traffic.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dismantle equipment or temporary structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive trucks or truck-mounted equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect equipment or tools to be used in construction or excavation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install equipment attachments or components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Load materials into construction equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain construction tools or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor construction operations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate equipment or vehicles to clear construction sites or move materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate heavy-duty construction or installation equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate road-surfacing equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spread concrete or other aggregate mixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spread sand, dirt or other loose materials onto surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": 2.43,
+        "level": 2.33,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.69,
+        "level": null,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.77,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.65,
+        "level": 5.55,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.49,
+        "level": 2.62,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.82,
+        "level": null,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.91,
+        "level": null,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.73,
+        "level": 2.93,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.43,
+        "level": 2.75,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.54,
+        "level": null,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.27,
+        "level": 2.05,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.26,
+        "level": 2.91,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.37,
+        "level": 2.17,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.54,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.4,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.73,
+        "level": null,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.2,
+        "level": 2.06,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.63,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.41,
+        "level": 2.26,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.77,
+        "level": 2.81,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.26,
+        "level": 3.81,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.49,
+        "level": 1.03,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.85,
+        "level": 1.75,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.4,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.74,
+        "level": 3.03,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.18,
+        "level": 1.87,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.93,
+        "level": 1.95,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.74,
+        "level": 2.74,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.67,
+        "level": null,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.55,
+        "level": null,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.54,
+        "level": null,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.67,
+        "level": null,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.06,
+        "level": 1.95,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 2.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.12,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 1.75,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.25,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.12,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Control paving machines to push dump trucks and to maintain a constant flow of asphalt or other material into hoppers or screeds.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Control traffic.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate truck dumping.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut or break up pavement and drive guardrail posts, using machines equipped with interchangeable hammers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive and operate curbing machines to extrude concrete or asphalt curbing.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive machines onto truck trailers, and drive trucks to transport machines and material to and from job sites.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fill tanks, hoppers, or machines with paving materials.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect, clean, maintain, and repair equipment, using mechanics' hand tools, or report malfunctions to supervisors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install dies, cutters, and extensions to screeds onto machines, using hand tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Light burners or start heating units of machines, and regulate screed temperatures and asphalt flow rates.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Observe distribution of paving material to adjust machine settings or material flow, and indicate low spots for workers to add material.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate machines that clean or cut expansion joints in concrete or asphalt and that rout out cracks in pavement.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate machines to spread, smooth, level, or steel-reinforce stone, concrete, or asphalt on road beds.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate oil distributors, loaders, chip spreaders, dump trucks, and snow plows.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate tamping machines or manually roll surfaces to compact earth fills, foundation forms, and finished road materials, according to grade specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Place strips of material, such as cork, asphalt, or steel into joints, or place rolls of expansion-joint material on machines that automatically insert material.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Set up and tear down equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Set up forms and lay out guidelines for curbs, according to written specifications, using string, spray paint, and concrete or water mixes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shovel blacktop.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Start machine, engage clutch, and push and move levers to guide machine along forms or guidelines and to control the operation of machine attachments.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD Civil 3D",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Database software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Email software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "HCSS HeavyBid",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Time report software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Warehouse management system WMS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt distributor trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt heating equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt mixing equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt paving machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt rakes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Automatic paving control systems",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chip spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Claw hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cold in-place recyclers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cold planers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compactors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete paving machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flatbed truck trailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hot mix material transfer devices",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jackhammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Liquid asphalt storage equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locking pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manual rollers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Milling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Motor graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nut drivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil distributors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pavement marking machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving curbing machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paving finishing machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic paving breakers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic rollers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power extendable screeds",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Profiling equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road heater-planers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Robotic paving machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rolling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rubber-tired asphalt pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rubber-track asphalt pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-contained breathing apparatus",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-propelled material transfer devices",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skid steer loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slip form machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snowplows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Static rollers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Straight screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Straightedges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "String lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Surveying tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tamping machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vibrating concrete screeds",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vibratory rollers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheel loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Windrow pickup machines",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2071.00",
+    "title": "Paving & Tamping Operators"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.25,
+        "level": 2.88,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.75,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.25,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.25,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.5,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.12,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.88,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.0,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.38,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.75,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.38,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.62,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.25,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.38,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diesel Pile Hammer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Driving Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Driving Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoisting Pile Driving Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic Pile Hammer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic Press-In Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nozzle Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driver Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driver Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driving Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driving Leadsman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driving Nozzleman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driving Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Driving Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vibratory Pile Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean equipment or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect equipment or tools to be used in construction or excavation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain construction tools or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate cranes, hoists, or other moving or lifting equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate heavy-duty construction or installation equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 2.93,
+        "level": 3.17,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.34,
+        "level": 1.53,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.29,
+        "level": 0.87,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.12,
+        "level": 5.42,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.09,
+        "level": 2.1,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.91,
+        "level": 1.44,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.79,
+        "level": 1.45,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.79,
+        "level": 2.91,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.15,
+        "level": 3.71,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.91,
+        "level": 0.99,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.58,
+        "level": 2.34,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.41,
+        "level": 4.26,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.82,
+        "level": 2.38,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.04,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.08,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.2,
+        "level": null,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.26,
+        "level": 1.76,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.12,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.13,
+        "level": 1.59,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.59,
+        "level": 3.55,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.65,
+        "level": 4.75,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.53,
+        "level": 0.76,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.93,
+        "level": 1.27,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.11,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.73,
+        "level": 2.87,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.95,
+        "level": 2.99,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.4,
+        "level": 3.66,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.67,
+        "level": 0.98,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.71,
+        "level": 0.34,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.6,
+        "level": 0.75,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.55,
+        "level": 0.87,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.47,
+        "level": 4.02,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.38,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 2.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 4.12,
+        "level": 3.75,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 3.62,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.0,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.25,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.25,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean, lubricate, and refill equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduct pre-operational checks on equipment to ensure proper functioning.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive pilings to provide support for buildings or other structures, using heavy equipment with a pile driver head.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Move hand and foot levers of hoisting equipment to position piling leads, hoist piling into leads, and position hammers over pilings.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Move levers and turn valves to activate power hammers, or to raise and lower drophammers that drive piles to required depths.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Email software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "GRL Engineers Wave Equation Analysis Program GRLWEAP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Global positioning system GPS software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Dynamics Case Pile Wave Analysis Program CAPWAP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile Dynamics Pile Driving Analyzer PDA",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Allen wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain slings",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diesel hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital ammeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital torque wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Emergency first aid equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Excavator mounted pile drivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Extension ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Filter wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fixed leads",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Four-point harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Global positioning system GPS receivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gravity drop hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ground release shackles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand-operated pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoisting equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hour meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic impact hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Life jackets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lifting sling",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lubricant dispensing funnels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mobile radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multipurpose fire extinguishers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "On-board computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile driving analyzers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile driving equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile extractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective ear muffs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quick-disconnect hose couplers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ratchet release shackles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remote control pendants",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rope taglines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety goggles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Saximeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreader beams",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swinging leads",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire ropes",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2072.00",
+    "title": "Pile Driver Operators"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.12,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 3.88,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.62,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.62,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.5,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.38,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.5,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.38,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.0,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.38,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.88,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Angle Dozer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Roller Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Back Hoe Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoe Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blade Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blade Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bulldozer Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bulldozer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bush Hog Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Car Runner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Catshovel Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clamshell Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Backhoe Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Bulldozer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Shovel Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crane Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Derrick Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digging Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditcher Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditching Machine Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditching Machine Operating Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditching Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dragline Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump Attendant",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevating Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engineering Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment Operating Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment Operator (EO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Excavator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklift Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Form Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gang Mower Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gradall Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grader",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grading Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heater Planer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Construction Equipment Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Construction Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Equipment Operating Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Equipment Operator (HEO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Machinery Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy Road Construction Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoe Runner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoisting Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hot Mix Asphalt Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic Hammer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Land Leveler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Landfill Grader",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Landfill Heavy Equipment Operator (Landfill HEO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lift Slab Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locomotive Crane Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintainer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Motor Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Muck Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mucker Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mucking Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operating Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power Shovel Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Grader",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Grader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Hogger Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Machine Runner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Roller Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rooter Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rotary Soil Stabilizer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sander",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sanitary Landfill Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scarifier Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scrap Drop Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scraper Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shovel Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slab Lifting Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stabilizer Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Shovel Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Shovel Operating Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Shovel Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Shovel Runner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Roller Engineer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Hoe Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assist skilled construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate with clients about products, procedures, and policies.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compact materials to create level bases.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive trucks or truck-mounted equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install equipment attachments or components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Load or unload materials used in construction or extraction.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate equipment or materials in need of repair or replacement.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain construction tools or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor construction operations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Move construction or extraction materials to locations where they are needed.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate equipment or vehicles to clear construction sites or move materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate heavy-duty construction or installation equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate pumps or compressors.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate road-surfacing equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position construction or extraction equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Record operational or environmental data.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove debris or vegetation from work sites.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select construction equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Signal equipment operators to indicate proper equipment positioning.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test air quality at work sites.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Update job related knowledge or skills.",
+        "type": "dwa"
+      },
+      {
+        "importance": 2.78,
+        "level": 2.63,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.28,
+        "level": null,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.53,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.46,
+        "level": 2.25,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.59,
+        "level": 1.35,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.69,
+        "level": null,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.42,
+        "level": null,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.73,
+        "level": 2.56,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.24,
+        "level": null,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.5,
+        "level": null,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.59,
+        "level": 2.72,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.35,
+        "level": 2.29,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.33,
+        "level": 3.11,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.66,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.2,
+        "level": null,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.76,
+        "level": null,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.66,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.16,
+        "level": null,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.81,
+        "level": 3.16,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.56,
+        "level": 4.36,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.05,
+        "level": null,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.96,
+        "level": 1.71,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.35,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.69,
+        "level": 1.44,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.02,
+        "level": null,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.12,
+        "level": null,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.13,
+        "level": 3.07,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.53,
+        "level": null,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.04,
+        "level": null,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.41,
+        "level": null,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.04,
+        "level": null,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.54,
+        "level": 2.51,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.62,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.0,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.12,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.12,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.25,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.25,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjust handwheels and depress pedals to control attachments, such as blades, buckets, scrapers, or swing booms.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Align machines, cutterheads, or depth gauge makers with reference stakes and guidelines or ground or position equipment, following hand signals of other workers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Check fuel supplies at sites to ensure adequate availability.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Connect hydraulic hoses, belts, mechanical linkages, or power takeoff shafts to tractors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate machine actions with other activities, positioning or moving loads in response to hand or audio signals from crew members.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive and maneuver equipment equipped with blades in successive passes over working areas to remove topsoil, vegetation, or rocks or to distribute and level earth or terrain.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive tractor-trailer trucks to move equipment from site to site.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Keep records of material or equipment usage or problems encountered.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Learn and follow safety regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Load and move dirt, rocks, equipment, or other materials, using trucks, crawler tractors, power cranes, shovels, graders, or related equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate underground services, such as pipes or wires, prior to beginning work.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monitor operations to ensure that health and safety standards are met.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate compactors, scrapers, or rollers to level, compact, or cover refuse at disposal grounds.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate equipment to demolish or remove debris or to remove snow from streets, roads, or parking lots.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate loaders to pull out stumps, rip asphalt or concrete, rough-grade properties, bury refuse, or perform general cleanup.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate road watering, oiling, or rolling equipment, or street sealing equipment, such as chip spreaders.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate tractors or bulldozers to perform such tasks as clearing land, mixing sludge, trimming backfills, or building roadways or parking lots.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Push other equipment when extra traction or assistance is required.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair and maintain equipment, making emergency adjustments or assisting with major repairs as necessary.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select and fasten bulldozer blades or other attachments to tractors, using hitches.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Signal operators to guide movement of tractor-drawn machines.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Start engines, move throttles, switches, or levers, or depress pedals to operate machines, such as bulldozers, trench excavators, road graders, or backhoes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Take actions to avoid potential hazards or obstructions, such as utility lines, other equipment, other workers, or falling objects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Talk to clients and study instructions, plans, or diagrams to establish work requirements.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test atmosphere for adequate oxygen or explosive conditions when working in confined spaces.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turn valves to control air or water output of compressors or pumps.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance record software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Windows",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Work record software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "15-ton truck cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "18-ton hydraulic cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "20-ton tractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aeroil propane kettles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Angle dozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aquatic weed harvesters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt compactors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt spreader boxes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Axes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoe attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Barrier movers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Basin machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Belly dumpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Belt loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blade attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Box scrapers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bucket attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bulldozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cell phones",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chemical-resistant clothing",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cherry pickers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chip spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Churn drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circular saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crawler dozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cultipackers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Curb pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutting torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Demolition machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dempster dumpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Derricks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Draglines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dredges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill presses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ear plugs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "End loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Extender conveyors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flatbed trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Front end loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Groovers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gutter pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Harrows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy duty excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoists",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic boom trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic telescoping boom utility trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial scrapers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jackhammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Land drilling rigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laydown machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mainline paint stripers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manlifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring wheels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mechanical sweepers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Milling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mini excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monorails",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Motor graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multipurpose vacuum catch basin cleaners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oiling equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pavement breakers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Picks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pickup trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Post hole diggers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road finishing machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road watering equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Robotic concrete busters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Robotic machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rollers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ross carriers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roustabout cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rubber-tired excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rulers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Runway deicers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety boots",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety glasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scoopmobiles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scrapers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Seeders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer rodding machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shielded arc welding tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shot blasters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shovels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Silent hoists",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Single axle dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skid steer loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skid steer machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skip loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snow blowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snowplows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sweepers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tampers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tandem axle dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tankers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Telescopic forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tilt graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tracked hydraulic excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tracked loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Travel lifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Treecutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trenchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck trailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck-mounted generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tugger hoists",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turf quakers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turn-a-pulls",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two-man augers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vacuum pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vertical drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verticutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vibratory compactors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weedeaters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheel loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Winches",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2073.00",
+    "title": "Operating Engineers"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 3.62,
+        "level": 3.12,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.25,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.38,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.88,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.38,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.25,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.88,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.62,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 0.88,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.75,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.75,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.5,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.5,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.5,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acoustical Carpenter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acoustical Ceiling Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acoustical Consultant",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acoustical Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acoustical Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ceiling Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dry Wall Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Application Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Applicator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Boardhanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Carrier",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Contractor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Finisher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Metal Stud Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Professional",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Sander",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Stripper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Taper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywaller",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Exterior Interior Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Furrer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Interior Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lath Hand",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Framer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Furrer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Stud Framer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plaster Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rock Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rockboard Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Applicator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Applier",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Finisher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Nailer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Sander",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rock Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Rocker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheetrock Applicator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wood Lather",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply material to fill gaps in surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply mortar.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean surfaces in preparation for work activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate construction project activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut openings in existing structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut tile, stone, or other masonry materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut wood components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install building fixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install insulation in equipment or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install masonry materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install metal structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install trim or paneling.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install wooden structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure materials or objects for installation or assembly.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate cranes, hoists, or other moving or lifting equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove worn, damaged or outdated materials from work areas.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trim excess material from installations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verify alignment of structures or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.09,
+        "level": 2.93,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.06,
+        "level": 2.03,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.15,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.47,
+        "level": 5.33,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.68,
+        "level": 1.43,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.21,
+        "level": null,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.78,
+        "level": 1.25,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.73,
+        "level": 2.9,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.97,
+        "level": 3.0,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.28,
+        "level": 1.41,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.42,
+        "level": 2.06,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.74,
+        "level": 2.93,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.96,
+        "level": 2.6,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.22,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.02,
+        "level": 1.38,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.7,
+        "level": 1.33,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.27,
+        "level": 0.43,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.98,
+        "level": 1.28,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.12,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.27,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.71,
+        "level": 1.07,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.21,
+        "level": 2.11,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.04,
+        "level": 1.71,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.53,
+        "level": 2.38,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.84,
+        "level": 1.73,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.18,
+        "level": 2.88,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.4,
+        "level": 2.16,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.36,
+        "level": 0.7,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 0.68,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.59,
+        "level": 1.29,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.53,
+        "level": 2.2,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.62,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.88,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.12,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.5,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.12,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.25,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.5,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply cement to backs of tiles and press tiles into place, aligning them with layout marks or joints of previously laid tile.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply or mount acoustical tile or blocks, strips, or sheets of shock-absorbing materials to ceilings or walls of buildings to reduce reflection of sound or to decorate rooms.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble or install metal framing or decorative trim for windows, doorways, or vents.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coordinate work with drywall finishers who cover the seams between drywall panels.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut and screw together metal channels to make floor or ceiling frames, according to plans for the location of rooms or hallways.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut fixture or border tiles to size, using keyhole saws, and insert them into surrounding frameworks.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal or wood framing and trim to size, using cutting tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fasten metal or rockboard lath to the structural framework of walls, ceilings, or partitions of buildings, using nails, screws, staples, or wire-ties.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fit and fasten wallboard or drywall into position on wood or metal frameworks, using glue, nails, or screws.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hang dry lines to wall moldings to guide positioning of main runners.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hang drywall panels on metal frameworks of walls and ceilings in offices, schools, or other large buildings, using lifts or hoists to adjust panel heights, when necessary.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect furrings, mechanical mountings, or masonry surfaces for plumbness and level, using spirit or water levels.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install blanket insulation between studs and tack plastic moisture barriers over insulation.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install horizontal and vertical metal or wooden studs to frames so that wallboard can be attached to interior walls.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install metal lath where plaster applications will be exposed to weather or water, or for curved or irregular surfaces.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure and cut openings in panels or tiles for electrical outlets, windows, vents, plumbing, or other fixtures, using keyhole saws or other cutting tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure and mark surfaces to lay out work, according to blueprints or drawings, using tape measures, straightedges or squares, and marking devices.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mount tile, using adhesives, or by nailing, screwing, stapling, or wire-tying lath directly to structural frameworks.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nail channels or wood furring strips to surfaces to provide mounting for tile.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Read blueprints or other specifications to determine methods of installation, work procedures, or material or tool requirements.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove existing plaster, drywall, or paneling, using crowbars and hammers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scribe and cut edges of tile to fit walls where wall molding is not specified.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Seal joints between ceiling tiles and walls.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Suspend angle iron grids or channel irons from ceilings, using wire.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trim rough edges from wallboard to maintain even joints, using knives.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wash concrete surfaces before mounting tile to increase adhesive qualities of surfaces, using washing soda and zinc sulfate solution.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Business management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Software Center EasyEst",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "DevWave Estimate Works",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Job costing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Logic Group Scanner Digitizing Software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Windows",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "On Center Quick Bid",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turtle Creek Software Goldenseal",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wilhelm Publishing Threshold",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adhesive guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Automatic taping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Box beam levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bullnose trowels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chalk lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chop saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circle cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Corner knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crowhead hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall T-squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall hatchets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall lifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall mud mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall ripping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall routers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall scoring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall screw guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drywall trowels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Edge cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fan blade mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Feather edge drywall darbies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy duty staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inside corner trowels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joint knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Keyhole saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser printers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mini lifters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Outside corner trowels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal digital assistants PDA",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pistol hopper guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pole sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power hand sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rasps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roll lifters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rotary sanders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Saber saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stilts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Taping knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Texture brushes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Texture guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Texture sprayers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tin snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torpedo levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trimming knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wall scrapers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wallboard T-squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wallboard saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wipe-down knives",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2081.00",
+    "title": "Drywall & Ceiling Tile Installers"
+  },
+  {
+    "job_zone": 3,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 3.62,
+        "level": 3.12,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.38,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.75,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.62,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.75,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.62,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.25,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.12,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.88,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 3.88,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.25,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.75,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.25,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 4.0,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 4.0,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 1.88,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Airport Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Antenna Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Antenna Rigger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Control Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conventional System Lightning Protection Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diesel Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diesel Maintenance Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric Sign Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric Stop Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Journey Person",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Journeyman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Maintenance Man",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Maintenance Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Sign Servicer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Sign Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical System Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Troubleshooter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrical Wiring Lineman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gaffer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ground Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "House Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Housing Maintenance Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inside Wireman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Interior Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Interior Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Journeyman Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Journeyman Lineman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Licensed Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lighting Fixture Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lightning Protection Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lightning Protection Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lightning Rod Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lineman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Low Voltage Technician (Low Voltage Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marine Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mine Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Light Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Sign Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Sign Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Sign Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Sign Servicer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Sign Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Neon Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Overhead Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paper Mill Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plant Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Production Machinery Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective Signal Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Wireman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Searchlight Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Service Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shift Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship and Boat Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Signal Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Solar Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Solar Photovoltaic Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stage Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Light Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Light Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Light Servicer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Light Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Switch Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Switchboard Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Television Antenna Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Temporary Services Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test Man",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Signal Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Signal Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Transport Electrician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wireman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wirer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wiring Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assist skilled construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate with other construction or extraction personnel to discuss project details.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Create construction or installation diagrams.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dig holes or trenches.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate construction project costs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fabricate parts or components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect electrical or electronic systems for defects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install electrical components, equipment, or systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Order construction or extraction materials or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan layout of construction, installation, or repairs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational reports.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair electrical equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test electrical equipment or systems to ensure proper functioning.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Thread wire or cable through ducts or conduits.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Train construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Update job related knowledge or skills.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.58,
+        "level": 3.66,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.33,
+        "level": 2.35,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.16,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.67,
+        "level": 4.62,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.61,
+        "level": 1.51,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.54,
+        "level": 1.45,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.98,
+        "level": 1.7,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.17,
+        "level": 3.19,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.32,
+        "level": 3.86,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.64,
+        "level": 0.86,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.21,
+        "level": 2.77,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.07,
+        "level": 2.12,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.64,
+        "level": 2.56,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.19,
+        "level": null,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.47,
+        "level": null,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.09,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.43,
+        "level": 1.89,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.4,
+        "level": 3.63,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.42,
+        "level": 3.41,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.19,
+        "level": null,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.11,
+        "level": 1.93,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.06,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.27,
+        "level": 2.8,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.7,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.68,
+        "level": 3.36,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.87,
+        "level": 3.18,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.18,
+        "level": 1.57,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.74,
+        "level": 1.43,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.48,
+        "level": 2.56,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.45,
+        "level": 0.97,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.44,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.75,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.75,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.25,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.38,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.88,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.75,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Advise management on whether continued operation of equipment could be hazardous.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble, install, test, or maintain electrical or electronic wiring, equipment, appliances, apparatus, or fixtures, using hand tools or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Connect wires to circuit breakers, transformers, or other components.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construct or fabricate parts, using hand tools, according to specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diagnose malfunctioning systems, apparatus, or components, using test equipment and hand tools to locate the cause of a breakdown and correct the problem.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct or train workers to install, maintain, or repair electrical wiring, equipment, or fixtures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fasten small metal or plastic boxes to walls to house electrical switches or outlets.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect electrical systems, equipment, or components to identify hazards, defects, or the need for adjustment or repair, and to ensure compliance with codes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install ground leads and connect power cables to equipment, such as motors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain current electrician's license or identification card to meet governmental regulations.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform business management duties, such as maintaining records or files, preparing reports, or ordering supplies or equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform physically demanding tasks, such as digging trenches to lay conduit or moving or lifting heavy objects.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Place conduit, pipes, or tubing, inside designated partitions, walls, or other concealed areas, and pull insulated wires or cables through the conduit to complete circuits between boxes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan layout and installation of electrical wiring, equipment, or fixtures, based on job specifications and local codes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare sketches or follow blueprints to determine the location of wiring or equipment and to ensure conformance to building and safety codes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Provide assistance during emergencies by operating floodlights or generators, placing flares, or driving needed vehicles.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Provide preliminary sketches or cost estimates for materials or services.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair or replace wiring, equipment, or fixtures, using hand tools or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test electrical systems or continuity of circuits in electrical wiring, equipment, or fixtures, using testing devices, such as ohmmeters, voltmeters, or oscilloscopes, to ensure compatibility and safety of system.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Use a variety of tools or equipment, such as power construction equipment, measuring devices, power tools, and testing equipment, such as oscilloscopes, ammeters, or test lamps.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Work from ladders, scaffolds, or roofs to install, maintain, or repair electrical wiring, equipment, or fixtures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "AVEVA InTouch HMI",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adobe Acrobat",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk AutoCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design CAD software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Master Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Craftsman CD Estimator",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Database software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electrosoft FlashWorks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software E-Coord",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software Inpoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software Outpoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software Short",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software VDROP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insight Direct ServiceCEO",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lighting calculation software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Windows",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "One Mile Up Panel Planner",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Programmable logic controller PLC software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Resolve Systems Service Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SAP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sage 300 Construction and Real Estate",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shafer Service Systems",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SmartDraw",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Socrates Contractor's Library",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "SoftEmpire Electrical Calculations",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Supervisory control and data acquisition SCADA software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turtle Creek Software Goldenseal",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Allen wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ammeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Automatic insulation strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Awls",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bandsaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bear claw wire threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bucket trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Butane soldering irons",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cabinet tip screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable butt trimmers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable gripping gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable jacket strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable labeling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable lacing needles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable sheath strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable splicing knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable tie guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Capacitance testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Channel lock crimping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Channel lock pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circuit testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circuit tracers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circular saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clamp-on ammeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Claw hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Coaxial cable cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit deburring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit fitting and reaming screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit locknut and reaming pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Continuity coaxial testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cordless drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crescent wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Current clamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutting torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Depth gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diagonal cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diggers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Double-end can socket wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill bit sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric conduit benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electricians' scissors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "End cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "End wire strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "External snap ring pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Feeler gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fish tape pullers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Frequency meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fuse pulling equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas leak detection devices",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ground fault circuit interrupter GFCI testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Growlers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammer drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hard hats",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heat guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy duty longnose pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hex key sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "High-leverage cable cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "High-leverage diagonal cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "High-leverage side cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hole saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic conduit benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic presses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic punching tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inductance testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Infrared scanners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspection mirrors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated bolt cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated cable cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated nutdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated socket sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Internal snap ring pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser plumb bobs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser printers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lighted magnet pickups",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lineman's pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Magnetic locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manlifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Megohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Micrometers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Milliameters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multimeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Needlenose pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nibbler cutting tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Non-contact voltage detectors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nut drivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oscilloscopes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phase rotation meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phillips head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Polyvinyl chloride PVC cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Programmable logic controllers PLC",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pump pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Punchdown tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ratchet crimper kits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ratcheting pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Razor knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Resistance bridges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Round shank screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety glasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screw-holding screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-adjusting insulation strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shears",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Side cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Single reel cable trailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Soldering tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Square shank screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Strap wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tap sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tapered reamers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tapping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Telescoping lighted pickups",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tension gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Terminal crimpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test lamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Threading die hand tool",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tin snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tongue and groove pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torpedo levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transfer impedance meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Universal stripping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility cable cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Volt tick meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Voltmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wattmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding hoods",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheeled wire dispensers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Winches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire crimpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire crimping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire dispensers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire dollies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire hand caddies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire loop pullers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire wrap guns",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2111.00",
+    "title": "Electricians"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.12,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 2.88,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.0,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.38,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.38,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.0,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "AC Insulation Installer (Air Conditioning Insulation Installer)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blanket Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boiler Coverer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Duct Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Firestopper Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Firestopper Technician (Firestopper Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heat and Frost Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial Pipe Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Power Unit Tender",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Technician (Insulation Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulation Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulator Journeyman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marine Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mechanic Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mechanical Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Coverer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Coverer and Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Refrigeration Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Metal Insulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply adhesives to construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply sealants or other protective coatings.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut carpet, vinyl or other flexible materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install insulation in equipment or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install metal structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure materials or objects for installation or assembly.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare surfaces for finishing.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": 4.02,
+        "level": 4.21,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.7,
+        "level": 3.19,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.43,
+        "level": 0.88,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.32,
+        "level": 4.9,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.03,
+        "level": 1.99,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.74,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.41,
+        "level": 2.41,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.09,
+        "level": 4.74,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.55,
+        "level": 3.96,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.86,
+        "level": 2.76,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.87,
+        "level": 4.44,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.57,
+        "level": 2.65,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.37,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.29,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.11,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.81,
+        "level": 0.95,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.79,
+        "level": 1.44,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.45,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.24,
+        "level": 1.77,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.83,
+        "level": 4.15,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.07,
+        "level": 4.5,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.58,
+        "level": 1.02,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.32,
+        "level": 3.63,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.28,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.17,
+        "level": 2.27,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.66,
+        "level": 4.11,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.78,
+        "level": 2.64,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.66,
+        "level": 3.69,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.34,
+        "level": 3.35,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.74,
+        "level": 1.34,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.95,
+        "level": 1.2,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.83,
+        "level": 1.67,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.08,
+        "level": 2.82,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.38,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.12,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.75,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.0,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply, remove, and repair insulation on industrial equipment, pipes, ductwork, or other mechanical systems such as heat exchangers, tanks, and vessels, to help control noise and maintain temperatures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cover, seal, or finish insulated surfaces or access holes with plastic covers, canvas strips, sealants, tape, cement, or asphalt mastic.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Determine the amounts and types of insulation needed, and methods of installation, based on factors such as location, surface shape, and equipment use.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fit insulation around obstructions, and shape insulating materials and protective coverings as required.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install sheet metal around insulated pipes with screws to protect the insulation from weather conditions or physical damage.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure and cut insulation for covering surfaces, using tape measures, handsaws, knives, and scissors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare surfaces for insulation application by brushing or spreading on adhesives, cement, or asphalt, or by attaching metal pins to surfaces.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Read blueprints and specifications to determine job requirements.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select appropriate insulation, such as fiberglass, Styrofoam, or cork, based on the heat retaining or excluding characteristics of the material.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "CMSN FieldPAK",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Comput-Ability Mechanical Insulation Key Estimator",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "IBM Maximo Asset Management",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "North American Insulation Manufacturers Association NAIMA 3E Plus",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turtle Creek Software Goldenseal",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acetylene torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable widemouth pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air filtering devices",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aviation snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Batt knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Beader crimpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chalk lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Copper benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Copper cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drop cloths",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Filtered vacuum cleaners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammer staplers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hole saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hooded protective suits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial sewing machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Painters whites",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic staplers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective suits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "R-value rulers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reciprocating saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety glasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scissors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet metal cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet metal templates",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stilts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stud scrubbers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trowels",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2132.00",
+    "title": "Insulation Workers, Mechanical"
+  },
+  {
+    "job_zone": 1,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.5,
+        "level": 3.0,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.12,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 3.0,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.5,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.62,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.38,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.38,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.75,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cast Iron Drain Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drain Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drain Tiler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Assembly Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Caulker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Connector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Cutter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Liner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Wrapping Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipelayer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipelaying Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipeman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Piper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer Connector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stormwater Technician (Stormwater Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tailman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tile Conduit Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trench Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Underground Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Underground Utility Locator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utilities Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Main Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply adhesives to construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Communicate with other construction or extraction personnel to discuss project details.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compact materials to create level bases.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dig holes or trenches.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill holes in construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive trucks or truck-mounted equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate projects to determine compliance with technical specifications.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install plumbing or piping.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate equipment or materials in need of repair or replacement.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain plumbing structures or fixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate equipment or vehicles to clear construction sites or move materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position hand tools.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spread sand, dirt or other loose materials onto surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Train construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 2.92,
+        "level": 2.69,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.06,
+        "level": 1.65,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.77,
+        "level": 1.48,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.7,
+        "level": 4.54,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.45,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.7,
+        "level": 1.17,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.21,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.51,
+        "level": 2.55,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.79,
+        "level": 2.93,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.64,
+        "level": 0.97,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.26,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.98,
+        "level": 2.9,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.84,
+        "level": 2.35,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.12,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.76,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.86,
+        "level": null,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.19,
+        "level": 1.83,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.6,
+        "level": 0.96,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.28,
+        "level": 1.63,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.71,
+        "level": 2.47,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.98,
+        "level": 3.5,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.61,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.17,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.23,
+        "level": 0.8,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.37,
+        "level": 2.55,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.84,
+        "level": 2.9,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.35,
+        "level": 2.82,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.01,
+        "level": 3.12,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.61,
+        "level": null,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.78,
+        "level": 1.63,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.04,
+        "level": 1.23,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.67,
+        "level": 1.11,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.22,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.0,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.0,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.38,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Align and position pipes to prepare them for welding or sealing.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Check slopes for conformance to requirements, using levels or lasers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Connect pipe pieces and seal joints, using welding equipment, cement, or glue.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cover pipes with earth or other materials.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut pipes to required lengths.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dig trenches to desired or required depths, by hand or using trenching tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grade or level trench bases, using tamping machines or hand tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install or repair sanitary or stormwater sewer structures or pipe systems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install or use instruments such as lasers, grade rods, or transit levels.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lay out pipe routes, following written instructions or blueprints and coordinating layouts with supervisors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate existing pipes needing repair or replacement, using magnetic or radio indicators.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate mechanized equipment, such as pickup trucks, rollers, tandem dump trucks, front-end loaders, or backhoes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tap and drill holes into pipes to introduce auxiliary lines or devices.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Train or supervise others in laying pipe.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aligning clamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Belting slings",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bevel grinding machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Block and tackle equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boring machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bulldozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable plows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Combination squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compactors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutting torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditch pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dredges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill presses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Explosimeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Facing machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fill pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand tampers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Horizontal boring machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser printers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Leak detection equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manlifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manual benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manual screw jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal inert gas MIG welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Motor-driven brushes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Motor-driven grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Narrow mouth shovels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Null locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Offset socket wrench sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Optical levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe bending mandrels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe beveling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe cutting machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe lasers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipelayers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipeline jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable welding machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Powered tampers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pressure testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pry bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reciprocating pipe saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roll groovers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Round point shovels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sand pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sandblasters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shielded arc welding tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Single-cut mill saw files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sledgehammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snakes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stationary grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tapping machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tractor pipe carrier attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tractors with backhoe attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tractors with loader attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trenchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tungsten inert gas TIG welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Voltmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water removal pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding hoods",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheel loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Winches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire tracers",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2151.00",
+    "title": "Pipelayers"
+  },
+  {
+    "job_zone": 3,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 2.75,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.38,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.12,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.38,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.12,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.25,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.38,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.25,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.38,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.75,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.5,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.5,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.75,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.12,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.62,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.88,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aircraft Hydraulic Equipment Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aircraft Hydraulic Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aircraft Plumbing Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commercial Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Corrosion Control Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diesel Engine Pipefitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drain Cleaner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drain Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dry Docks Utility Systems Repair Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment Service Associate (ESA)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire Control System Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire Hydrant Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire Sprinkler Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire Sprinkler Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire Sprinkler Service Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire Sprinkler Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Line Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Line Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Line Servicer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Main Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Meter Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Pipe Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gasfitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Green Pipefitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Green Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heating Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heating Unit Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hot Water Heater Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydrant Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Industrial Gasfitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Irrigation System Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Irrigation Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Journeyman Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Licensed Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locomotive Pipefitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manhole Steamline Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marine Pipefitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marine Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Marine Steamfitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Meter Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe Welder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipefitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipefitter Helper",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipefitter Journeyman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipeline Technician (Pipeline Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Piping Designer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumbing Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumbing Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumbing Service Tech (Plumbing Service Technician)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumbing Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Residential Service Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Service Plumber",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship and Boat Coppersmith",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ship and Boat Pipe Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Soft Water Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sprinkler Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sprinkler Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sprinkling System Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Heating Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Pipefitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Service Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Trap Man",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam Trap Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steamfitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steamfitter Furnace Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tinner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Underground Steamline Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Valve Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Distribution Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Hydrant Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Meter Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Pipe Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Pump Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Regulator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Softener Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water Softener Servicer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean equipment or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Create construction or installation diagrams.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut openings in existing structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate construction project costs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate construction project labor requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fabricate parts or components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect plumbing systems or fixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect work sites to determine condition or necessary repairs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect work sites to identify potential environmental or safety hazards.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install gauges or controls.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install green plumbing or water handling systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install plumbing or piping.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain plumbing structures or fixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure materials or objects for installation or assembly.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate pumps or compressors.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan layout of construction, installation, or repairs.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Record operational or environmental data.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove parts or components from equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair worn, damaged, or defective mechanical parts.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Replace worn, damaged, or defective mechanical parts.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.31,
+        "level": 4.02,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.21,
+        "level": 2.13,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.34,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.35,
+        "level": 5.36,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.51,
+        "level": 2.99,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.85,
+        "level": 1.27,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.11,
+        "level": 2.08,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.6,
+        "level": 4.2,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.76,
+        "level": 5.05,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.14,
+        "level": 1.44,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.82,
+        "level": 3.73,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.24,
+        "level": 3.97,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.91,
+        "level": 2.61,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.17,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.71,
+        "level": 1.08,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.48,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.47,
+        "level": 0.91,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.42,
+        "level": 0.62,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.31,
+        "level": 1.84,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.33,
+        "level": 4.86,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.69,
+        "level": 1.01,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.16,
+        "level": 1.53,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.47,
+        "level": 1.07,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.23,
+        "level": 4.05,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.68,
+        "level": 2.88,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.9,
+        "level": 1.49,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.24,
+        "level": 3.08,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.17,
+        "level": 2.01,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.3,
+        "level": 0.45,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.59,
+        "level": 0.89,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.51,
+        "level": 1.18,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.22,
+        "level": 1.72,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.5,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": null,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.38,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.62,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.12,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.62,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 0.88,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Anchor steel supports from ceiling joists to hold pipes in place.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble pipe sections, tubing, or fittings, using couplings, clamps, screws, bolts, cement, plastic solvent, caulking, or soldering, brazing, or welding equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Attach pipes to walls, structures, or fixtures, such as radiators or tanks, using brackets, clamps, tools, or welding equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut openings in structures to accommodate pipes or pipe fittings, using hand or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut, thread, or hammer pipes to specifications, using tools such as saws, cutting torches, pipe threaders, or pipe benders.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct helpers engaged in pipe cutting, preassembly, or installation of plumbing systems or components.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimate time, material, or labor costs for use in project plans.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fill pipes or plumbing fixtures with water or air and observe pressure gauges to detect and locate leaks.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect structures to assess material or equipment needs, to establish the sequence of pipe installations, or to plan installation around obstructions, such as electrical wiring.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect work sites for obstructions or holes that could cause structural weakness.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect, examine, or test installed systems or pipe lines, using pressure gauge, hydrostatic testing, observation, or other methods.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install automatic controls to regulate pipe systems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install fixtures, appliances, or equipment designed to reduce water or energy consumption.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install green plumbing equipment, such as faucet flow restrictors, dual-flush or pressure-assisted flush toilets, or tankless hot water heaters.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install pipe assemblies, fittings, valves, appliances such as dishwashers or water heaters, or fixtures such as sinks or toilets, using hand or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install pipe systems to support alternative energy-fueled systems, such as geothermal heating or cooling systems.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install underground storm, sanitary, or water piping systems, extending piping as needed to connect fixtures and plumbing.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Keep records of work assignments.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lay out full scale drawings of pipe systems, supports, or related equipment, according to blueprints.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate and mark the position of pipe installations, connections, passage holes, or fixtures in structures, using measuring instruments such as rulers or levels.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain or repair plumbing by replacing defective washers, replacing or mending broken pipes, or opening clogged drains.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Modify, clean, or maintain pipe systems, units, fittings, or related machines or equipment, using hand or power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate motorized pumps to remove water from flooded manholes, basements, or facility floors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plan pipe system layout, installation, or repair, according to specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair hydraulic or air pumps.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair or remove and replace system components.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints, building codes, or specifications to determine work details or procedures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Select pipe sizes, types, or related materials, such as supports, hangers, or hydraulic cylinders, according to specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shut off steam, water, or other gases or liquids from pipe sections, using valve keys or wrenches.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld small pipes or special piping, using specialized techniques, equipment, or materials, such as computer-assisted welding or microchip fabrication.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "AEC Design Group CADPIPE",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Atlas Construction Business Forms",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Autodesk Building Systems",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bentley Systems AutoPIPE",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bookkeeping software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "COADE CAESAR II",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design CAD software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Database software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drawing and drafting software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software DPIPE",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software FIRE",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software HSYM",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software Plumbing CAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software Spipe",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elite Software Sprinkler CAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Email software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Estimating software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "FastEST FastPipe",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "FastEST software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heat loss calculation software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Horizon Engineering Sigma Plumbing Calculator",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insight Direct ServiceCEO",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Internet browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Intuit QuickBooks",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Job costing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "KRS Enterprises Service First!",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Klear Estimator",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance management software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Active Server Pages ASP",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipepro Pipefitting",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Piping construction costs estimation software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PipingOffice",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "PricePoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quicken",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quote Software QuoteExpress",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vision InfoSoft Plumbing Bid Manager",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "ViziFlow",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Watter Hammer Software Hytran",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wilhelm Publishing Threshold",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wintac Pro",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acetylene torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable slip lock nut wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air operated grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air wire brushes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air-acetylene torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Allen wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Alternating current AC welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amp meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Angle air grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Augers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Automatic levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ball peen hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bandsaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Basin wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Basket strainer wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bench chain vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bench yoke vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bibb seat tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Block and tackle equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bolt cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Box end wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brazing equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Butane torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Calipers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Centering head tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain falls",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain tongs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Channel lock pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circular saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Claw hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cleanout plug wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cold chisels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Combination squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compound leverage wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Comprehensive water gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compression sleeve pullers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Copper cutting machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crescent wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crowbars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutting torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Deburring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diagonal cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct current DC arc welder",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct tap machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drain cleaning cables",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill presses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drophead dies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dumpy levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "End pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Explosimeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Faucet handle pullers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Faucet stem and cartridge pullers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flaring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flat blade screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flat head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flow gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Four-in-one keys",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Framing squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas leak detection devices",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gasket cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand spinners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hand tachometers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heat guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy duty drain cleaning machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy duty water pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hex wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hole cutting tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hole saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hollow core socket wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic valve turners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydrostatic testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Impact hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Impact screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Impact wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inductive clamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inner/outer reamers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Internal wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jackhammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jam-proof ratchet threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser alignment tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser printers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lathes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Leak-testing gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Light pickup trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Line locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locking pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Magnetic circle layout tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Magnetic locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manlifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manual pipe benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Manual ratchet threader sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Material-hoisting slings",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maximum reading water pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal cutting dies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal cutting taps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal hand saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal inert gas MIG welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mini hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mini tubing cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Moisture meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Monkey wrench sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mud pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "No hub torque wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Non-contact infrared thermometers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Null locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Nylon strap wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Offset grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Offset pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oilers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "One stop wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oxyacetylene welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pavement stompers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pedestal grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pedestal sink wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal digital assistants PDA",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phillips head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe bending mandrels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe bending tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe extractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe fabrication shears",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe flange aligners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe flaring tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe freezing kits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe lasers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe taps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe threading machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe welding vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipeline jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pit depth gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plasma cutting guides",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plastic nut basin wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plastic pipe/conduit die heads",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumb bobs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plungers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic pipe bevelers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic wire brushes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pocket levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Polyvinyl chloride PVC cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Polyvinyl chloride PVC saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pop-up plug wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable welding machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power pipe cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power pipe threading machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power sink machine drain cleaners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power spinners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pressurized water pigs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Propane torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pry bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pulleys",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quality control QC welders' gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Radius markers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rapwrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rasps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ratcheting box wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ratcheting polyvinyl chloride PVC cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reamers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar locators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Receding threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reciprocating saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Right-angle drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rodders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Roll groovers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Root ranger jetter nozzles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rotary hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rubber strap wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Seat dressers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Seat wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sectional drain cleaning machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewage pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shears",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shielded arc welding tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shower valve socket wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shut-off keys",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Single-cut mill saw files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Six-step faucet seat wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Skip loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slip joint pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Soil pipe cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Soldering equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spiral ratchet pipe reamers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Split bubble levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spud wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stands",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stationary grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stillson wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Straight pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Straight-fluted pipe reamers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Strainer wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Strap wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sump pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swaging tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tapping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Telescopic inspection mirrors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Telescoping basin wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Thread repair files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Threading machine die heads",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Three-way pipe threaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tin snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tirfors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Toilet augers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torch cutter guides",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torpedo levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transmitters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trenchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tripod vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tristand chain vises",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trutest smoke detectors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tub drain removers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tube bending springs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tube crimping tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tubing cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tuggers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tungsten inert gas TIG welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two-hole pins",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ultrasonic leak detectors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Universal nut wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vacuum gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vertical bandsaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vibration analyzers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Video diagnostic tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vise grip pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water heater element removal wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water jetters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water meter keys",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water pump pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water samplers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water stoppers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding clamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding hoods",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wide roll pipe cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Winches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire tracers",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2152.00",
+    "title": "Plumbers & Pipefitters"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.5,
+        "level": 3.12,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.62,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.5,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.38,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.38,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.62,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.38,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.75,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.88,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.12,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.25,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.75,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.88,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Buster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Rod Buster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Field Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Journeyman Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Post Tensioning Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Bender",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Fabricator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Production Fabricator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Rodbuster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Tier",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforced Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforcing Iron Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforcing Iron and Rebar Workers",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforcing Metal Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforcing Rod Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Reinforcing Steel Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rod Buster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rodbuster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rodman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Rod Buster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Tier",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install fencing or other barriers.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install metal structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position safety or support equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.37,
+        "level": 3.89,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.66,
+        "level": null,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.08,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.58,
+        "level": 5.97,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.18,
+        "level": 2.18,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.39,
+        "level": 0.93,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.55,
+        "level": null,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.46,
+        "level": 2.3,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.29,
+        "level": 4.05,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.66,
+        "level": null,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.65,
+        "level": 2.46,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.04,
+        "level": 3.66,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.27,
+        "level": 2.84,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.04,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.07,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.58,
+        "level": 0.86,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.46,
+        "level": 1.04,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.11,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.72,
+        "level": 1.35,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.43,
+        "level": 3.63,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.72,
+        "level": 2.51,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.62,
+        "level": null,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.45,
+        "level": 2.1,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.19,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.06,
+        "level": 1.68,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.32,
+        "level": 1.94,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.33,
+        "level": 2.46,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.65,
+        "level": 2.61,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.66,
+        "level": null,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.44,
+        "level": 0.77,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.53,
+        "level": 0.51,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.63,
+        "level": 1.04,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.35,
+        "level": 2.29,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.38,
+        "level": 1.88,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.12,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.25,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.0,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.0,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.62,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bend steel rods with hand tools or rod-bending machines and weld them with arc-welding equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut and fit wire mesh or fabric, using hooked rods, and position fabric or mesh in concrete to reinforce concrete.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut rods to required lengths, using metal shears, hacksaws, bar cutters, or acetylene torches.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Determine quantities, sizes, shapes, and locations of reinforcing rods from blueprints, sketches, or oral instructions.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Place blocks under rebar to hold the bars off the deck when reinforcing floors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position and secure steel bars, rods, cables, or mesh in concrete forms, using fasteners, rod-bending machines, blowtorches, or hand tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Space and fasten together rods in forms according to blueprints, using wire and pliers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Application Software SHEAR",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Applied Systems Associates aSa Rebar",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "OTP ArmaCAD",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "RebarWin",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Acetylene torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable widemouth pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Arc welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Automatic rebar tying tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Beam spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bolt cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caulking guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain slings",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chokers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crowbars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutoff saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Double lanyards",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grease guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hard hats",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hard sole boots",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hickey bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hole saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic cable cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic crimpers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jig saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal shears",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable hydraulic rod benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rigging equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shackle straps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shear lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Socket wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swaging tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tie wire reel",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tie wire reels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tuggers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire twisters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Workshop cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wrecking bars",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2171.00",
+    "title": "Reinforcing Iron & Rebar Workers"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 4.0,
+        "level": 3.88,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.75,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.5,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.5,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.88,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.88,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.0,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.25,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 3.88,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 3.75,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.62,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.0,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.12,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.88,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.25,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.12,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 4.12,
+        "level": 4.5,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 4.0,
+        "level": 3.88,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Awnings Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Billboard Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Billboard Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Billboard Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bolter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridge Maintainer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bridgeman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Construction Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Combination Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Guard Rail Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Guzzler Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Housesmith",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Guardrail Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Iron Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Joist Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Journeyman Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Layout Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Building Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Building Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Buildings Assembler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Tank Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Tank Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metal Trim Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Metalsmith",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil Field Rig Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ornamental Iron Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ornamental Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ornamental Metal Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ornamental Metal Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Petroleum Production Tank Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Playground Equipment Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pre-Engineered Metal Building Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Precast Concrete Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rebar Fabricator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffold Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sheet Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Board Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sign Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Construction Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Fabricator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Hanger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Layout Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Rigger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steel Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Iron Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Layout Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Metal Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Rigger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Steel Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Steel Fitter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Steel Ironworker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Steel Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Structural Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tank Setter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tower Hand",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wind Turbine Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble temporary equipment or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assist skilled construction or extraction personnel.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dismantle equipment or temporary structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fabricate parts or components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install electrical components, equipment, or systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install gauges or controls.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install insulation in equipment or structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install metal structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Load or unload materials used in construction or extraction.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate cranes, hoists, or other moving or lifting equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position safety or support equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Position structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Signal equipment operators to indicate proper equipment positioning.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verify alignment of structures or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.01,
+        "level": 2.73,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.65,
+        "level": 1.04,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.17,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.58,
+        "level": 6.14,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.91,
+        "level": 1.54,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.55,
+        "level": 0.87,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.32,
+        "level": null,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.87,
+        "level": 3.29,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.83,
+        "level": 2.52,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.43,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.82,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.36,
+        "level": 3.1,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.89,
+        "level": 2.88,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.39,
+        "level": 0.59,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.19,
+        "level": null,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.0,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.36,
+        "level": 0.55,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.48,
+        "level": 3.68,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.67,
+        "level": 3.8,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.52,
+        "level": 0.67,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.3,
+        "level": 2.09,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.14,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.29,
+        "level": 1.9,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.97,
+        "level": 1.74,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.06,
+        "level": 1.83,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.31,
+        "level": 3.01,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.49,
+        "level": 0.79,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.27,
+        "level": null,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.37,
+        "level": null,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.39,
+        "level": null,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.45,
+        "level": 2.18,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.38,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.5,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.25,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.12,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.0,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 1.0,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.62,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.38,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.0,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.0,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 3.0,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.62,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.25,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.38,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.12,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.25,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 1.88,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.38,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble hoisting equipment or rigging, such as cables, pulleys, or hooks, to move heavy equipment or materials.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bolt aligned structural steel members in position for permanent riveting, bolting, or welding into place.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Connect columns, beams, and girders with bolts, following blueprints and instructions from supervisors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut, bend, or weld steel pieces, using metal shears, torches, or welding equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dismantle structures or equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive drift pins through rivet holes to align rivet holes in structural steel members with corresponding holes in previously placed members.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Erect metal or precast concrete components for structures, such as buildings, bridges, dams, towers, storage tanks, fences, or highway guard rails.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fabricate metal parts, such as steel frames, columns, beams, or girders, according to blueprints or instructions from supervisors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fasten structural steel members to hoist cables, using chains, cables, or rope.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Force structural steel members into final positions, using turnbuckles, crowbars, jacks, or hand tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoist steel beams, girders, or columns into place, using cranes or signaling hoisting equipment operators to lift and position structural steel members.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hold rivets while riveters use air hammers to form heads on rivets.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insert sealing strips, wiring, insulating material, ladders, flanges, gauges, or valves, depending on types of structures being assembled.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Place blocks under reinforcing bars used to reinforce floors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pull, push, or pry structural steel members into approximate positions for bolting into place.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Read specifications or blueprints to determine the locations, quantities, or sizes of materials required.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ride on girders or other structural steel members to position them, or use rope to guide them into position.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Unload and position prefabricated steel units for hoisting, as needed.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verify vertical and horizontal alignment of structural steel members, using plumb bobs, laser equipment, transits, or levels.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computer aided design CAD software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cost estimating software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inventory tracking software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Project scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turtle Creek Software Goldenseal",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable widemouth pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blow torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bolt cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bull pins",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "C clamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Center punches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chalk lines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cold chisels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Combination squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crowbars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutoff saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Decoilers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drift pins",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ear plugs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electric drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fire extinguishers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flat head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forging dies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grout mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hard hats",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Life preservers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Notebook computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Open end wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phillips head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pipe wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plasma cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumb bobs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable welding machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power lifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective coveralls",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rivet busters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rivet guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rivet tongs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Robertson screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rod ovens",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rubber mallets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety belts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety boots",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety glasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety lanyards",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scribers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Side cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Single-cut mill saw files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sledgehammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slings",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Socket wrench sets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreader beams",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spud wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Squares",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Staple guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stressing jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Strikers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swing stages",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tin snips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tongs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Torpedo levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tuggers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Utility knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vise grip pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding helmets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding hoods",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welding tips",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Winches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire brushes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Workshop cranes",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-2221.00",
+    "title": "Structural Iron and Steel Workers"
+  },
+  {
+    "job_zone": 3,
+    "sector": "Building Construction",
+    "skills": [
+      {
+        "importance": 3.5,
+        "level": 3.25,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.12,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.0,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.75,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.25,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.0,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.0,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.5,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.12,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.38,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.25,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.25,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.12,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.0,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.5,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 3.25,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.5,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.75,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Accessibility Lift Technician (Accessibility Lift Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Accessibility and Private Residence Lift Technician (Accessibility and Private Residence Lift Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Building Serviceman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Contract Serviceman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Adjuster",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Constructor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Examiner",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Installation Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Lift Technician (Elevator Lift Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Repair and Maintenance Technician (Elevator Repair and Maintenance Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Service Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Service Technician (Elevator Service Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Serviceman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Technician (Elevator Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Troubleshooter",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Escalator Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Escalator Maintenance Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Escalator Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Escalator Service Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Freight Elevator Erector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic Elevator Constructor",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Platform Power Technician (Platform Power Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair Maintenance Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transit Elevator Maintenance Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble products or production equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Evaluate construction projects to determine compliance with external standards or regulations.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect electrical or electronic systems for defects.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect industrial or commercial equipment to ensure proper operation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install electrical components, equipment, or systems.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install metal structural components.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate equipment or materials in need of repair or replacement.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain mechanical equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Prepare operational reports.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Record operational or environmental data.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair electrical equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Review blueprints or specifications to determine work requirements.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test electrical equipment or systems to ensure proper functioning.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Thread wire or cable through ducts or conduits.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Update job related knowledge or skills.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.06,
+        "level": 3.76,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.93,
+        "level": 3.14,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.39,
+        "level": null,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.65,
+        "level": 4.44,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.42,
+        "level": 2.91,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.74,
+        "level": null,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.4,
+        "level": 3.6,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.77,
+        "level": 4.36,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.96,
+        "level": 3.87,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.86,
+        "level": 1.57,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.91,
+        "level": 3.31,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.17,
+        "level": 3.94,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.91,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.39,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.38,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.46,
+        "level": 0.92,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.78,
+        "level": 1.62,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.39,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.55,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 4.11,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.33,
+        "level": 5.19,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.81,
+        "level": 1.38,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.45,
+        "level": 2.45,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.5,
+        "level": 1.05,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.82,
+        "level": 3.81,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.31,
+        "level": 2.47,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.76,
+        "level": 1.27,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.57,
+        "level": 4.27,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.49,
+        "level": 3.23,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.45,
+        "level": null,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.68,
+        "level": 2.7,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.42,
+        "level": null,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.71,
+        "level": 2.72,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.12,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.25,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.25,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.38,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.88,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.25,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.5,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.38,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.62,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.88,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.5,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.25,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 4.0,
+        "level": 4.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjust safety controls, counterweights, door mechanisms, and components such as valves, ratchets, seals, and brake linings.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble electrically powered stairs, steel frameworks, and tracks, and install associated motors and electrical wiring.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble elevator cars, installing each car's platform, walls, and doors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Assemble, install, repair, and maintain elevators, escalators, moving sidewalks, and dumbwaiters, using hand and power tools, and testing devices such as test lamps, ammeters, and voltmeters.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Attach guide shoes and rollers to minimize the lateral motion of cars as they travel through shafts.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bolt or weld steel rails to the walls of shafts to guide elevators, working from scaffolding or platforms.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Check that safety regulations and building codes are met, and complete service reports verifying conformance to standards.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Connect car frames to counterweights, using steel cables.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Connect electrical wiring to control panels and electric motors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut prefabricated sections of framework, rails, and other components to specified dimensions.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Disassemble defective units, and repair or replace parts such as locks, gears, cables, and electric wiring.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect wiring connections, control panel hookups, door installations, and alignments and clearances of cars and hoistways to ensure that equipment will operate properly.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install electrical wires and controls by attaching conduit along shaft walls from floor to floor and pulling plastic-covered wires through the conduit.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install outer doors and door frames at elevator entrances on each floor of a structure.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate malfunctions in brakes, motors, switches, and signal and control systems, using test equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain log books that detail all repairs and checks performed.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate elevators to determine power demands, and test power consumption to detect overload factors.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Participate in additional training to keep skills up to date.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Read and interpret blueprints to determine the layout of system components, frameworks, and foundations, and to select installation equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test newly installed equipment to ensure that it meets specifications, such as stopping at floors for set amounts of time.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computerized maintenance management system CMMS",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Elevator Controls INTERACT",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scheduling software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Troubleshooting software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "WORLD Electronics Freedomware",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ammeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Amp meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cable tensionmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Capacity testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cleaning scrapers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Commutator stones",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Conduit benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cutting torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Diagonal cutting pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digital oscilloscopes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Disk grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Electricians' knives",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment dollies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Event recorders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flat metal files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fuse testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graphic data recording meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grease guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hacksaws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hoists",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic elevator cylinder repair kits",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Insulated pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ladders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laptop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Levels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Logic probes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Long nose pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring tapes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Megohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Micrometers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Millivoltmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multimeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ohmmeters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Open end wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phase rotation meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Phillips head screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Plumb bobs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pressure gauges",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Programmable logic controllers PLC",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pump pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Resistance testers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shielded arc welding tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Signal generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Slings",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Soldering irons",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spring scales",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stick welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tablet computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tachometers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Temperature profile recorders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Test lamps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tungsten inert gas TIG welder",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vacuum pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Volt meters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire brushes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wire strippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Work platforms",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-4021.00",
+    "title": "Elevator & Escalator Installers"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.25,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.75,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.5,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 1.62,
+        "level": 1.12,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 3.88,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.0,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.88,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.62,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.62,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt Raker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Caltrans Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Certified Flagger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Construction Flagger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Equipment Operator (EO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flagger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Maintainer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Maintenance Crew Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Maintenance Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Maintenance Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Technician (Highway Tech)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Highway Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hot Oiler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lane Marker Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Material Handler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Materials Handling Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil Spreader Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Quick Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Builder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Crew Member",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Maintenance Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Maker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Mender",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Oiler",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Oiling Truck Driver",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Patcher",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Sign Installer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Road Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snow Plow Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Street Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Control Flagger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Control Laborer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Control Specialist",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Controller",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Flagger",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Traffic Signal Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Maintenance Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Maintenance Specialist (TMS)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Technician",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transportation Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply paint to surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean equipment or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compact materials to create level bases.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Direct vehicle traffic.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dismantle equipment or temporary structures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive trucks or truck-mounted equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect completed work to ensure proper installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect industrial or commercial equipment to ensure proper operation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Install fencing or other barriers.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain mechanical equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain plumbing structures or fixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mark reference points on construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure work site dimensions.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mix substances or compounds needed for work activities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Move construction or extraction materials to locations where they are needed.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate equipment or vehicles to clear construction sites or move materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate road-surfacing equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pour materials into or on designated areas.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove debris or vegetation from work sites.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spread concrete or other aggregate mixtures.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spread sand, dirt or other loose materials onto surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Treat greenery or surfaces with protective substances.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.3,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.13,
+        "level": 2.26,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.97,
+        "level": 1.9,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.21,
+        "level": 3.5,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.2,
+        "level": 2.67,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.31,
+        "level": 2.55,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.01,
+        "level": 1.44,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.95,
+        "level": 4.41,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.58,
+        "level": 2.52,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.27,
+        "level": 3.03,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.03,
+        "level": 2.77,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.87,
+        "level": 3.66,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.51,
+        "level": 3.5,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.32,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.33,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.64,
+        "level": 1.11,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.53,
+        "level": 1.88,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.34,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.35,
+        "level": 2.17,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.8,
+        "level": 2.7,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.99,
+        "level": 4.19,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.58,
+        "level": null,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.29,
+        "level": 1.7,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.53,
+        "level": 0.89,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.08,
+        "level": 2.11,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.62,
+        "level": 3.17,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.18,
+        "level": 2.9,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 4.23,
+        "level": 4.44,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.51,
+        "level": null,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.84,
+        "level": null,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.27,
+        "level": 1.86,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.88,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.26,
+        "level": 3.34,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.5,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.38,
+        "level": 0.5,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.75,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.12,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.12,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.5,
+        "level": 3.0,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.38,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.12,
+        "level": 0.12,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.75,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.62,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.5,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply oil to road surfaces, using sprayers.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply poisons along roadsides and in animal burrows to eliminate unwanted roadside vegetation and rodents.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Blend compounds to form adhesive mixtures used for marker installation.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean and clear debris from culverts, catch basins, drop inlets, ditches, and other drain structures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive heavy equipment and vehicles with adjustable attachments to sweep debris from paved surfaces, mow grass and weeds, remove snow and ice, and spread salt and sand.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive trucks to transport crews and equipment to work sites.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump, spread, and tamp asphalt, using pneumatic tampers, to repair joints and patch broken pavement.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Erect, install, or repair guardrails, road shoulders, berms, highway markers, warning signals, and highway lighting, using hand tools and power tools.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flag motorists to warn them of obstacles or repair work ahead.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Haul and spread sand, gravel, and clay to fill washouts and repair road shoulders.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect markers to verify accurate installation.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Inspect, clean, and repair drainage systems, bridges, tunnels, and other structures.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measure and mark locations for installation of markers, using tape, string, or chalk.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paint traffic control lines and place pavement traffic messages, by hand or using machines.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform preventative maintenance on vehicles and heavy equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Perform roadside landscaping work, such as clearing weeds and brush, and planting and trimming trees.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Place and remove snow fences used to prevent the accumulation of drifting snow on highways.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Remove litter and debris from roadways, including debris from rock and mud slides.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Set out signs and cones around work areas to divert traffic.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Database software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Outlook",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft PowerPoint",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Word",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spreadsheet software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Web browser software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Word processing software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "10-ton crawlers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "10-ton tandem-axle dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "13000-23000 pound graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "30-ton clam buckets",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "4-6 ton roller patchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "8-ton dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable widemouth pliers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Aggregate spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air compressors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Asphalt reclaimers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Athey loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Belly dump tractor trailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Berm drag tractors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bituminous pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Boom trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Brush chippers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bucket trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bulldozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Bush axes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Catch basin vacuum cleaners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chain saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chemical sprayers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cherry pickers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Chip spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Circuit testing equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cold planers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compactors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Computerized weed spray trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete groovers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete paving vibrators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Concrete saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Culvert cleaners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Desktop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Digger derricks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ditchers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Draglines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Epoxy guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Flatbed trailers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Four-wheel drive front end loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Front end loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas transporters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Generators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gradalls",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Graffiti removing lasers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Harrows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Heavy trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "High-pressure hydraulic pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hole diggers/augers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Impact wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jackhammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laser printers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laydown machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Light trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Low boys",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Machetes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Measuring wheels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Medium pressure hydraulic pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mounted pavement breakers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Mud jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Multipurpose vacuum street sweepers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil heating burners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paint guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paint mixers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paint transfer pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Patch rollers less than 9 tons",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pavement grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pavement joint sealers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pavement rollers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Personal computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Picks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pile drivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Platform trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic tampers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable welding equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pothole excavation milling machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power broom street sweepers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power screeds",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pressure washers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pull type pavers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Push mowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rakes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rear brush hog mowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rear flail mowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rock cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rock drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rotary snowplows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sand spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sandblasters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scaffolding",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Scissor trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Screwdrivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Seeders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-propelled cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-propelled road wideners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Self-propelled sweepers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer cleaners",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Sewer eels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shovels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Side dozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Side-mount rotary mowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snoopers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snow blowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Snowplows",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spades",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Steam cleaning equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stone box spreaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stump cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swinging stages",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Swiss hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tanker trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tar distributors",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tar kettles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Theodolites",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Thermoplastic applicators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tire chains",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tow brooms",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Towable barricades",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tractor disc attachments",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tractor-mounted mowers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Transport trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck low-bed trailer combos",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck mounted cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck mounted excavators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Truck-mounted pavement striping machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two way radios",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Two-wheel drive front end loaders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vans",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water pumps",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Water trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weedeaters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Wheeled hydraulic booms",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Windrow loaders",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-4051.00",
+    "title": "Highway Maintenance Workers"
+  },
+  {
+    "job_zone": 2,
+    "sector": "Heavy Highway Construction",
+    "skills": [
+      {
+        "importance": 3.62,
+        "level": 3.0,
+        "name": "Arm-Hand Steadiness",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Auditory Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Category Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.88,
+        "level": 4.0,
+        "name": "Control Precision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Deductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Depth Perception",
+        "type": "ability"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Dynamic Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Dynamic Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.38,
+        "name": "Explosive Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Extent Flexibility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.75,
+        "name": "Far Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Finger Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.38,
+        "name": "Flexibility of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Fluency of Ideas",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Glare Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Gross Body Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Gross Body Equilibrium",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Hearing Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Inductive Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Information Ordering",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.12,
+        "name": "Manual Dexterity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.5,
+        "name": "Mathematical Reasoning",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 1.88,
+        "name": "Memorization",
+        "type": "ability"
+      },
+      {
+        "importance": 3.75,
+        "level": 4.0,
+        "name": "Multilimb Coordination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.0,
+        "name": "Near Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Night Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Number Facility",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Oral Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 3.0,
+        "name": "Oral Expression",
+        "type": "ability"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Originality",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Perceptual Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.0,
+        "level": 2.0,
+        "name": "Peripheral Vision",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.0,
+        "name": "Problem Sensitivity",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.12,
+        "name": "Rate Control",
+        "type": "ability"
+      },
+      {
+        "importance": 3.62,
+        "level": 3.62,
+        "name": "Reaction Time",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.25,
+        "name": "Response Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Selective Attention",
+        "type": "ability"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.38,
+        "name": "Sound Localization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Spatial Orientation",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.38,
+        "name": "Speech Clarity",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.25,
+        "name": "Speech Recognition",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.38,
+        "name": "Speed of Closure",
+        "type": "ability"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.75,
+        "name": "Speed of Limb Movement",
+        "type": "ability"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.88,
+        "name": "Stamina",
+        "type": "ability"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.75,
+        "name": "Static Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.88,
+        "name": "Time Sharing",
+        "type": "ability"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.5,
+        "name": "Trunk Strength",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.62,
+        "name": "Visual Color Discrimination",
+        "type": "ability"
+      },
+      {
+        "importance": 3.38,
+        "level": 3.5,
+        "name": "Visualization",
+        "type": "ability"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.38,
+        "name": "Wrist-Finger Speed",
+        "type": "ability"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.75,
+        "name": "Written Comprehension",
+        "type": "ability"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Written Expression",
+        "type": "ability"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Ballast Cleaning Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Emergency Service Restorer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintenance Laborer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oil Distributor Tender",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable Grinding Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail Maintenance Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail Track Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail Track Maintainer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railroad Track Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Railway Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Section Hand",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Section Laborer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Special Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Stone Crusher Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Dresser",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Equipment Operator (TEO)",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Grinder Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Inspector",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Laborer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Layer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Laying Equipment Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Laying Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Machine Operator Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Maintainer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Man",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Mechanic",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Moving Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Repair Person",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Repair Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Repairer",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Service Person",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Service Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Surfacing Machine Operator",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Walker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Welder",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track Worker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trackman",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Trackwalker",
+        "type": "alternate_title"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply paint to surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Apply sealants or other protective coatings.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean equipment or facilities.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Compact materials to create level bases.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut metal components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut wood components for installation.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill holes in construction materials.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Locate equipment or materials in need of repair or replacement.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain construction tools or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Maintain mechanical equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate cranes, hoists, or other moving or lifting equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate heavy-duty construction or installation equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Smooth surfaces with abrasive materials or tools.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spread sand, dirt or other loose materials onto surfaces.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Verify alignment of structures or equipment.",
+        "type": "dwa"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld metal components.",
+        "type": "dwa"
+      },
+      {
+        "importance": 3.04,
+        "level": 2.85,
+        "name": "Administration and Management",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.55,
+        "level": 1.78,
+        "name": "Administrative",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.74,
+        "level": 1.1,
+        "name": "Biology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.51,
+        "level": 4.45,
+        "name": "Building and Construction",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.27,
+        "level": 2.24,
+        "name": "Chemistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.83,
+        "level": 1.24,
+        "name": "Communications and Media",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.08,
+        "level": 1.52,
+        "name": "Computers and Electronics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.82,
+        "level": 2.96,
+        "name": "Customer and Personal Service",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.55,
+        "level": 2.51,
+        "name": "Design",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.99,
+        "level": 1.47,
+        "name": "Economics and Accounting",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.92,
+        "level": 2.92,
+        "name": "Education and Training",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.99,
+        "level": 3.68,
+        "name": "Engineering and Technology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.64,
+        "level": 2.16,
+        "name": "English Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.28,
+        "level": null,
+        "name": "Fine Arts",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.48,
+        "level": null,
+        "name": "Food Production",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.57,
+        "level": null,
+        "name": "Foreign Language",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.3,
+        "level": 2.3,
+        "name": "Geography",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.53,
+        "level": null,
+        "name": "History and Archeology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.45,
+        "level": 1.61,
+        "name": "Law and Government",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.94,
+        "level": 3.28,
+        "name": "Mathematics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.65,
+        "level": 4.31,
+        "name": "Mechanical",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.68,
+        "level": 0.88,
+        "name": "Medicine and Dentistry",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.46,
+        "level": 1.85,
+        "name": "Personnel and Human Resources",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.45,
+        "level": null,
+        "name": "Philosophy and Theology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.58,
+        "level": 2.84,
+        "name": "Physics",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.86,
+        "level": 2.79,
+        "name": "Production and Processing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.14,
+        "level": 1.73,
+        "name": "Psychology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.03,
+        "name": "Public Safety and Security",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.09,
+        "level": 1.37,
+        "name": "Sales and Marketing",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.62,
+        "level": 0.68,
+        "name": "Sociology and Anthropology",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.39,
+        "level": 1.76,
+        "name": "Telecommunications",
+        "type": "knowledge"
+      },
+      {
+        "importance": 1.48,
+        "level": 1.04,
+        "name": "Therapy and Counseling",
+        "type": "knowledge"
+      },
+      {
+        "importance": 3.66,
+        "level": 3.29,
+        "name": "Transportation",
+        "type": "knowledge"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.38,
+        "name": "Active Learning",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Active Listening",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.38,
+        "name": "Complex Problem Solving",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.12,
+        "name": "Coordination",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Critical Thinking",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.0,
+        "name": "Equipment Maintenance",
+        "type": "skill"
+      },
+      {
+        "importance": 2.62,
+        "level": 2.25,
+        "name": "Equipment Selection",
+        "type": "skill"
+      },
+      {
+        "importance": 1.5,
+        "level": 0.5,
+        "name": "Installation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.62,
+        "name": "Instructing",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Judgment and Decision Making",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.25,
+        "name": "Learning Strategies",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Management of Financial Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.0,
+        "name": "Management of Material Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.5,
+        "level": 2.12,
+        "name": "Management of Personnel Resources",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.0,
+        "name": "Mathematics",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 2.88,
+        "name": "Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 1.88,
+        "level": 1.75,
+        "name": "Negotiation",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.12,
+        "name": "Operation and Control",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Operations Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 3.75,
+        "level": 3.25,
+        "name": "Operations Monitoring",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 1.88,
+        "name": "Persuasion",
+        "type": "skill"
+      },
+      {
+        "importance": 1.0,
+        "level": 0.0,
+        "name": "Programming",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Quality Control Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.38,
+        "level": 2.25,
+        "name": "Reading Comprehension",
+        "type": "skill"
+      },
+      {
+        "importance": 3.12,
+        "level": 3.0,
+        "name": "Repairing",
+        "type": "skill"
+      },
+      {
+        "importance": 1.25,
+        "level": 0.25,
+        "name": "Science",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 1.88,
+        "name": "Service Orientation",
+        "type": "skill"
+      },
+      {
+        "importance": 2.75,
+        "level": 2.0,
+        "name": "Social Perceptiveness",
+        "type": "skill"
+      },
+      {
+        "importance": 2.88,
+        "level": 2.25,
+        "name": "Speaking",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.12,
+        "name": "Systems Analysis",
+        "type": "skill"
+      },
+      {
+        "importance": 2.12,
+        "level": 2.0,
+        "name": "Systems Evaluation",
+        "type": "skill"
+      },
+      {
+        "importance": 1.75,
+        "level": 0.75,
+        "name": "Technology Design",
+        "type": "skill"
+      },
+      {
+        "importance": 3.0,
+        "level": 2.75,
+        "name": "Time Management",
+        "type": "skill"
+      },
+      {
+        "importance": 3.25,
+        "level": 3.0,
+        "name": "Troubleshooting",
+        "type": "skill"
+      },
+      {
+        "importance": 2.25,
+        "level": 2.12,
+        "name": "Writing",
+        "type": "skill"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjust controls of machines that spread, shape, raise, level, or align track, according to specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean or make minor repairs to machines or equipment.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean tracks or clear ice or snow from tracks or switch boxes.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Clean, grade, or level ballast on railroad tracks.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Cut rails to specified lengths, using rail saws.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dress and reshape worn or damaged railroad switch points or frogs, using portable power grinders.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drill holes through rails, tie plates, or fishplates for insertion of bolts or spikes, using power drills.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive graders, tamping machines, brooms, or ballast spreading machines to redistribute gravel or ballast between rails.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Drive vehicles that automatically move and lay tracks or rails over sections of track to be constructed, repaired, or maintained.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Engage mechanisms that lay tracks or rails to specified gauges.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grind ends of new or worn rails to attain smooth joints, using portable grinders.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Lubricate machines, change oil, or fill hydraulic reservoirs to specified levels.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Observe leveling indicator arms to verify levelness and alignment of tracks.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate single- or multiple-head spike driving machines to drive spikes into ties and secure rails.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate single- or multiple-head spike pullers to pull old spikes from ties.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate tie-adzing machines to cut ties and permit insertion of fishplates that hold rails.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Operate track wrenches to tighten or loosen bolts at joints that hold ends of rails together.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Paint railroad signs, such as speed limits or gate-crossing warnings.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Patrol assigned track sections so that damaged or broken track can be located and reported.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Push controls to close grasping devices on track or rail sections so that they can be raised or moved.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Raise rails, using hydraulic jacks, to allow for tie removal and replacement.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Repair or adjust track switches, using wrenches and replacement parts.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spray ties, fishplates, or joints with oil to protect them from weathering.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "String and attach wire-guidelines machine to rails so that tracks or rails can be aligned or leveled.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Turn wheels of machines, using lever controls, to adjust guidelines for track alignments or grades, following specifications.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weld sections of track together, such as switch points and frogs.",
+        "type": "task"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Enterprise resource planning ERP software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Excel",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Microsoft Office software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Timekeeping software",
+        "type": "technology"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Adjustable hand wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air purifying respirators",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Air-powered wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Backhoes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Claw bars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Crowbars",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dollies",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Dump trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Fall protection harnesses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Forklifts",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Gas-powered wrenches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Global positioning system GPS receivers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grading equipment",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Grease guns",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Handheld computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hard hats",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hi-rail vehicles",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Hydraulic jacks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Jackhammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Laptop computers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Light pickup trucks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Oxyacetylene torches",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pesticide sprayers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Picks",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Pneumatic hammers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Portable track loading fixtures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Power washers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Precision files",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Precision tape measures",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Protective ear plugs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail benders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail drills",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail profile grinders",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail saws",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail tongs",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Rail-mounted cranes",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety glasses",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Safety gloves",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shielded arc welding tools",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Shovels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Spike pullers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tamping machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track chisels",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Track-wrench machines",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Tracked bulldozers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Vernier calipers",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Weed cutters",
+        "type": "tool"
+      },
+      {
+        "importance": null,
+        "level": null,
+        "name": "Welders",
+        "type": "tool"
+      }
+    ],
+    "soc_code": "47-4061.00",
+    "title": "Rail-Track Laying Equipment"
+  }
+]

--- a/scripts/curate_onet.py
+++ b/scripts/curate_onet.py
@@ -1,0 +1,150 @@
+"""
+Curate the O*NET occupation-skill mapping for Chalkline's 21 SOC codes.
+
+Downloads element-type files from the O*NET 30.0 database, filters to the
+stakeholder-curated SOC codes in `data/stakeholder/reference/onet_codes.json`,
+merges Skills, Knowledge, Abilities, Tasks, Technology Skills, Detailed Work
+Activities, Tools Used, and Alternate Titles into a structured `skills` array,
+and writes `data/lexicons/onet.json`.
+
+Run from the worktree root:
+
+    uv run python scripts/curate_onet.py
+"""
+
+from collections import Counter, defaultdict
+from json        import dumps, load
+from operator    import itemgetter
+from pandas      import read_csv
+from pathlib     import Path
+from urllib      import request
+
+
+ONET_FILES = {
+    "abilities"     : "Abilities.txt",
+    "alt_titles"    : "Alternate Titles.txt",
+    "dwa_reference" : "DWA Reference.txt",
+    "job_zones"     : "Job Zones.txt",
+    "knowledge"     : "Knowledge.txt",
+    "skills"        : "Skills.txt",
+    "tasks"         : "Task Statements.txt",
+    "tasks_to_dwas" : "Tasks to DWAs.txt",
+    "tech_skills"   : "Technology Skills.txt",
+    "tools_used"    : "Tools Used.txt"
+}
+
+BASE = "https://www.onetcenter.org/dl_files/database/db_30_0_text"
+
+entry = lambda name, type_label, importance=None, level=None: {
+    "importance" : importance,
+    "level"      : level,
+    "name"       : name,
+    "type"       : type_label
+}
+
+
+def main():
+    root = Path(__file__).resolve().parent.parent
+
+    with open(root / "data/stakeholder/reference/onet_codes.json") as f:
+        codes = {c["soc_code"]: c for c in load(f)}
+
+    print("Downloading O*NET 30.0 database files...")
+    raw = {}
+    for name, filename in ONET_FILES.items():
+        print(f"  Downloading {filename}...")
+        with request.urlopen(
+            f"{BASE}/{request.quote(filename)}"
+        ) as resp:
+            df = read_csv(resp, delimiter="\t", dtype=str)
+        raw[name] = (
+            df[df["O*NET-SOC Code"].isin(codes)]
+            if "O*NET-SOC Code" in df.columns else df
+        )
+    print(f"  Downloaded {len(ONET_FILES)} files.\n")
+
+    print("Extracting element types for 21 SOC codes...")
+    merged = defaultdict(list)
+
+    for source_key, type_label in (
+        ("abilities", "ability"),
+        ("knowledge", "knowledge"),
+        ("skills",    "skill")
+    ):
+        df = raw[source_key]
+        df = df[df["Recommend Suppress"] != "Y"]
+        for soc, group in df.groupby("O*NET-SOC Code"):
+            im, lv = (
+                dict(zip(
+                    (sub := group[group["Scale ID"] == scale])["Element Name"],
+                    sub["Data Value"].astype(float)
+                ))
+                for scale in ("IM", "LV")
+            )
+            merged[soc].extend(
+                entry(name, type_label, im.get(name), lv.get(name))
+                for name in im.keys() | lv.keys()
+            )
+
+    for soc, group in (
+        raw["tasks_to_dwas"]
+        .drop_duplicates(subset=["O*NET-SOC Code", "DWA ID"])
+        .merge(raw["dwa_reference"], on="DWA ID")
+        .groupby("O*NET-SOC Code")
+    ):
+        merged[soc].extend(
+            entry(title, "dwa") for title in group["DWA Title"]
+        )
+
+    for source_key, name_column, type_label in (
+        ("alt_titles",  "Alternate Title", "alternate_title"),
+        ("tasks",       "Task",            "task"),
+        ("tech_skills", "Example",         "technology"),
+        ("tools_used",  "Example",         "tool")
+    ):
+        for soc, group in (
+            raw[source_key]
+            .drop_duplicates(subset=["O*NET-SOC Code", name_column])
+            .groupby("O*NET-SOC Code")
+        ):
+            merged[soc].extend(
+                entry(name, type_label) for name in group[name_column]
+            )
+
+    job_zones = (
+        raw["job_zones"]
+        .set_index("O*NET-SOC Code")["Job Zone"]
+        .astype(int)
+        .to_dict()
+    )
+
+    occupations = [
+        {
+            "job_zone" : job_zones.get(soc),
+            "sector"   : codes[soc]["sector"],
+            "skills"   : sorted(merged[soc], key=itemgetter("type", "name")),
+            "soc_code" : soc,
+            "title"    : codes[soc]["title"]
+        }
+        for soc in sorted(codes)
+    ]
+
+    out_path = root / "data/lexicons/onet.json"
+    out_path.parent.mkdir(exist_ok=True, parents=True)
+    out_path.write_text(dumps(occupations, ensure_ascii=False, indent=2) + "\n")
+
+    print(f"  Wrote {len(occupations)} occupations to {out_path}")
+    for occ in occupations:
+        print(
+            f"    {occ['soc_code']}  {occ['title']:45s}"
+            f"  JZ={occ['job_zone']}  [{', '.join(
+                f'{v} {k}' for k, v in sorted(
+                    Counter(s['type'] for s in occ['skills']).items()
+                )
+            )}]"
+        )
+
+
+if __name__ == "__main__":
+
+    main()


### PR DESCRIPTION
### 📐 Quick Summary

Curates the O\*NET 30.0 occupation-skill mapping for Chalkline's **21** stakeholder SOC codes. The element type selection follows the occupational modeling literature[^2], retaining both concrete types (*Tasks, Technology Skills, DWAs, Tools, Alternate Titles*) for skill extraction and abstract KSA types (*Skills, Knowledge, Abilities*) with importance/level ratings for occupation-level similarity, consistent with how SOC-based mobility networks weight skill overlap[^1].

The output format is JSON rather than the spec's original CSV because the `skills` field contains nested structured objects that CSV would flatten into a delimited string.

***

### 🧱 Key Changes

- Add `scripts/curate_onet.py` fetching 10 O\*NET database files, pre-filtering to scoped SOC codes at download time, and merging rated (*IM/LV scale pairs*) and unrated element types into a unified `skills` array per occupation
- Add `data/lexicons/onet.json` containing **21** occupations with **6621** skill entries across **8** element types, Job Zone levels 1-5, and 3 sector assignments

***

### 🔩 Related Issues

- Closes #2

***

### 📚 References

[^1]: del Rio-Chanona, et al. 2021. "Occupational Mobility and Automation: A Data-Driven Network Model." *Journal of the Royal Society Interface* 18 (174): 20200898. https://doi.org/10.1098/rsif.2020.0898

[^2]: Dixon, et al. 2023. "Occupational Models from 42 Million Unstructured Job Postings." *Patterns* 4 (7): 100757. https://doi.org/10.1016/j.patter.2023.100757