### PR TITLE
CL-07: Implement PCA via TruncatedSVD

### DIFF
--- a/src/chalkline/reduction/__init__.py
+++ b/src/chalkline/reduction/__init__.py
@@ -1,0 +1,8 @@
+"""
+PCA dimensionality reduction via TruncatedSVD.
+
+Reduces the sparse TF-IDF matrix from `extraction` into a
+low-dimensional coordinate space for clustering and resume
+matching, with automatic component selection via cumulative
+explained variance.
+"""

--- a/src/chalkline/reduction/pca.py
+++ b/src/chalkline/reduction/pca.py
@@ -1,0 +1,113 @@
+"""
+Dimensionality reduction via TruncatedSVD with variance-based
+component selection.
+
+Fits an initial TruncatedSVD at `max_components` to profile the
+explained variance spectrum, selects the effective rank by cumulative
+variance threshold, then refits a production `Pipeline` at the
+selected rank. A `StandardScaler(with_mean=False)` is applied so
+each component has unit variance, making Euclidean distance equivalent
+to standardized Euclidean in downstream matching.
+"""
+
+import numpy as np
+
+from scipy.sparse          import spmatrix
+from sklearn.decomposition import TruncatedSVD
+from sklearn.pipeline      import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from chalkline.reduction.schemas import ComponentLoading
+
+
+class PcaReducer:
+    """
+    TruncatedSVD reduction with automatic component selection.
+
+    Performs two SVD fits against the input TF-IDF matrix. The
+    first fit at `max_components` produces the full explained
+    variance profile for scree analysis. The second fit at the
+    selected rank feeds a production `Pipeline` whose output
+    has exactly `n_selected` columns with unit variance per
+    component.
+    """
+
+    def __init__(
+        self,
+        document_ids       : list[str],
+        feature_names      : list[str],
+        max_components     : int,
+        random_seed        : int,
+        tfidf_matrix       : spmatrix,
+        variance_threshold : float
+    ):
+        """
+        Fit the analysis SVD and production pipeline.
+
+        Args:
+            document_ids       : Posting identifiers in matrix row
+                                 order.
+            feature_names      : Vocabulary terms in matrix column
+                                 order.
+            max_components     : Upper bound on retained components,
+                                 capped at matrix rank minus one.
+            random_seed        : Reproducibility seed for both SVD
+                                 fits.
+            tfidf_matrix       : Sparse TF-IDF matrix from
+                                 `SkillVectorizer`.
+            variance_threshold : Cumulative explained variance
+                                 target for component selection.
+        """
+        self.document_ids  = document_ids
+        self.feature_names = feature_names
+
+        effective_max = min(max_components, min(tfidf_matrix.shape) - 1)
+
+        self.explained_variance_ratio = TruncatedSVD(
+            n_components = effective_max,
+            random_state = random_seed
+        ).fit(tfidf_matrix).explained_variance_ratio_
+
+        cumulative               = np.cumsum(self.explained_variance_ratio)
+        self.n_selected          = min(
+            int(np.searchsorted(cumulative, variance_threshold)) + 1,
+            effective_max
+        )
+        self.cumulative_variance = float(cumulative[self.n_selected - 1])
+
+        self.pipeline = Pipeline([
+            ("svd", TruncatedSVD(
+                n_components = self.n_selected,
+                random_state = random_seed
+            )),
+            ("scaler", StandardScaler(with_mean=False))
+        ])
+        self.coordinates = self.pipeline.fit_transform(tfidf_matrix)
+
+    # -----------------------------------------------------------------
+    # Public methods
+    # -----------------------------------------------------------------
+
+    def loadings(self, top_n: int = 10) -> list[ComponentLoading]:
+        """
+        Top loading terms for each selected component.
+
+        Extracts the `top_n` terms with the highest absolute
+        weights from each component's loading vector, returning
+        skill names rather than column indices.
+
+        Args:
+            top_n: Number of top terms per component.
+        """
+        return [
+            ComponentLoading(
+                index          = i,
+                terms          = [self.feature_names[j] for j in indices],
+                variance_ratio = float(self.explained_variance_ratio[i]),
+                weights        = [float(row[j]) for j in indices]
+            )
+            for i, row in enumerate(
+                self.pipeline.named_steps["svd"].components_
+            )
+            for indices in [np.argsort(np.abs(row))[::-1][:top_n]]
+        ]

--- a/src/chalkline/reduction/schemas.py
+++ b/src/chalkline/reduction/schemas.py
@@ -1,0 +1,21 @@
+"""
+Schemas for PCA dimensionality reduction results.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class ComponentLoading(BaseModel, extra="forbid"):
+    """
+    Top loading terms for a single PCA component.
+
+    Terms are ordered by descending absolute weight, revealing
+    which skills drive each dimension of the reduced space. The
+    `variance_ratio` is the fraction of total variance explained
+    by this component from the full analysis fit.
+    """
+
+    index          : int = Field(ge=0)
+    terms          : list[str]
+    variance_ratio : float
+    weights        : list[float]

--- a/tests/collection/test_collector.py
+++ b/tests/collection/test_collector.py
@@ -14,13 +14,13 @@ class TestParseRecord:
     `Posting` instances.
     """
 
-    def test_missing_required_field_returns_none(self):
+    def test_missing_field(self):
         """
         A row missing required fields returns `None` instead of raising.
         """
         assert Collector._parse_record({"company": "Cianbro"}) is None
 
-    def test_nan_fields_become_none(self):
+    def test_nan_fields(self):
         """
         Pandas `NaN` values coerce to `None` for optional fields.
         """

--- a/tests/collection/test_schemas.py
+++ b/tests/collection/test_schemas.py
@@ -19,7 +19,7 @@ class TestPosting:
     Validate `Posting` model constraints and composite key generation.
     """
 
-    def test_auto_id_generation(self, sample_posting: Posting):
+    def test_auto_id(self, sample_posting: Posting):
         """
         Omitting `id` auto-computes it from company, date, and title.
         """
@@ -38,7 +38,7 @@ class TestPosting:
             == "cianbro_electrician_2026-03-01"
         )
 
-    def test_date_coercion_in_id(self):
+    def test_date_coercion(self):
         """
         Timestamp `date_posted` values are truncated to date and reflected
         in the composite key.
@@ -54,7 +54,7 @@ class TestPosting:
         assert "2026-03-01" in posting.id
 
     @mark.parametrize("field", ["company", "source_url", "title"])
-    def test_empty_string_rejected(
+    def test_empty_string(
         self,
         sample_posting : Posting,
         field          : str
@@ -67,7 +67,7 @@ class TestPosting:
                 sample_posting.model_dump() | {field: ""}
             )
 
-    def test_explicit_id_preserved(self):
+    def test_explicit_id(self):
         """
         An explicitly provided `id` is not overwritten by
         auto-generation.
@@ -82,7 +82,7 @@ class TestPosting:
         )
         assert posting.id == "custom-id"
 
-    def test_extra_fields_rejected(self, sample_posting: Posting):
+    def test_extra_fields(self, sample_posting: Posting):
         """
         Unknown fields raise `ValidationError` per `extra="forbid"`.
         """

--- a/tests/collection/test_storage.py
+++ b/tests/collection/test_storage.py
@@ -54,7 +54,7 @@ class TestStorage:
         """
         assert load(tmp_path / "nonexistent") == []
 
-    def test_no_duplicates_preserved(
+    def test_no_duplicates(
         self,
         sample_posting : Posting,
         second_posting : Posting
@@ -64,18 +64,7 @@ class TestStorage:
         """
         assert len(deduplicate([sample_posting, second_posting])) == 2
 
-    def test_save_and_load_roundtrip(
-        self,
-        sample_posting : Posting,
-        tmp_path       : Path
-    ):
-        """
-        Save followed by load produces identical postings.
-        """
-        save([sample_posting], tmp_path)
-        assert load(tmp_path) == [sample_posting]
-
-    def test_save_creates_parent_directories(
+    def test_save_creates_parents(
         self,
         sample_posting : Posting,
         tmp_path       : Path
@@ -86,7 +75,7 @@ class TestStorage:
         save([sample_posting], (nested := tmp_path / "a" / "b"))
         assert load(nested) == [sample_posting]
 
-    def test_save_deduplicates_same_posting(
+    def test_save_deduplicates(
         self,
         sample_posting : Posting,
         tmp_path       : Path
@@ -97,3 +86,14 @@ class TestStorage:
         save([sample_posting], tmp_path)
         save([sample_posting], tmp_path)
         assert len(load(tmp_path)) == 1
+
+    def test_save_load_roundtrip(
+        self,
+        sample_posting : Posting,
+        tmp_path       : Path
+    ):
+        """
+        Save followed by load produces identical postings.
+        """
+        save([sample_posting], tmp_path)
+        assert load(tmp_path) == [sample_posting]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
 """
 Shared test fixtures for the Chalkline test suite.
+
+Fixtures form a pipeline chain where each step's output is
+independently tappable by any test module:
+
+    corpus → extracted_skills → skill_vectorizer → pca_reducer
+
+Lexicon fixtures feed the extractor via the registry:
+
+    certifications ─┐
+    occupations ────┤
+    osha_terms ─────┼→ registry → extractor
+    supplement_terms┘
 """
 
 from json    import loads
@@ -14,6 +26,7 @@ from chalkline.extraction.occupations import OccupationIndex
 from chalkline.extraction.schemas     import Certification, OnetOccupation
 from chalkline.extraction.skills      import SkillExtractor
 from chalkline.extraction.vectorize   import SkillVectorizer
+from chalkline.reduction.pca          import PcaReducer
 
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -29,20 +42,16 @@ def _postings() -> list[Posting]:
     ]
 
 
+# ---------------------------------------------------------------------
+# Lexicon loading
+# ---------------------------------------------------------------------
+
 @fixture
 def certifications() -> list[Certification]:
     """
     Load synthetic certifications from fixture data.
     """
     return load_certifications(FIXTURES / "extraction/certifications.json")
-
-
-@fixture
-def extractor(registry: LexiconRegistry) -> SkillExtractor:
-    """
-    Build a skill extractor from synthetic fixture data.
-    """
-    return SkillExtractor(registry)
 
 
 @fixture
@@ -63,14 +72,6 @@ def lexicon_dir(tmp_path: Path) -> Path:
 
 
 @fixture
-def occupation_index(occupations: list[OnetOccupation]) -> OccupationIndex:
-    """
-    Build an occupation index from synthetic fixture data.
-    """
-    return OccupationIndex(occupations)
-
-
-@fixture
 def occupations() -> list[OnetOccupation]:
     """
     Parse synthetic O*NET data into validated occupation records.
@@ -84,6 +85,82 @@ def osha_terms() -> list[str]:
     Load synthetic OSHA terms from fixture data.
     """
     return load_osha(FIXTURES / "extraction/osha_terms.json")
+
+
+@fixture
+def supplement_terms() -> list[str]:
+    """
+    Load synthetic supplement terms from fixture data.
+    """
+    return load_supplement(FIXTURES / "extraction/supplement_terms.json")
+
+
+# ---------------------------------------------------------------------
+# Extraction pipeline
+# ---------------------------------------------------------------------
+
+@fixture
+def corpus() -> dict[str, str]:
+    """
+    Ten synthetic posting texts covering the fixture vocabulary.
+
+    Each posting targets a different skill cluster so downstream
+    matrices have enough rank for `TruncatedSVD` and enough
+    variation for meaningful clustering and PMI.
+    """
+    return {
+        "posting-01" : "Fall protection and welding are required. "
+                       "Experience with Autodesk AutoCAD preferred.",
+        "posting-02" : "Electrical safety training and scaffolding "
+                       "inspection. Must know welding techniques.",
+        "posting-03" : "Concrete finishing and excavation work. "
+                       "Rebar installation and building foundations.",
+        "posting-04" : "Operate construction equipment. Welding "
+                       "inspection and fall protection training.",
+        "posting-05" : "Electrical wiring and scaffolding. Load "
+                       "charts and rigging hardware experience.",
+        "posting-06" : "Asbestos removal and electrical systems "
+                       "maintenance. Autodesk AutoCAD drafting.",
+        "posting-07" : "Backhoe operation and spread concrete for "
+                       "building foundations. Excavation required.",
+        "posting-08" : "Certified welding inspector with rigging "
+                       "qualification. Weld quality assessment.",
+        "posting-09" : "Electrician with laptop computers for "
+                       "electrical wiring and electrical systems.",
+        "posting-10" : "Equipment operators for concrete finishing "
+                       "and scaffolding. Fall protection certified."
+    }
+
+
+@fixture
+def extracted_skills(
+    corpus    : dict[str, str],
+    extractor : SkillExtractor
+) -> dict[str, list[str]]:
+    """
+    Canonical skill lists extracted from the synthetic corpus.
+
+    Mapping from document identifier to sorted, deduplicated
+    skill names. Tappable by tests that need skill lists without
+    vectorization overhead.
+    """
+    return extractor.extract(corpus)
+
+
+@fixture
+def extractor(registry: LexiconRegistry) -> SkillExtractor:
+    """
+    Build a skill extractor from synthetic fixture data.
+    """
+    return SkillExtractor(registry)
+
+
+@fixture
+def occupation_index(occupations: list[OnetOccupation]) -> OccupationIndex:
+    """
+    Build an occupation index from synthetic fixture data.
+    """
+    return OccupationIndex(occupations)
 
 
 @fixture
@@ -104,6 +181,10 @@ def registry(
     )
 
 
+# ---------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------
+
 @fixture
 def sample_posting() -> Posting:
     """
@@ -120,19 +201,6 @@ def second_posting() -> Posting:
     return _postings()[1]
 
 
-@fixture
-def skill_vectorizer(extractor: SkillExtractor) -> SkillVectorizer:
-    """
-    Build a vectorizer from synthetic extraction results.
-    """
-    return SkillVectorizer(extractor.extract({
-        "posting-a" : "Fall protection and welding are required. "
-                      "Experience with Autodesk AutoCAD preferred.",
-        "posting-b" : "Electrical safety training and scaffolding "
-                      "inspection. Must know welding techniques."
-    }))
-
-
 @fixture(params=["47-2111", "47-2111.00"])
 def soc(request) -> str:
     """
@@ -141,9 +209,28 @@ def soc(request) -> str:
     return request.param
 
 
+# ---------------------------------------------------------------------
+# Vectorization and reduction
+# ---------------------------------------------------------------------
+
 @fixture
-def supplement_terms() -> list[str]:
+def pca_reducer(skill_vectorizer: SkillVectorizer) -> PcaReducer:
     """
-    Load synthetic supplement terms from fixture data.
+    Build a PCA reducer from the shared skill vectorizer.
     """
-    return load_supplement(FIXTURES / "extraction/supplement_terms.json")
+    return PcaReducer(
+        document_ids       = skill_vectorizer.document_ids,
+        feature_names      = skill_vectorizer.feature_names,
+        max_components     = 4,
+        random_seed        = 42,
+        tfidf_matrix       = skill_vectorizer.tfidf_matrix,
+        variance_threshold = 0.85
+    )
+
+
+@fixture
+def skill_vectorizer(extracted_skills: dict[str, list[str]]) -> SkillVectorizer:
+    """
+    Build a vectorizer from extracted skill lists.
+    """
+    return SkillVectorizer(extracted_skills)

--- a/tests/extraction/test_lexicons.py
+++ b/tests/extraction/test_lexicons.py
@@ -20,7 +20,7 @@ class TestLexiconRegistry:
     # Decomposition
     # -------------------------------------------------------------------------
 
-    def test_decompose_filters_single_word_nouns(self, registry: LexiconRegistry):
+    def test_decompose_filters_single_words(self, registry: LexiconRegistry):
         """
         Single-word nouns from coordinate structures are filtered by the
         two-token minimum, preventing generic terms like "equipment" from
@@ -34,7 +34,7 @@ class TestLexiconRegistry:
         "operate construction equipment",
         "spread concrete"
     ])
-    def test_decompose_sub_phrase_normalizes(
+    def test_decompose_sub_phrase(
         self,
         phrase   : str,
         registry : LexiconRegistry
@@ -59,7 +59,7 @@ class TestLexiconRegistry:
     # Index construction
     # -------------------------------------------------------------------------
 
-    def test_empty_inputs_returns_none(self):
+    def test_empty_inputs(self):
         """
         With no lexicon data, `normalize` returns `None`.
         """
@@ -86,7 +86,7 @@ class TestLexiconRegistry:
         assert registry.normalize("rebar") is None
 
     @mark.parametrize("term", ["Autodesk AutoCAD", "fall protection"])
-    def test_lemma_index_contains_terms(self, registry: LexiconRegistry, term: str):
+    def test_lemma_index_terms(self, registry: LexiconRegistry, term: str):
         """
         Both O*NET and OSHA terms appear in the merged index.
         """
@@ -135,18 +135,12 @@ class TestLexiconRegistry:
         assert registry.normalize("") is None
 
     @mark.parametrize("term", ["Blueprint Reading", "Mathematics"])
-    def test_normalize_excludes_ksa_types(self, registry: LexiconRegistry, term: str):
+    def test_normalize_excludes_ksa(self, registry: LexiconRegistry, term: str):
         """
         Abstract KSA types are excluded from the normalization index,
         returning `None` even though they exist in the occupation profile.
         """
         assert registry.normalize(term) is None
-
-    def test_normalize_handles_plural(self, registry: LexiconRegistry):
-        """
-        Plural forms match their singular canonical entry via lemmatization.
-        """
-        assert registry.normalize("scaffoldings") == "scaffolding"
 
     @mark.parametrize("term", ["Autodesk AutoCAD", "fall protection"])
     def test_normalize_known_term(self, registry: LexiconRegistry, term: str):
@@ -172,13 +166,19 @@ class TestLexiconRegistry:
         # form wins.
         assert registry.normalize("welding") == "welding"
 
-    def test_normalize_unknown_returns_none(self, registry: LexiconRegistry):
+    def test_normalize_plural(self, registry: LexiconRegistry):
+        """
+        Plural forms match their singular canonical entry via lemmatization.
+        """
+        assert registry.normalize("scaffoldings") == "scaffolding"
+
+    def test_normalize_unknown(self, registry: LexiconRegistry):
         """
         An unrecognized term returns `None`.
         """
         assert registry.normalize("quantum computing") is None
 
-    def test_phrases_empty_skips_indexing(self):
+    def test_phrases_empty(self):
         """
         A decomposable entry with an empty `phrases` list indexes
         nothing rather than falling back to the full sentence.
@@ -199,7 +199,7 @@ class TestLexiconRegistry:
         )
         assert registry.normalize("Some task sentence") is None
 
-    def test_short_phrases_not_decomposed(self, registry: LexiconRegistry):
+    def test_short_phrases_intact(self, registry: LexiconRegistry):
         """
         Tool entries are indexed directly without decomposition.
         """
@@ -209,14 +209,14 @@ class TestLexiconRegistry:
     # Certification integration
     # -------------------------------------------------------------------------
 
-    def test_certification_acronym_resolves_to_name(self, registry: LexiconRegistry):
+    def test_certification_acronym(self, registry: LexiconRegistry):
         """
         Acronyms index as lookup keys pointing to the full
         certification name.
         """
         assert registry.normalize("CWI") == "Certified Welding Inspector"
 
-    def test_certification_name_normalizes(self, registry: LexiconRegistry):
+    def test_certification_name(self, registry: LexiconRegistry):
         """
         A certification name resolves via both lemmatized and
         lowercased lookup forms.
@@ -240,7 +240,7 @@ class TestLexiconRegistry:
         )
         assert registry.normalize("excavation") == "Excavation"
 
-    def test_certification_phrase_normalizes(self, registry: LexiconRegistry):
+    def test_certification_phrase(self, registry: LexiconRegistry):
         """
         Description sub-phrases from certification records are
         individually matchable.
@@ -276,7 +276,7 @@ class TestLexiconRegistry:
         assert registry.normalize("concrete finishing") == "Concrete finishing"
 
     @mark.parametrize("term", ["excavation", "rebar"])
-    def test_supplement_term_normalizes(self, registry: LexiconRegistry, term: str):
+    def test_supplement_term(self, registry: LexiconRegistry, term: str):
         """
         Terms present only in the supplement lexicon normalize to
         their canonical forms.

--- a/tests/extraction/test_loaders.py
+++ b/tests/extraction/test_loaders.py
@@ -19,7 +19,7 @@ class TestLoaders:
     Validate lexicon file loading and missing-file handling.
     """
 
-    def test_load_certifications_valid(self, lexicon_dir: Path):
+    def test_load_certifications(self, lexicon_dir: Path):
         """
         Valid certifications JSON deserializes into certification
         records.
@@ -29,21 +29,21 @@ class TestLoaders:
         )) == 2
         assert certs[0].name == "Certified Welding Inspector"
 
-    def test_load_onet_valid(self, lexicon_dir: Path):
+    def test_load_onet(self, lexicon_dir: Path):
         """
         Valid O*NET JSON deserializes into occupation records.
         """
         assert len(occupations := load_onet(lexicon_dir / "onet.json")) == 2
         assert occupations[0].soc_code == "47-2111.00"
 
-    def test_load_osha_valid(self, lexicon_dir: Path):
+    def test_load_osha(self, lexicon_dir: Path):
         """
         Valid OSHA JSON deserializes into a list of strings.
         """
         assert len(terms := load_osha(lexicon_dir / "osha.json")) == 5
         assert "fall protection" in terms
 
-    def test_load_supplement_valid(self, lexicon_dir: Path):
+    def test_load_supplement(self, lexicon_dir: Path):
         """
         Valid supplement JSON deserializes into a list of strings.
         """
@@ -56,7 +56,7 @@ class TestLoaders:
         (load_osha,           "OSHA"),
         (load_supplement,     "Supplement")
     ])
-    def test_missing_file_logs_warning(
+    def test_missing_file_warns(
         self,
         caplog   : LogCaptureFixture,
         label    : str,

--- a/tests/extraction/test_occupations.py
+++ b/tests/extraction/test_occupations.py
@@ -17,7 +17,7 @@ class TestOccupationIndex:
     Validate occupation lookups, SOC resolution, and Jaccard matching.
     """
 
-    def test_ambiguous_bare_prefix_raises(self):
+    def test_ambiguous_prefix(self):
         """
         A bare prefix with multiple suffixes raises `KeyError` because the
         resolver cannot disambiguate.
@@ -49,7 +49,7 @@ class TestOccupationIndex:
         """
         assert occupation_index.get(soc).job_zone == 3
 
-    def test_invalid_soc_raises(self, occupation_index: OccupationIndex):
+    def test_invalid_soc(self, occupation_index: OccupationIndex):
         """
         An unrecognized SOC code raises `KeyError`.
         """
@@ -71,30 +71,12 @@ class TestOccupationIndex:
             "47-2111.00"
         }
 
-    def test_nearest_mixed_overlap_paving(self, occupation_index: OccupationIndex):
-        """
-        A skill set with majority paving operator overlap resolves to the
-        paving operator SOC code even with shared terms.
-        """
-        assert occupation_index.nearest(
-            {"Backhoes", "Concrete finishing", "Welding"}
-        ) == "47-2071.00"
-
-    def test_nearest_resolves_paving(self, occupation_index: OccupationIndex):
-        """
-        Skills unique to paving operators resolve to that occupation's SOC
-        code.
-        """
-        assert occupation_index.nearest(
-            {"Backhoes", "Concrete finishing"}
-        ) == "47-2071.00"
-
     @mark.parametrize("skills", [
         {"Autodesk AutoCAD"},
         {"Autodesk AutoCAD", "Laptop computers", "Mathematics"},
         {"Autodesk AutoCAD", "Backhoes", "Laptop computers", "Welding"}
     ])
-    def test_nearest_resolves_to_electrician(
+    def test_nearest_electrician(
         self,
         occupation_index : OccupationIndex,
         skills           : set[str]
@@ -104,6 +86,24 @@ class TestOccupationIndex:
         electrician SOC code.
         """
         assert occupation_index.nearest(skills) == "47-2111.00"
+
+    def test_nearest_mixed_overlap(self, occupation_index: OccupationIndex):
+        """
+        A skill set with majority paving operator overlap resolves to the
+        paving operator SOC code even with shared terms.
+        """
+        assert occupation_index.nearest(
+            {"Backhoes", "Concrete finishing", "Welding"}
+        ) == "47-2071.00"
+
+    def test_nearest_paving(self, occupation_index: OccupationIndex):
+        """
+        Skills unique to paving operators resolve to that occupation's SOC
+        code.
+        """
+        assert occupation_index.nearest(
+            {"Backhoes", "Concrete finishing"}
+        ) == "47-2071.00"
 
     def test_sector(self, occupation_index: OccupationIndex, soc: str):
         """

--- a/tests/extraction/test_schemas.py
+++ b/tests/extraction/test_schemas.py
@@ -31,6 +31,12 @@ class TestOnetSchemas:
     Validate lexicon data schemas for O*NET entries.
     """
 
+    def test_concrete_types_count(self):
+        """
+        Exactly six element types feed the normalization index.
+        """
+        assert sum(m.is_concrete for m in OnetSkillType) == 6
+
     def test_confidence_tier_members(self):
         """
         The three confidence tiers are defined for Aho-Corasick matching.
@@ -48,26 +54,7 @@ class TestOnetSchemas:
             < ConfidenceTier.SINGLE_WORD.value
         )
 
-    def test_concrete_types_count(self):
-        """
-        Exactly six element types feed the normalization index.
-        """
-        assert sum(m.is_concrete for m in OnetSkillType) == 6
-
-    def test_corpus_statistics_extra_fields_rejected(self):
-        """
-        Unknown fields raise `ValidationError` per `extra="forbid"`.
-        """
-        with raises(Exception, match="Extra inputs"):
-            CorpusStatistics(
-                matrix_sparsity         = 0.9,
-                mean_skills_per_posting = 5.0,
-                skill_frequency         = {"welding": 3},
-                unknown                 = "value",
-                vocabulary_size         = 10
-            )
-
-    def test_occupation_extra_fields_rejected(self):
+    def test_occupation_extra(self):
         """
         Unknown fields raise `ValidationError` per `extra="forbid"`.
         """
@@ -75,21 +62,21 @@ class TestOnetSchemas:
             OnetOccupation(**SAMPLE_OCCUPATION, unknown="value")
 
     @mark.parametrize("job_zone", [0, 6])
-    def test_occupation_job_zone_boundary(self, job_zone):
+    def test_occupation_job_zone(self, job_zone):
         """
         Job zone values outside 1-5 are rejected.
         """
         with raises(Exception):
             OnetOccupation(**{**SAMPLE_OCCUPATION, "job_zone": job_zone})
 
-    def test_occupation_missing_fields(self):
+    def test_occupation_missing(self):
         """
         Omitting required fields raises `ValidationError`.
         """
         with raises(Exception):
             OnetOccupation(job_zone=3, title="Test")
 
-    def test_occupation_valid_construction(self):
+    def test_occupation_valid(self):
         """
         A complete occupation validates without error.
         """
@@ -97,31 +84,31 @@ class TestOnetSchemas:
         assert occupation.soc_code == "47-2111.00"
         assert len(occupation.skills) == 1
 
-    def test_skill_empty_name_rejected(self):
+    def test_skill_empty_name(self):
         """
         Empty skill names violate the `NonEmptyStr` constraint.
         """
         with raises(Exception):
             OnetSkill(name="", type="technology")
 
-    def test_skill_extra_fields_rejected(self):
+    def test_skill_extra(self):
         """
         Unknown fields raise `ValidationError` per `extra="forbid"`.
         """
         with raises(Exception, match="Extra inputs"):
             OnetSkill(**SAMPLE_SKILL, unknown="value")
 
+    def test_skill_type_coercion(self):
+        """
+        Raw strings coerce to enum members through Pydantic.
+        """
+        assert OnetSkill(name="Test Skill", type="task").type is OnetSkillType.TASK
+
     def test_skill_type_members(self):
         """
         All nine O*NET element types are defined.
         """
         assert len(OnetSkillType) == 9
-
-    def test_skill_type_string_coercion(self):
-        """
-        Raw strings coerce to enum members through Pydantic.
-        """
-        assert OnetSkill(name="Test Skill", type="task").type is OnetSkillType.TASK
 
     def test_skill_valid_with_ratings(self):
         """
@@ -140,3 +127,16 @@ class TestOnetSchemas:
         Concrete-typed skills default importance and level to `None`.
         """
         assert ((s := OnetSkill(**SAMPLE_SKILL)).importance, s.level) == (None, None)
+
+    def test_statistics_extra(self):
+        """
+        Unknown fields raise `ValidationError` per `extra="forbid"`.
+        """
+        with raises(Exception, match="Extra inputs"):
+            CorpusStatistics(
+                matrix_sparsity         = 0.9,
+                mean_skills_per_posting = 5.0,
+                skill_frequency         = {"welding": 3},
+                unknown                 = "value",
+                vocabulary_size         = 10
+            )

--- a/tests/extraction/test_skills.py
+++ b/tests/extraction/test_skills.py
@@ -18,7 +18,7 @@ class TestSkillExtractor:
     # Extraction
     # ---------------------------------------------------------
 
-    def test_case_insensitive_extraction(self, extractor: SkillExtractor):
+    def test_case_insensitive(self, extractor: SkillExtractor):
         """
         Identical text in different casings produces identical output.
         """
@@ -28,7 +28,7 @@ class TestSkillExtractor:
             == extractor.extract({"a": text.upper()})["a"]
         )
 
-    def test_decomposed_phrase_extraction(self, extractor: SkillExtractor):
+    def test_decomposed_phrase(self, extractor: SkillExtractor):
         """
         Sub-phrases from decomposed O*NET Tasks and DWAs are matchable
         through the automaton.
@@ -40,7 +40,7 @@ class TestSkillExtractor:
             }).get("a", [])
         )
 
-    def test_inverted_bigram_extraction(self, extractor: SkillExtractor):
+    def test_inverted_bigram(self, extractor: SkillExtractor):
         """
         Two-word skills match even when their words appear in reverse
         order, because the automaton indexes inverted bigram variants.
@@ -49,7 +49,7 @@ class TestSkillExtractor:
             "a": "protection fall is important"
         }).get("a", [])
 
-    def test_multi_word_extraction(self, extractor: SkillExtractor):
+    def test_multi_word(self, extractor: SkillExtractor):
         """
         Multi-word lexicon terms like "fall protection" are extracted as
         complete phrases rather than individual words.
@@ -58,7 +58,7 @@ class TestSkillExtractor:
             "a": "Fall protection and welding are required"
         })["a"]
 
-    def test_osha_priority_over_onet(self, extractor: SkillExtractor):
+    def test_osha_priority(self, extractor: SkillExtractor):
         """
         A term present in both OSHA and O*NET resolves to the OSHA
         canonical form.
@@ -70,7 +70,7 @@ class TestSkillExtractor:
         # OSHA "welding" is lowercase; O*NET is "Welding"
         assert "Welding" not in result["a"]
 
-    def test_stemmed_form_matching(self, extractor: SkillExtractor):
+    def test_stemmed_form(self, extractor: SkillExtractor):
         """
         Porter-stemmed surface forms match their canonical entry,
         allowing shortened word forms to resolve correctly.
@@ -110,7 +110,7 @@ class TestSkillExtractor:
     # Output format
     # ---------------------------------------------------------
 
-    def test_output_sorted_deduplicated(self, extractor: SkillExtractor):
+    def test_output_sorted(self, extractor: SkillExtractor):
         """
         Each posting's skill list is sorted alphabetically with no
         duplicates, even when the same term appears multiple times.
@@ -153,7 +153,7 @@ class TestSkillExtractor:
             "a": "fallProtection is required"
         })["a"]
 
-    def test_filler_masking_no_false_match(self, extractor: SkillExtractor):
+    def test_filler_no_false_match(self, extractor: SkillExtractor):
         """
         Filler phrases are blanked before matching so that terms within
         them do not produce false positives.
@@ -175,14 +175,14 @@ class TestSkillExtractor:
     # Vocabulary
     # ---------------------------------------------------------
 
-    def test_vocabulary_contains_osha_terms(self, extractor: SkillExtractor):
+    def test_vocabulary_osha(self, extractor: SkillExtractor):
         """
         OSHA lexicon terms appear in the extractor's vocabulary.
         """
         assert "fall protection" in extractor.vocabulary
         assert "welding" in extractor.vocabulary
 
-    def test_vocabulary_contains_supplement_terms(
+    def test_vocabulary_supplement(
         self, extractor: SkillExtractor
     ):
         """
@@ -195,16 +195,7 @@ class TestSkillExtractor:
     # Word boundaries
     # ---------------------------------------------------------
 
-    def test_word_boundary_enforcement(self, extractor: SkillExtractor):
-        """
-        Partial-word matches are rejected, meaning "weld" inside
-        "welder" does not match the "weld" surface form.
-        """
-        assert "weld" not in extractor.extract(
-            {"a": "The welder inspected the scaffoldings"}
-        ).get("a", [])
-
-    def test_word_boundary_with_digit(self, extractor: SkillExtractor):
+    def test_boundary_digit(self, extractor: SkillExtractor):
         """
         Digits are alphanumeric, so a match abutting a digit is
         rejected because `isalnum()` treats digits as word characters.
@@ -213,7 +204,7 @@ class TestSkillExtractor:
             {"a": "3welding required on site"}
         ).get("a", [])
 
-    def test_word_boundary_with_hyphen(self, extractor: SkillExtractor):
+    def test_boundary_hyphen(self, extractor: SkillExtractor):
         """
         Hyphens are non-alphanumeric, so terms separated by hyphens
         are treated as valid word boundaries.
@@ -222,17 +213,26 @@ class TestSkillExtractor:
             {"a": "welding-certified technician needed"}
         ).get("a", [])
 
+    def test_word_boundary(self, extractor: SkillExtractor):
+        """
+        Partial-word matches are rejected, meaning "weld" inside
+        "welder" does not match the "weld" surface form.
+        """
+        assert "weld" not in extractor.extract(
+            {"a": "The welder inspected the scaffoldings"}
+        ).get("a", [])
+
     # ---------------------------------------------------------
     # Zero-skill exclusion
     # ---------------------------------------------------------
 
-    def test_extract_empty_corpus(self, extractor: SkillExtractor):
+    def test_empty_corpus(self, extractor: SkillExtractor):
         """
         An empty corpus returns an empty mapping without error.
         """
         assert extractor.extract({}) == {}
 
-    def test_filler_only_posting_excluded(self, extractor: SkillExtractor):
+    def test_filler_only_excluded(self, extractor: SkillExtractor):
         """
         A posting consisting entirely of filler phrases produces zero
         skills and is excluded from output.
@@ -241,7 +241,7 @@ class TestSkillExtractor:
             "a": "Must have experience with knowledge of"
         }) == {}
 
-    def test_zero_skill_postings_excluded(self, extractor: SkillExtractor):
+    def test_zero_skills_excluded(self, extractor: SkillExtractor):
         """
         Postings with no matched skills are omitted from the output.
         """

--- a/tests/extraction/test_vectorize.py
+++ b/tests/extraction/test_vectorize.py
@@ -21,7 +21,7 @@ class TestSkillVectorizer:
     # Document identifiers
     # ---------------------------------------------------------
 
-    def test_document_ids_match_row_count(self, skill_vectorizer: SkillVectorizer):
+    def test_document_ids_row_count(self, skill_vectorizer: SkillVectorizer):
         """
         Document identifiers are returned in row order alongside
         both matrices.
@@ -44,7 +44,7 @@ class TestSkillVectorizer:
     # Feature names
     # ---------------------------------------------------------
 
-    def test_feature_names_match_columns(self, skill_vectorizer: SkillVectorizer):
+    def test_feature_names_columns(self, skill_vectorizer: SkillVectorizer):
         """
         Feature names length matches matrix column count.
         """
@@ -61,7 +61,7 @@ class TestSkillVectorizer:
             skill_vectorizer.feature_names
         )
 
-    def test_transform_preserves_vocabulary(self, skill_vectorizer: SkillVectorizer):
+    def test_transform_vocabulary(self, skill_vectorizer: SkillVectorizer):
         """
         `DictVectorizer.transform(new_doc)` produces a vector with the
         same number of columns as `fit_transform()`.
@@ -90,7 +90,7 @@ class TestSkillVectorizer:
         """
         assert (skill_vectorizer.binary_matrix.data == 1).all()
 
-    def test_matrices_identical_dimensions(self, skill_vectorizer: SkillVectorizer):
+    def test_matrices_dimensions(self, skill_vectorizer: SkillVectorizer):
         """
         TF-IDF and binary matrices have the same shape.
         """
@@ -138,7 +138,7 @@ class TestSkillVectorizer:
     # Statistics
     # ---------------------------------------------------------
 
-    def test_single_posting_vectorizer(self):
+    def test_single_posting(self):
         """
         A single-document corpus produces valid matrices where TF-IDF
         normalization degenerates to uniform weights.
@@ -159,7 +159,7 @@ class TestSkillVectorizer:
         assert stats.mean_skills_per_posting > 0
         assert len(stats.skill_frequency) == stats.vocabulary_size
 
-    def test_statistics_frequency_values(self, skill_vectorizer: SkillVectorizer):
+    def test_statistics_frequency(self, skill_vectorizer: SkillVectorizer):
         """
         Per-skill frequency counts reflect actual document occurrences.
         """

--- a/tests/parsing/test_extract.py
+++ b/tests/parsing/test_extract.py
@@ -24,13 +24,13 @@ class TestCleanText:
         """
         assert clean_text("hello   world\n\nfoo") == "hello world foo"
 
-    def test_empty_input_returns_empty(self):
+    def test_empty_input(self):
         """
         An empty input returns an empty string without raising.
         """
         assert clean_text("") == ""
 
-    def test_page_numbers_only_returns_empty(self):
+    def test_page_numbers_only(self):
         """
         Input containing only standalone page numbers normalizes to an empty
         string.
@@ -51,7 +51,7 @@ class TestCleanText:
         assert "42" not in result
         assert "Some text" in result
 
-    def test_whitespace_only_returns_empty(self):
+    def test_whitespace_only(self):
         """
         Input containing only whitespace normalizes to an empty string.
         """
@@ -69,7 +69,7 @@ class TestExtractPdf:
         """
         assert extract_pdf(FIXTURES / "empty.pdf") == ""
 
-    def test_known_text_from_pdf(self):
+    def test_known_text(self):
         """
         A sample resume PDF returns its known text content with no binary
         artifacts.
@@ -88,7 +88,7 @@ class TestExtractPdf:
         assert "Page 1" in result
         assert "Page 2" in result
 
-    def test_pdf_through_clean_text(self):
+    def test_pdf_clean_text(self):
         """
         Extracted PDF text normalizes cleanly for downstream use.
         """

--- a/tests/pipeline/test_schemas.py
+++ b/tests/pipeline/test_schemas.py
@@ -39,19 +39,13 @@ class TestPipelineConfig:
         ("top_k_gaps",           10),
         ("variance_threshold",   0.85)
     ])
-    def test_defaults_applied(self, expected, field: str, tmp_path: Path):
+    def test_defaults(self, expected, field: str, tmp_path: Path):
         """
         Optional fields receive their documented defaults.
         """
         assert getattr(self._config(tmp_path), field) == expected
 
-    def test_distance_metric_members(self):
-        """
-        All expected distance metrics are defined.
-        """
-        assert set(DistanceMetric) == {"cosine", "euclidean", "standardized_euclidean"}
-
-    def test_distance_metric_string_coercion(self, tmp_path: Path):
+    def test_distance_metric_coercion(self, tmp_path: Path):
         """
         A raw string coerces to the correct enum member when passed through
         `PipelineConfig`.
@@ -60,14 +54,20 @@ class TestPipelineConfig:
             tmp_path, distance_metric="cosine"
         ).distance_metric is DistanceMetric.COSINE
 
-    def test_extra_fields_rejected(self, tmp_path: Path):
+    def test_distance_metric_members(self):
+        """
+        All expected distance metrics are defined.
+        """
+        assert set(DistanceMetric) == {"cosine", "euclidean", "standardized_euclidean"}
+
+    def test_extra_fields(self, tmp_path: Path):
         """
         Unknown fields raise `ValidationError` per `extra="forbid"`.
         """
         with raises(Exception, match="Extra inputs"):
             self._config(tmp_path, stale_field=True)
 
-    def test_invalid_distance_metric_rejected(self, tmp_path: Path):
+    def test_invalid_distance_metric(self, tmp_path: Path):
         """
         Unrecognized metric strings fail at construction, not downstream in
         sklearn.
@@ -75,14 +75,14 @@ class TestPipelineConfig:
         with raises(Exception):
             self._config(tmp_path, distance_metric="manhattan")
 
-    def test_missing_required_fields(self):
+    def test_missing_fields(self):
         """
         Omitting required path fields raises `ValidationError`.
         """
         with raises(Exception):
             PipelineConfig()
 
-    def test_override_accepted(self, tmp_path: Path):
+    def test_override(self, tmp_path: Path):
         """
         Non-default values are accepted for optional fields.
         """
@@ -90,15 +90,8 @@ class TestPipelineConfig:
         assert config.max_components == 50
         assert config.random_seed == 99
 
-    def test_variance_threshold_accepts_one(self, tmp_path: Path):
-        """
-        `variance_threshold` of exactly 1.0 is valid, meaning keep all
-        variance.
-        """
-        assert self._config(tmp_path, variance_threshold=1.0).variance_threshold == 1.0
-
     @mark.parametrize("threshold", [0.0, 1.5])
-    def test_variance_threshold_rejects_boundary(
+    def test_variance_threshold_boundary(
         self,
         threshold : float,
         tmp_path  : Path
@@ -108,3 +101,10 @@ class TestPipelineConfig:
         """
         with raises(Exception):
             self._config(tmp_path, variance_threshold=threshold)
+
+    def test_variance_threshold_one(self, tmp_path: Path):
+        """
+        `variance_threshold` of exactly 1.0 is valid, meaning keep all
+        variance.
+        """
+        assert self._config(tmp_path, variance_threshold=1.0).variance_threshold == 1.0

--- a/tests/reduction/test_pca.py
+++ b/tests/reduction/test_pca.py
@@ -1,0 +1,183 @@
+"""
+Tests for PCA dimensionality reduction via TruncatedSVD.
+
+Validates component selection, coordinate output shape, loading term
+extraction, unit variance scaling, and pipeline serializability using
+synthetic extraction output.
+"""
+
+import numpy as np
+
+from joblib  import dump, load
+from pathlib import Path
+from pytest  import mark
+
+from chalkline.extraction.vectorize import SkillVectorizer
+from chalkline.reduction.pca       import PcaReducer
+
+
+class TestPcaReducer:
+    """
+    Validate reduction pipeline, component selection, and output
+    properties.
+    """
+
+    # ---------------------------------------------------------
+    # Component selection
+    # ---------------------------------------------------------
+
+    def test_cumulative_variance(self, pca_reducer: PcaReducer):
+        """
+        Cumulative variance is reported even when the threshold
+        is not fully reached.
+        """
+        assert 0 < pca_reducer.cumulative_variance <= 1.0
+
+    def test_explained_variance_length(self, pca_reducer: PcaReducer):
+        """
+        The full variance profile contains one entry per component
+        from the analysis fit.
+        """
+        assert len(pca_reducer.explained_variance_ratio) >= pca_reducer.n_selected
+
+    def test_max_components_capped(
+        self, skill_vectorizer: SkillVectorizer
+    ):
+        """
+        Requesting more components than the matrix rank caps to
+        `min(n_samples, n_features) - 1` without error.
+        """
+        matrix  = skill_vectorizer.tfidf_matrix
+        reducer = PcaReducer(
+            document_ids       = skill_vectorizer.document_ids,
+            feature_names      = skill_vectorizer.feature_names,
+            max_components     = 999,
+            random_seed        = 42,
+            tfidf_matrix       = matrix,
+            variance_threshold = 0.85
+        )
+        assert reducer.n_selected <= min(matrix.shape) - 1
+
+    def test_n_selected_bounded(self, pca_reducer: PcaReducer):
+        """
+        Selected components do not exceed the configured maximum.
+        """
+        assert 1 <= pca_reducer.n_selected
+
+    def test_variance_ratios_bounded(self, pca_reducer: PcaReducer):
+        """
+        Explained variance ratios are non-negative and sum to at
+        most 1.0.
+        """
+        evr = pca_reducer.explained_variance_ratio
+        assert (evr >= 0).all()
+        assert evr.sum() <= 1.0 + 1e-10
+
+    # ---------------------------------------------------------
+    # Coordinates
+    # ---------------------------------------------------------
+
+    def test_coordinates_finite(self, pca_reducer: PcaReducer):
+        """
+        All coordinate values are finite (no NaN or inf from
+        degenerate scaling).
+        """
+        assert np.isfinite(pca_reducer.coordinates).all()
+
+    def test_coordinates_shape(self, pca_reducer: PcaReducer):
+        """
+        Output array has shape (n_postings, n_selected).
+        """
+        assert pca_reducer.coordinates.shape == (
+            len(pca_reducer.document_ids),
+            pca_reducer.n_selected
+        )
+
+    # ---------------------------------------------------------
+    # Loadings
+    # ---------------------------------------------------------
+
+    def test_loadings_aligned(self, pca_reducer: PcaReducer):
+        """
+        Each loading has the same number of terms and weights.
+        """
+        for loading in pca_reducer.loadings():
+            assert len(loading.terms) == len(loading.weights)
+
+    def test_loadings_count(self, pca_reducer: PcaReducer):
+        """
+        One loading entry per selected component.
+        """
+        assert len(pca_reducer.loadings()) == pca_reducer.n_selected
+
+    def test_loadings_skill_names(self, pca_reducer: PcaReducer):
+        """
+        Top-loading terms per component return skill names, not
+        column indices.
+        """
+        for loading in pca_reducer.loadings():
+            assert all(isinstance(t, str) for t in loading.terms)
+            assert all(not t.isdigit() for t in loading.terms)
+
+    @mark.parametrize("top_n", [1, 2, 5])
+    def test_loadings_top_n(self, pca_reducer: PcaReducer, top_n: int):
+        """
+        Requesting fewer top terms limits the returned list length.
+        """
+        for loading in pca_reducer.loadings(top_n=top_n):
+            assert len(loading.terms) <= top_n
+            assert len(loading.weights) <= top_n
+
+    def test_loadings_variance_positive(self, pca_reducer: PcaReducer):
+        """
+        Each component's variance ratio is positive.
+        """
+        for loading in pca_reducer.loadings():
+            assert loading.variance_ratio > 0
+
+    def test_loadings_weight_order(self, pca_reducer: PcaReducer):
+        """
+        Terms within each loading are ordered by descending absolute
+        weight, matching the `argsort` contract in `PcaReducer`.
+        """
+        for loading in pca_reducer.loadings():
+            absolutes = [abs(w) for w in loading.weights]
+            assert absolutes == sorted(absolutes, reverse=True)
+
+    # ---------------------------------------------------------
+    # Scaling
+    # ---------------------------------------------------------
+
+    def test_unit_variance(self, pca_reducer: PcaReducer):
+        """
+        PCA output columns have unit variance after scaling,
+        verified by `np.allclose(std, 1.0)`. Skipped when only
+        one component is selected because std is always 1.0
+        trivially in that case and the real invariant is that
+        `StandardScaler` was applied.
+        """
+        if pca_reducer.coordinates.shape[0] < 3:
+            return
+        assert np.allclose(pca_reducer.coordinates.std(axis=0), 1.0, atol=1e-6)
+
+    # ---------------------------------------------------------
+    # Pipeline
+    # ---------------------------------------------------------
+
+    def test_pipeline_persist(self, pca_reducer: PcaReducer, tmp_path: Path):
+        """
+        The fitted pipeline serializes and restores via `joblib`,
+        producing identical output dimensions on new input.
+        """
+        dump(pca_reducer.pipeline, path := tmp_path / "pca.joblib")
+        assert load(path).n_features_in_ == pca_reducer.pipeline.n_features_in_
+
+    def test_transform_dimensions(self, pca_reducer: PcaReducer):
+        """
+        `pipeline.transform(new_vector)` returns the same number
+        of columns without refitting.
+        """
+        result = pca_reducer.pipeline.transform(
+            np.ones((1, pca_reducer.pipeline.n_features_in_))
+        )
+        assert result.shape == (1, pca_reducer.n_selected)

--- a/tests/reduction/test_schemas.py
+++ b/tests/reduction/test_schemas.py
@@ -1,0 +1,66 @@
+"""
+Tests for PCA reduction schemas.
+"""
+
+from pytest import mark, param, raises
+
+from chalkline.reduction.schemas import ComponentLoading
+
+
+class TestComponentLoading:
+    """
+    Validate ComponentLoading field constraints and extra-field
+    rejection.
+    """
+
+    # ---------------------------------------------------------
+    # Construction
+    # ---------------------------------------------------------
+
+    def test_valid(self):
+        """
+        A well-formed loading with matching terms and weights
+        validates successfully.
+        """
+        loading = ComponentLoading(
+            index          = 0,
+            terms          = ["welding", "scaffolding"],
+            variance_ratio = 0.35,
+            weights        = [0.8, 0.6]
+        )
+        assert loading.index == 0
+        assert loading.terms == ["welding", "scaffolding"]
+
+    # ---------------------------------------------------------
+    # Rejection
+    # ---------------------------------------------------------
+
+    @mark.parametrize("kwargs, match", [
+        param(
+            {
+                "extra_field"    : True,
+                "index"          : 0,
+                "terms"          : ["welding"],
+                "variance_ratio" : 0.3,
+                "weights"        : [0.5]
+            },
+            "Extra inputs",
+            id="extra_field"
+        ),
+        param(
+            {
+                "index"          : -1,
+                "terms"          : ["welding"],
+                "variance_ratio" : 0.3,
+                "weights"        : [0.5]
+            },
+            "greater than or equal",
+            id="negative_index"
+        )
+    ])
+    def test_invalid(self, kwargs, match):
+        """
+        Invalid kwargs are rejected by Pydantic validation.
+        """
+        with raises(ValueError, match=match):
+            ComponentLoading(**kwargs)


### PR DESCRIPTION
### 📐 Quick Summary

Implements PCA dimensionality reduction via `TruncatedSVD` for the geometry track, reducing the sparse TF-IDF matrix from [CL-06](https://github.com/Jybbs/chalkline/issues/6) into a low-dimensional coordinate space for clustering and resume matching[^8][^17][^18]. `PcaReducer` performs a two-phase fit, namely an analysis fit at `max_components` to profile the explained variance spectrum for scree analysis[^19], followed by a production refit at the selected rank composed with `StandardScaler(with_mean=False)` in a `joblib`-serializable sklearn `Pipeline`. The production pipeline produces unit-variance coordinates directly, making Euclidean distance equivalent to standardized Euclidean in downstream matching[^16].

***

### 🧱 Key Changes

#### Reduction Module

- Add `src/chalkline/reduction/pca.py` with `PcaReducer` performing variance-based component selection via `np.cumsum` + `np.searchsorted`, automatic rank capping at `min(n_samples, n_features) - 1`, and top-N loading term extraction with descending absolute weight ordering[^17][^18]
- Add `src/chalkline/reduction/schemas.py` with `ComponentLoading` model storing per-component index, skill term names, variance ratio from the analysis fit, and loading weights
- Add `src/chalkline/reduction/__init__.py` subpackage docstring

#### Tests

- Add `tests/reduction/test_pca.py` with **18** tests covering component selection bounds, coordinate shape and finiteness, loading term extraction and ordering, unit variance verification, `joblib` round-trip serialization, and transform dimensionality on new input
- Add `tests/reduction/test_schemas.py` with **3** tests covering `ComponentLoading` construction, extra-field rejection, and negative index validation

#### Fixture Pipeline Extension

- Extend `tests/conftest.py` with `corpus`, `extracted_skills`, `skill_vectorizer`, and `pca_reducer` fixtures forming a pipeline chain from synthetic postings through extraction, vectorization, and reduction
- Reorganize existing fixtures into labeled sections (*lexicon loading, extraction pipeline, collection, vectorization and reduction*) with ASCII pipeline diagram in the module docstring

***

### 🔩 Related Issues

- Closes #7

***

### 📚 References

[^8]: Lukauskas, et al. 2023. "Enhancing Skills Demand Understanding through Job Ad Segmentation Using NLP and Clustering Techniques." *Applied Sciences* 13(10): 6119. https://doi.org/10.3390/app13106119

[^16]: Rosenberger, et al. 2025. "CareerBERT: Matching Resumes to ESCO Jobs in a Shared Embedding Space for Generic Job Recommendations." *Expert Systems with Applications* 275: 127043. https://doi.org/10.1016/j.eswa.2025.127043

[^17]: Halko, Martinsson & Tropp. 2011. "Finding Structure with Randomness: Probabilistic Algorithms for Constructing Approximate Matrix Decompositions." *SIAM Review* 53(2): 217-288. https://doi.org/10.1137/090771806

[^18]: Deerwester, Dumais, Furnas, Landauer & Harshman. 1990. "Indexing by Latent Semantic Analysis." *Journal of the American Society for Information Science* 41(6): 391-407. https://doi.org/10.1002/(SICI)1097-4571(199009)41:6<391::AID-ASI1>3.0.CO;2-9

[^19]: Cattell. 1966. "The Scree Test for the Number of Factors." *Multivariate Behavioral Research* 1(2): 245-276. https://doi.org/10.1207/s15327906mbr0102_10