### PR TITLE
CL-08: Implement clustering with HAC primary and comparison methods

### DIFF
--- a/src/chalkline/clustering/__init__.py
+++ b/src/chalkline/clustering/__init__.py
@@ -1,0 +1,9 @@
+"""
+Hierarchical agglomerative clustering with comparison methods.
+
+Groups PCA-reduced job postings into career families via Ward-linkage
+HAC with cophenetic validation, cluster labeling from TF-IDF centroids,
+and ARI benchmarking against the three-sector industry taxonomy.
+Comparison methods (K-Means, DBSCAN, Mean Shift, HDBSCAN) exist for
+the DS5230 deliverable and are excluded from the production pipeline.
+"""

--- a/src/chalkline/clustering/comparison.py
+++ b/src/chalkline/clustering/comparison.py
@@ -1,0 +1,260 @@
+"""
+DS5230 comparison clustering methods.
+
+Fits K-Means, DBSCAN, Mean Shift, and HDBSCAN on PCA-reduced
+coordinates with automatic parameter selection via KneeLocator.
+Each method returns a `ComparisonResult` with cluster assignments
+and optional internal validity metrics. This module is excluded
+from the production pipeline.
+"""
+
+import numpy as np
+
+from kneed             import KneeLocator
+from math              import floor
+from sklearn.cluster   import DBSCAN, estimate_bandwidth, HDBSCAN
+from sklearn.cluster   import KMeans, MeanShift
+from sklearn.metrics   import adjusted_rand_score
+from sklearn.metrics   import calinski_harabasz_score
+from sklearn.metrics   import davies_bouldin_score
+from sklearn.metrics   import silhouette_samples, silhouette_score
+from sklearn.neighbors import NearestNeighbors
+
+from chalkline.clustering.schemas import ComparisonResult
+
+
+class ClusterComparison:
+    """
+    Comparison clustering methods for DS5230 evaluation.
+
+    Stores PCA coordinates and provides methods that fit each
+    algorithm with corpus-scaled parameter selection, returning
+    structured results with validity metrics.
+    """
+
+    def __init__(
+        self,
+        coordinates   : np.ndarray,
+        random_seed   : int,
+        sector_labels : list[str] | None = None
+    ):
+        """
+        Store coordinates and derive matrix dimensions.
+
+        Args:
+            coordinates   : PCA output of shape `(n_postings, n_selected)`.
+            random_seed   : Reproducibility seed for K-Means.
+            sector_labels : Optional sector strings for ARI computation
+                            across all methods.
+        """
+        self.coordinates   = coordinates
+        self.random_seed   = random_seed
+        self.sector_labels = sector_labels
+        self.n, self.d     = coordinates.shape
+
+    # -----------------------------------------------------------------
+    # Private helpers
+    # -----------------------------------------------------------------
+
+    def _build_result(
+        self,
+        assignments : np.ndarray,
+        method      : str,
+        noise_count : int = 0
+    ) -> ComparisonResult:
+        """
+        Wrap assignments and validity metrics into a structured result.
+
+        Masks noise labels before computing ARI and internal validity
+        scores, returning None for metrics when fewer than 2 non-noise
+        clusters exist.
+        """
+        mask       = assignments >= 0
+        n_clusters = len(np.unique(assignments[mask]))
+
+        metrics = self._validity_metrics(assignments)
+
+        ari = None
+        if self.sector_labels is not None and n_clusters >= 2:
+            ari = float(adjusted_rand_score(
+                np.array(self.sector_labels)[mask],
+                assignments[mask]
+            ))
+
+        return ComparisonResult(
+            assignments       = assignments.tolist(),
+            ari_vs_sectors    = ari,
+            calinski_harabasz = metrics["calinski_harabasz"],
+            davies_bouldin    = metrics["davies_bouldin"],
+            method            = method,
+            n_clusters        = n_clusters,
+            noise_count       = noise_count,
+            silhouette        = metrics["silhouette"]
+        )
+
+    def _validity_metrics(self, assignments: np.ndarray) -> dict[str, float | None]:
+        """
+        Compute internal validity metrics for non-degenerate clusterings.
+
+        Returns None for each metric when fewer than 2 non-noise
+        clusters exist, because sklearn's scoring functions require
+        at least 2 distinct labels.
+
+        Args:
+            assignments: Cluster label per observation.
+        """
+        mask   = assignments >= 0
+        coords = self.coordinates[mask]
+        labels = assignments[mask]
+
+        metrics = [
+            ("calinski_harabasz", calinski_harabasz_score),
+            ("davies_bouldin",    davies_bouldin_score),
+            ("silhouette",        silhouette_score)
+        ]
+
+        if (n := len(np.unique(labels))) < 2 or n >= self.n:
+            return {name: None for name, _ in metrics}
+
+        return {
+            name: float(func(coords, labels))
+            for name, func in metrics
+        }
+
+    # -----------------------------------------------------------------
+    # Clustering methods
+    # -----------------------------------------------------------------
+
+    def dbscan(self) -> ComparisonResult:
+        """
+        DBSCAN with KneeLocator epsilon from k-distance graph.
+
+        Computes `min_samples` from PCA dimensionality and corpus
+        size, builds the k-distance graph via `NearestNeighbors`,
+        and selects epsilon at the knee of the sorted distances.
+        Falls back to the median k-distance when no knee is found.
+        """
+        min_samples = max(2, min(floor(0.1 * self.n), 2 * self.d))
+
+        k_distances = np.sort(
+            NearestNeighbors(n_neighbors = min_samples)
+            .fit(self.coordinates)
+            .kneighbors(self.coordinates)[0][:, -1]
+        )
+
+        knee = KneeLocator(
+            curve     = "convex",
+            direction = "increasing",
+            x         = range(len(k_distances)),
+            y         = k_distances
+        ).knee
+
+        eps = (
+            float(k_distances[knee])
+            if knee is not None
+            else float(np.median(k_distances))
+        )
+        if eps <= 0:
+            eps = float(np.max(k_distances)) or 0.5
+
+        assignments = DBSCAN(
+            eps         = eps,
+            min_samples = min_samples
+        ).fit_predict(self.coordinates)
+
+        return self._build_result(
+            assignments = assignments,
+            method      = "dbscan",
+            noise_count = int((assignments == -1).sum())
+        )
+
+    def hdbscan(self) -> ComparisonResult:
+        """
+        HDBSCAN with corpus-scaled minimum cluster size.
+        """
+        assignments = HDBSCAN(
+            copy             = False,
+            min_cluster_size = max(3, floor(0.05 * self.n))
+        ).fit_predict(self.coordinates)
+
+        return self._build_result(
+            assignments = assignments,
+            method      = "hdbscan",
+            noise_count = int((assignments == -1).sum())
+        )
+
+    def kmeans(self) -> ComparisonResult:
+        """
+        K-Means with KneeLocator K from inertia curve.
+
+        Fits K-Means across a range of cluster counts and selects
+        the elbow via KneeLocator. Falls back to K=3 when no knee
+        is found.
+        """
+        ks = range(2, min(self.n, 11))
+
+        inertias = [
+            KMeans(
+                n_clusters   = k,
+                n_init       = 10,
+                random_state = self.random_seed
+            ).fit(self.coordinates).inertia_
+            for k in ks
+        ]
+
+        knee = KneeLocator(
+            curve     = "convex",
+            direction = "decreasing",
+            x         = ks,
+            y         = inertias
+        ).knee
+
+        assignments = KMeans(
+            n_clusters   = knee if knee is not None else 3,
+            n_init       = 10,
+            random_state = self.random_seed
+        ).fit_predict(self.coordinates)
+
+        return self._build_result(
+            assignments = assignments,
+            method      = "kmeans"
+        )
+
+    def mean_shift(self) -> ComparisonResult:
+        """
+        Mean Shift with bandwidth estimated at quantile 0.3.
+        """
+        assignments = MeanShift(
+            bandwidth = estimate_bandwidth(self.coordinates, quantile = 0.3) or None
+        ).fit_predict(self.coordinates)
+
+        return self._build_result(
+            assignments = assignments,
+            method      = "mean_shift"
+        )
+
+    # -----------------------------------------------------------------
+    # Silhouette
+    # -----------------------------------------------------------------
+
+    def silhouette_details(self, assignments: np.ndarray) -> np.ndarray:
+        """
+        Per-posting silhouette coefficients.
+
+        Returns an array of length `n_postings` with silhouette
+        scores in [-1, 1]. For degenerate clusterings (fewer than
+        2 labels), returns zeros.
+
+        Args:
+            assignments: Cluster label per observation.
+        """
+        mask = assignments >= 0
+        if len(np.unique(assignments[mask])) < 2:
+            return np.zeros(self.n)
+
+        scores = np.zeros(self.n)
+        scores[mask] = silhouette_samples(
+            self.coordinates[mask],
+            assignments[mask]
+        )
+        return scores

--- a/src/chalkline/clustering/hierarchical.py
+++ b/src/chalkline/clustering/hierarchical.py
@@ -1,0 +1,221 @@
+"""
+Ward-linkage hierarchical agglomerative clustering with cophenetic
+validation and TF-IDF centroid labeling.
+
+Fits Ward, complete, and average linkage matrices on PCA-reduced
+coordinates, selects a flat partition via the inconsistency method,
+and derives human-readable cluster labels from the top TF-IDF terms
+of each cluster's centroid vector. The complete and average linkage
+matrices exist only for cophenetic comparison and are not stored.
+"""
+
+import numpy as np
+
+from scipy.cluster.hierarchy import cophenet, cut_tree, dendrogram
+from scipy.cluster.hierarchy import fcluster, leaders, linkage
+from scipy.sparse            import spmatrix
+from scipy.spatial.distance  import pdist
+from sklearn.metrics         import adjusted_rand_score
+from sklearn.metrics         import calinski_harabasz_score
+from sklearn.metrics         import davies_bouldin_score
+from sklearn.metrics         import silhouette_samples, silhouette_score
+
+from chalkline.clustering.schemas     import ClusterLabel, CopheneticResult
+from chalkline.extraction.occupations import OccupationIndex
+
+
+def compute_sector_labels(
+    document_ids     : list[str],
+    extracted_skills : dict[str, list[str]],
+    occupation_index : OccupationIndex
+) -> list[str]:
+    """
+    Map postings to sector labels via Jaccard-nearest SOC code.
+
+    For each document in row order, finds the O*NET occupation
+    whose skill profile has maximum Jaccard overlap with the
+    posting's canonical skill set, then returns that occupation's
+    sector field.
+
+    Args:
+        document_ids     : Posting identifiers in matrix row order.
+        extracted_skills : Mapping from document identifier to
+                           canonical skill names.
+        occupation_index : O*NET occupation lookup with Jaccard
+                           matching.
+    """
+    return [
+        occupation_index.get(
+            occupation_index.nearest(set(extracted_skills[doc]))
+        ).sector
+        for doc in document_ids
+    ]
+
+
+class HierarchicalClusterer:
+    """
+    Ward-linkage HAC with multi-method cophenetic validation.
+
+    Computes the Ward linkage matrix with optimal leaf ordering,
+    selects a flat partition via the inconsistency method, and
+    derives cluster labels from the top TF-IDF centroid terms.
+    Complete and average linkage matrices are computed for
+    cophenetic comparison but not retained.
+
+    Requirement coverage: linkage (1), cophenetic (2, 7),
+    dendrogram (3), inconsistency cut (4), cut_tree (5),
+    validate_at_k (6), cluster labels (8), ARI (9).
+    """
+
+    def __init__(
+        self,
+        coordinates   : np.ndarray,
+        document_ids  : list[str],
+        feature_names : list[str],
+        tfidf_matrix  : spmatrix,
+        depth         : int   = 2,
+        threshold     : float = 1.0
+    ):
+        """
+        Fit Ward-linkage HAC and derive cluster assignments.
+
+        Args:
+            coordinates   : PCA output of shape
+                            `(n_postings, n_selected)`.
+            document_ids  : Posting identifiers in row order.
+            feature_names : TF-IDF vocabulary in column order.
+            tfidf_matrix  : Sparse TF-IDF matrix for cluster
+                            centroid labeling.
+            depth         : Inconsistency calculation depth.
+            threshold     : Inconsistency cut threshold.
+        """
+        self.document_ids  = document_ids
+        self.feature_names = feature_names
+
+        n = len(coordinates)
+
+        self.linkage = linkage(
+            coordinates,
+            method           = "ward",
+            optimal_ordering = True
+        )
+
+        distances = pdist(coordinates)
+        self.cophenetic = [
+            CopheneticResult(
+                correlation = float(cophenet(z, distances)[0]),
+                method      = method
+            )
+            for method, z in [
+                ("average",  linkage(coordinates, method = "average")),
+                ("complete", linkage(coordinates, method = "complete")),
+                ("ward",     self.linkage)
+            ]
+        ]
+
+        self.cut_height  = threshold
+        self.assignments = fcluster(
+            self.linkage,
+            criterion = "inconsistent",
+            depth     = depth,
+            t         = threshold
+        )
+        self.k = len(np.unique(self.assignments))
+
+        max_k = min(n - 1, 20)
+        if max_k >= 2:
+            self.cut_tree = cut_tree(
+                self.linkage,
+                n_clusters = range(2, max_k + 1)
+            )
+        else:
+            self.cut_tree = np.empty((n, 0), dtype = int)
+
+        self.tfidf_dense = tfidf_matrix.toarray()
+        leader_nodes, leader_labels = leaders(self.linkage, self.assignments)
+        self.leader_map = dict(zip(leader_labels, leader_nodes))
+
+        if 2 <= self.k < n:
+            args = (coordinates, self.assignments)
+            self.calinski_harabasz   = float(calinski_harabasz_score(*args))
+            self.davies_bouldin      = float(davies_bouldin_score(*args))
+            self.silhouette          = float(silhouette_score(*args))
+            self.silhouette_samples_ = silhouette_samples(*args)
+        else:
+            self.calinski_harabasz   = None
+            self.davies_bouldin      = None
+            self.silhouette          = None
+            self.silhouette_samples_ = np.zeros(n)
+
+    # -----------------------------------------------------------------
+    # Public methods
+    # -----------------------------------------------------------------
+
+    def ari_vs_sectors(self, sector_labels: list[str]) -> float:
+        """
+        Adjusted Rand index between HAC assignments and sector
+        labels.
+
+        Args:
+            sector_labels: Sector strings aligned with
+                           `document_ids` row order.
+        """
+        return float(adjusted_rand_score(sector_labels, self.assignments))
+
+    def dendrogram_data(self, title_map: dict[str, str] | None = None) -> dict:
+        """
+        Dendrogram structure for rendering without plotting.
+
+        Returns the scipy dendrogram dict with `icoord`, `dcoord`,
+        `ivl`, and `color_list` keys. When `title_map` is provided,
+        leaf labels are mapped from document identifiers to display
+        titles.
+
+        Args:
+            title_map: Optional mapping from document identifier to
+                       display title for leaf labeling.
+        """
+        return dendrogram(
+            self.linkage,
+            labels  = [
+                title_map.get(doc, doc) for doc in self.document_ids
+            ] if title_map else self.document_ids,
+            no_plot = True
+        )
+
+    def labels(self, top_n: int = 5) -> list[ClusterLabel]:
+        """
+        Human-readable labels from top TF-IDF centroid terms.
+
+        Averages the original TF-IDF vectors of each cluster's
+        members and extracts the `top_n` highest-weighted terms.
+
+        Args:
+            top_n: Number of top terms per cluster label.
+        """
+        return [
+            ClusterLabel(
+                cluster_id     = int(cluster_id),
+                leader_node_id = int(self.leader_map[cluster_id]),
+                size           = int(mask.sum()),
+                terms          = [self.feature_names[j] for j in indices],
+                weights        = [float(centroid[j]) for j in indices]
+            )
+            for cluster_id in np.unique(self.assignments)
+            for mask     in [self.assignments == cluster_id]
+            for centroid in [self.tfidf_dense[mask].mean(0)]
+            for indices  in [np.argsort(centroid)[::-1][:top_n]]
+        ]
+
+    def validate_at_k(self, k: int) -> np.ndarray:
+        """
+        Flat cluster assignments at a specified number of clusters.
+
+        Cuts the Ward linkage tree at exactly `k` clusters via
+        `fcluster` with the `maxclust` criterion, enabling
+        post-hoc comparison against K-Means' elbow-selected K.
+
+        Args:
+            k: Target number of clusters.
+        """
+        return fcluster(self.linkage, criterion = "maxclust", t = k)

--- a/src/chalkline/clustering/hierarchical.py
+++ b/src/chalkline/clustering/hierarchical.py
@@ -2,11 +2,11 @@
 Ward-linkage hierarchical agglomerative clustering with cophenetic
 validation and TF-IDF centroid labeling.
 
-Fits Ward, complete, and average linkage matrices on PCA-reduced
-coordinates, selects a flat partition via the inconsistency method,
-and derives human-readable cluster labels from the top TF-IDF terms
-of each cluster's centroid vector. The complete and average linkage
-matrices exist only for cophenetic comparison and are not stored.
+Fits Ward linkage on PCA-reduced coordinates, selects a flat partition
+via the merge-height acceleration criterion, and exposes cophenetic
+comparison and internal validity metrics as on-demand methods. Cluster
+labels are derived from TF-IDF centroid terms when explicitly requested
+via `labels()`.
 """
 
 import numpy as np
@@ -20,7 +20,8 @@ from sklearn.metrics         import calinski_harabasz_score
 from sklearn.metrics         import davies_bouldin_score
 from sklearn.metrics         import silhouette_samples, silhouette_score
 
-from chalkline.clustering.schemas     import ClusterLabel, CopheneticResult
+from chalkline.clustering.schemas     import ClusterLabel
+from chalkline.clustering.schemas     import CopheneticResult, ValidationMetrics
 from chalkline.extraction.occupations import OccupationIndex
 
 
@@ -30,12 +31,13 @@ def compute_sector_labels(
     occupation_index : OccupationIndex
 ) -> list[str]:
     """
-    Map postings to sector labels via Jaccard-nearest SOC code.
+    Map postings to SOC codes via Jaccard-nearest occupation.
 
     For each document in row order, finds the O*NET occupation
     whose skill profile has maximum Jaccard overlap with the
     posting's canonical skill set, then returns that occupation's
-    sector field.
+    SOC code, giving 21 distinct ground-truth classes for ARI
+    evaluation rather than 3 broad sectors.
 
     Args:
         document_ids     : Posting identifiers in matrix row order.
@@ -47,7 +49,7 @@ def compute_sector_labels(
     return [
         occupation_index.get(
             occupation_index.nearest(set(extracted_skills[doc]))
-        ).sector
+        ).soc_code
         for doc in document_ids
     ]
 
@@ -56,41 +58,33 @@ class HierarchicalClusterer:
     """
     Ward-linkage HAC with multi-method cophenetic validation.
 
-    Computes the Ward linkage matrix with optimal leaf ordering,
-    selects a flat partition via the inconsistency method, and
-    derives cluster labels from the top TF-IDF centroid terms.
-    Complete and average linkage matrices are computed for
-    cophenetic comparison but not retained.
+    Computes the Ward linkage matrix with optimal leaf ordering and
+    selects a flat partition via the merge-height acceleration
+    criterion. Cophenetic comparison and internal validity metrics
+    are computed on demand via `cophenetic_comparison()` and
+    `validation_metrics()`. Cluster labels are derived from TF-IDF
+    centroid terms when explicitly requested via `labels()`.
 
     Requirement coverage: linkage (1), cophenetic (2, 7),
-    dendrogram (3), inconsistency cut (4), cut_tree (5),
+    dendrogram (3), acceleration cut (4), cut_tree (5),
     validate_at_k (6), cluster labels (8), ARI (9).
     """
 
     def __init__(
         self,
-        coordinates   : np.ndarray,
-        document_ids  : list[str],
-        feature_names : list[str],
-        tfidf_matrix  : spmatrix,
-        depth         : int   = 2,
-        threshold     : float = 1.0
+        coordinates  : np.ndarray,
+        document_ids : list[str]
     ):
         """
         Fit Ward-linkage HAC and derive cluster assignments.
 
         Args:
-            coordinates   : PCA output of shape
-                            `(n_postings, n_selected)`.
-            document_ids  : Posting identifiers in row order.
-            feature_names : TF-IDF vocabulary in column order.
-            tfidf_matrix  : Sparse TF-IDF matrix for cluster
-                            centroid labeling.
-            depth         : Inconsistency calculation depth.
-            threshold     : Inconsistency cut threshold.
+            coordinates  : PCA output of shape
+                           `(n_postings, n_selected)`.
+            document_ids : Posting identifiers in row order.
         """
-        self.document_ids  = document_ids
-        self.feature_names = feature_names
+        self.coordinates  = coordinates
+        self.document_ids = document_ids
 
         n = len(coordinates)
 
@@ -100,52 +94,22 @@ class HierarchicalClusterer:
             optimal_ordering = True
         )
 
-        distances = pdist(coordinates)
-        self.cophenetic = [
-            CopheneticResult(
-                correlation = float(cophenet(z, distances)[0]),
-                method      = method
-            )
-            for method, z in [
-                ("average",  linkage(coordinates, method = "average")),
-                ("complete", linkage(coordinates, method = "complete")),
-                ("ward",     self.linkage)
-            ]
-        ]
+        heights = self.linkage[:, 2]
+        if n <= 3:
+            k = 2
+        else:
+            acceleration = np.diff(heights, n = 2)
+            k            = int(acceleration[::-1].argmax()) + 2
+        self.cut_height  = float(heights[-k])
+        self.assignments = fcluster(self.linkage, criterion = "maxclust", t = k)
+        self.k           = len(np.unique(self.assignments))
 
-        self.cut_height  = threshold
-        self.assignments = fcluster(
-            self.linkage,
-            criterion = "inconsistent",
-            depth     = depth,
-            t         = threshold
+        max_k         = min(n - 1, 20)
+        self.cut_tree = (
+            cut_tree(self.linkage, n_clusters = range(2, max_k + 1))
+            if max_k >= 2
+            else np.empty((n, 0), dtype = int)
         )
-        self.k = len(np.unique(self.assignments))
-
-        max_k = min(n - 1, 20)
-        if max_k >= 2:
-            self.cut_tree = cut_tree(
-                self.linkage,
-                n_clusters = range(2, max_k + 1)
-            )
-        else:
-            self.cut_tree = np.empty((n, 0), dtype = int)
-
-        self.tfidf_dense = tfidf_matrix.toarray()
-        leader_nodes, leader_labels = leaders(self.linkage, self.assignments)
-        self.leader_map = dict(zip(leader_labels, leader_nodes))
-
-        if 2 <= self.k < n:
-            args = (coordinates, self.assignments)
-            self.calinski_harabasz   = float(calinski_harabasz_score(*args))
-            self.davies_bouldin      = float(davies_bouldin_score(*args))
-            self.silhouette          = float(silhouette_score(*args))
-            self.silhouette_samples_ = silhouette_samples(*args)
-        else:
-            self.calinski_harabasz   = None
-            self.davies_bouldin      = None
-            self.silhouette          = None
-            self.silhouette_samples_ = np.zeros(n)
 
     # -----------------------------------------------------------------
     # Public methods
@@ -161,6 +125,27 @@ class HierarchicalClusterer:
                            `document_ids` row order.
         """
         return float(adjusted_rand_score(sector_labels, self.assignments))
+
+    def cophenetic_comparison(self) -> list[CopheneticResult]:
+        """
+        Cophenetic correlations for Ward, complete, and average
+        linkage on the same coordinates.
+
+        Computes `pdist` and two additional linkage matrices on
+        demand. Results are not cached, so repeated calls refit.
+        """
+        distances = pdist(self.coordinates)
+        return [
+            CopheneticResult(
+                correlation = float(cophenet(z, distances)[0]),
+                method      = method
+            )
+            for method, z in [
+                ("average",  linkage(self.coordinates, method = "average")),
+                ("complete", linkage(self.coordinates, method = "complete")),
+                ("ward",     self.linkage)
+            ]
+        ]
 
     def dendrogram_data(self, title_map: dict[str, str] | None = None) -> dict:
         """
@@ -183,27 +168,39 @@ class HierarchicalClusterer:
             no_plot = True
         )
 
-    def labels(self, top_n: int = 5) -> list[ClusterLabel]:
+    def labels(
+        self,
+        feature_names : list[str],
+        tfidf_matrix  : spmatrix,
+        top_n         : int = 5
+    ) -> list[ClusterLabel]:
         """
         Human-readable labels from top TF-IDF centroid terms.
 
-        Averages the original TF-IDF vectors of each cluster's
-        members and extracts the `top_n` highest-weighted terms.
+        Averages the TF-IDF vectors of each cluster's members and
+        extracts the `top_n` highest-weighted terms. The dense
+        conversion of `tfidf_matrix` is scoped to this call.
 
         Args:
-            top_n: Number of top terms per cluster label.
+            feature_names : TF-IDF vocabulary in column order.
+            tfidf_matrix  : Sparse TF-IDF matrix for centroid
+                            computation, aligned with `document_ids`.
+            top_n         : Number of top terms per cluster label.
         """
+        tfidf_dense                 = tfidf_matrix.toarray()
+        leader_nodes, leader_labels = leaders(self.linkage, self.assignments)
+        leader_map                  = dict(zip(leader_labels, leader_nodes))
         return [
             ClusterLabel(
                 cluster_id     = int(cluster_id),
-                leader_node_id = int(self.leader_map[cluster_id]),
+                leader_node_id = int(leader_map[cluster_id]),
                 size           = int(mask.sum()),
-                terms          = [self.feature_names[j] for j in indices],
+                terms          = [feature_names[j] for j in indices],
                 weights        = [float(centroid[j]) for j in indices]
             )
             for cluster_id in np.unique(self.assignments)
             for mask     in [self.assignments == cluster_id]
-            for centroid in [self.tfidf_dense[mask].mean(0)]
+            for centroid in [tfidf_dense[mask].mean(0)]
             for indices  in [np.argsort(centroid)[::-1][:top_n]]
         ]
 
@@ -219,3 +216,23 @@ class HierarchicalClusterer:
             k: Target number of clusters.
         """
         return fcluster(self.linkage, criterion = "maxclust", t = k)
+
+    def validation_metrics(self) -> ValidationMetrics:
+        """
+        Internal validity metrics for the current flat partition.
+
+        Computes silhouette, Calinski-Harabasz, and Davies-Bouldin
+        scores on demand. Returns a `ValidationMetrics` instance
+        with all fields set to `None` when the partition is
+        degenerate (fewer than 2 clusters).
+        """
+        n = len(self.coordinates)
+        if not (2 <= self.k < n):
+            return ValidationMetrics()
+        args = (self.coordinates, self.assignments)
+        return ValidationMetrics(
+            calinski_harabasz  = float(calinski_harabasz_score(*args)),
+            davies_bouldin     = float(davies_bouldin_score(*args)),
+            silhouette         = float(silhouette_score(*args)),
+            silhouette_samples = silhouette_samples(*args).tolist()
+        )

--- a/src/chalkline/clustering/hierarchical.py
+++ b/src/chalkline/clustering/hierarchical.py
@@ -1,12 +1,12 @@
 """
-Ward-linkage hierarchical agglomerative clustering with cophenetic
+Average-linkage hierarchical agglomerative clustering with cophenetic
 validation and TF-IDF centroid labeling.
 
-Fits Ward linkage on PCA-reduced coordinates, selects a flat partition
-via the merge-height acceleration criterion, and exposes cophenetic
-comparison and internal validity metrics as on-demand methods. Cluster
-labels are derived from TF-IDF centroid terms when explicitly requested
-via `labels()`.
+Fits average linkage on PCA-reduced coordinates, selects a flat
+partition via the merge-height acceleration criterion, and exposes
+cophenetic comparison and internal validity metrics as on-demand
+methods. Cluster labels are derived from TF-IDF centroid terms when
+explicitly requested via `labels()`.
 """
 
 import numpy as np
@@ -56,9 +56,9 @@ def compute_sector_labels(
 
 class HierarchicalClusterer:
     """
-    Ward-linkage HAC with multi-method cophenetic validation.
+    Average-linkage HAC with multi-method cophenetic validation.
 
-    Computes the Ward linkage matrix with optimal leaf ordering and
+    Computes the average linkage matrix with optimal leaf ordering and
     selects a flat partition via the merge-height acceleration
     criterion. Cophenetic comparison and internal validity metrics
     are computed on demand via `cophenetic_comparison()` and
@@ -90,7 +90,7 @@ class HierarchicalClusterer:
 
         self.linkage = linkage(
             coordinates,
-            method           = "ward",
+            method           = "average",
             optimal_ordering = True
         )
 
@@ -141,9 +141,9 @@ class HierarchicalClusterer:
                 method      = method
             )
             for method, z in [
-                ("average",  linkage(self.coordinates, method = "average")),
+                ("average",  self.linkage),
                 ("complete", linkage(self.coordinates, method = "complete")),
-                ("ward",     self.linkage)
+                ("ward",     linkage(self.coordinates, method = "ward"))
             ]
         ]
 

--- a/src/chalkline/clustering/schemas.py
+++ b/src/chalkline/clustering/schemas.py
@@ -54,3 +54,18 @@ class CopheneticResult(BaseModel, extra="forbid"):
 
     correlation : float
     method      : NonEmptyStr
+
+
+class ValidationMetrics(BaseModel, extra="forbid"):
+    """
+    Internal validity metrics for a hierarchical cluster partition.
+
+    All metric fields are optional because degenerate clusterings
+    (fewer than 2 clusters) cannot produce internal validity scores.
+    `silhouette_samples` is an empty list in the degenerate case.
+    """
+
+    calinski_harabasz  : float | None = None
+    davies_bouldin     : float | None = None
+    silhouette         : float | None = None
+    silhouette_samples : list[float]  = Field(default_factory = list)

--- a/src/chalkline/clustering/schemas.py
+++ b/src/chalkline/clustering/schemas.py
@@ -1,0 +1,56 @@
+"""
+Schemas for clustering results and validity metrics.
+"""
+
+from pydantic import BaseModel, Field
+
+from chalkline import NonEmptyStr
+
+
+class ClusterLabel(BaseModel, extra="forbid"):
+    """
+    Human-readable label for a single cluster derived from TF-IDF
+    centroid terms.
+
+    The `leader_node_id` maps to the linkage node serving as the
+    subtree root for this cluster, enabling direct annotation of
+    dendrogram branches with cluster labels.
+    """
+
+    cluster_id     : int = Field(ge = 0)
+    leader_node_id : int = Field(ge = 0)
+    size           : int = Field(ge = 1)
+    terms          : list[str]
+    weights        : list[float]
+
+
+class ComparisonResult(BaseModel, extra="forbid"):
+    """
+    Output from a single comparison clustering method.
+
+    Metric fields are optional because degenerate clusterings
+    (fewer than 2 non-noise clusters) cannot produce internal
+    validity scores.
+    """
+
+    assignments : list[int]
+    method      : NonEmptyStr
+    n_clusters  : int = Field(ge = 0)
+
+    ari_vs_sectors    : float | None = None
+    calinski_harabasz : float | None = None
+    davies_bouldin    : float | None = None
+    noise_count       : int          = Field(ge = 0, default = 0)
+    silhouette        : float | None = None
+
+
+class CopheneticResult(BaseModel, extra="forbid"):
+    """
+    Cophenetic correlation for a single linkage method.
+
+    Measures how faithfully the dendrogram preserves pairwise
+    distances from the original coordinate space.
+    """
+
+    correlation : float
+    method      : NonEmptyStr

--- a/src/chalkline/extraction/skills.py
+++ b/src/chalkline/extraction/skills.py
@@ -8,12 +8,13 @@ phrase masking. The output is a mapping from document identifiers to
 deduplicated, sorted canonical skill names.
 """
 
-from ahocorasick_rs                  import AhoCorasick, MatchKind
-from logging                         import getLogger
-from nltk.stem                       import PorterStemmer
-from re                              import sub
-from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS
-from typing                          import NamedTuple
+from ahocorasick_rs import AhoCorasick, MatchKind
+from html           import unescape
+from logging        import getLogger
+from nltk.stem      import PorterStemmer
+from re             import sub
+from typing         import NamedTuple
+from wordfreq       import word_frequency
 
 from chalkline.extraction.lexicons import LexiconRegistry
 from chalkline.extraction.schemas  import ConfidenceTier
@@ -127,7 +128,8 @@ class SkillExtractor:
         )
 
         patterns, self.metadata = self._build_patterns()
-        self.automaton = AhoCorasick(
+        self.pattern_chars      = frozenset(c for p in patterns for c in p)
+        self.automaton          = AhoCorasick(
             patterns, MatchKind.LeftmostLongest
         )
 
@@ -167,9 +169,12 @@ class SkillExtractor:
             canonical_to_lemmas.setdefault(canonical, set()).add(lemma)
 
         for canonical, lemmas in sorted(canonical_to_lemmas.items()):
-            forms = {canonical.lower(), self._stem(canonical)} | lemmas
+            canon = canonical.lower().replace("/", " ").strip()
+            forms = {canon, self._stem(canon)} | {
+                f.replace("/", " ").strip() for f in lemmas
+            }
 
-            if len(words := canonical.lower().split()) == 2:
+            if len(words := canon.split()) == 2:
                 forms.add(f"{words[1]} {words[0]}")
 
             forms -= seen | {""}
@@ -204,6 +209,10 @@ class SkillExtractor:
         """
         Check whether a match span falls on word boundaries.
 
+        After preprocessing, all non-pattern characters have been
+        replaced with spaces, so a valid boundary is simply a space
+        or string edge.
+
         Args:
             end   : End position (exclusive) of the match.
             start : Start position of the match.
@@ -213,8 +222,8 @@ class SkillExtractor:
             `True` if both boundaries are valid.
         """
         return (
-            (start == 0 or not text[start - 1].isalnum())
-            and (end == len(text) or not text[end].isalnum())
+            (start == 0 or text[start - 1] == " ")
+            and (end == len(text) or text[end] == " ")
         )
 
     def _match(self, text: str) -> list[str]:
@@ -248,10 +257,12 @@ class SkillExtractor:
         """
         Normalize raw posting text and mask filler phrases.
 
-        Converts bullet characters and semicolons to periods, splits
-        camelCase terms into separate words, collapses whitespace,
-        lowercases, and blanks filler phrase spans with whitespace
-        before skill matching.
+        Splits camelCase terms into separate words, lowercases, strips
+        all characters that do not appear in any lexicon pattern,
+        collapses whitespace, and blanks filler phrase spans before
+        skill matching. The allowed character set is derived at init
+        time from the automaton patterns themselves, so the filter
+        is always consistent with whatever the lexicons contain.
 
         Args:
             text: Raw posting description.
@@ -259,10 +270,12 @@ class SkillExtractor:
         Returns:
             Cleaned, lowercased text with fillers replaced by spaces.
         """
-        text = sub(r"[•●■◦▪–—;]", ". ", text)
+        text = sub(r"<[^>]+>", " ", text)
+        text = unescape(text)
         text = sub(r"([a-z])([A-Z])", r"\1 \2", text)
-        text = sub(r"\s+", " ", text)
         text = text.lower().strip()
+        text = "".join(c if c in self.pattern_chars else " " for c in text)
+        text = sub(r"\s+", " ", text)
 
         chars = list(text)
         for _, start, end in self.filler_automaton.find_matches_as_indexes(text):
@@ -320,7 +333,7 @@ class SkillExtractor:
 
             corpus_tokens.update(
                 t for t in lemmatized.split()
-                if len(t) >= 3 and t not in ENGLISH_STOP_WORDS
+                if len(t) >= 3 and word_frequency(t, "en") < 1e-4
             )
             matched_tokens.update(
                 t for s in skills for t in s.lower().split()

--- a/src/chalkline/extraction/vectorize.py
+++ b/src/chalkline/extraction/vectorize.py
@@ -39,6 +39,7 @@ class SkillVectorizer:
                     skill names, as returned by `SkillExtractor.extract`.
         """
         self.document_ids = sorted(skills)
+
         self._dicts = [
             dict.fromkeys(skills[doc], 1)
             for doc in self.document_ids
@@ -46,7 +47,7 @@ class SkillVectorizer:
 
         self.pipeline = Pipeline([
             ("vec",   DictVectorizer()),
-            ("tfidf", TfidfTransformer(norm=None)),
+            ("tfidf", TfidfTransformer(norm = None)),
             ("norm",  Normalizer())
         ])
 

--- a/tests/clustering/__init__.py
+++ b/tests/clustering/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for hierarchical clustering and comparison methods.
+"""

--- a/tests/clustering/test_comparison.py
+++ b/tests/clustering/test_comparison.py
@@ -1,0 +1,137 @@
+"""
+Tests for comparison clustering methods.
+
+Validates K-Means, DBSCAN, Mean Shift, and HDBSCAN result structure,
+validity metrics, silhouette details, and sector ARI computation
+using the synthetic 20-posting fixture chain.
+"""
+
+import numpy as np
+
+from pytest import mark
+
+from chalkline.clustering.comparison import ClusterComparison
+
+
+class TestClusterComparison:
+    """
+    Validate result structure and metrics from each comparison
+    clustering method.
+    """
+
+    # ---------------------------------------------------------
+    # Structural properties across all methods
+    # ---------------------------------------------------------
+
+    @mark.parametrize("method", ["dbscan", "hdbscan", "kmeans", "mean_shift"])
+    def test_assignment_count(self, comparison: ClusterComparison, method: str):
+        """
+        Every method assigns one label per posting.
+        """
+        result = getattr(comparison, method)()
+        assert len(result.assignments) == len(comparison.coordinates)
+
+    @mark.parametrize("method", ["kmeans", "mean_shift"])
+    def test_no_noise(self, comparison: ClusterComparison, method: str):
+        """
+        Partitioning methods produce no noise points.
+        """
+        result = getattr(comparison, method)()
+        assert result.noise_count == 0
+
+    @mark.parametrize("method", ["dbscan", "hdbscan"])
+    def test_noise_nonnegative(self, comparison: ClusterComparison, method: str):
+        """
+        Density methods report non-negative noise counts.
+        """
+        result = getattr(comparison, method)()
+        assert result.noise_count >= 0
+
+    # ---------------------------------------------------------
+    # K-Means specifics
+    # ---------------------------------------------------------
+
+    def test_kmeans_at_least_two_clusters(self, comparison: ClusterComparison):
+        """
+        K-Means produces at least 2 clusters from the elbow method.
+        """
+        assert comparison.kmeans().n_clusters >= 2
+
+    def test_kmeans_with_sectors(self, comparison_with_sectors: ClusterComparison):
+        """
+        K-Means ARI against sector labels falls within [-1, 1].
+        """
+        result = comparison_with_sectors.kmeans()
+        if result.ari_vs_sectors is not None:
+            assert -1 <= result.ari_vs_sectors <= 1
+
+    # ---------------------------------------------------------
+    # Sector ARI
+    # ---------------------------------------------------------
+
+    def test_ari_none_without_sectors(self, comparison: ClusterComparison):
+        """
+        Results carry no ARI when the runner has no sector labels.
+        """
+        result = comparison.kmeans()
+        assert result.ari_vs_sectors is None
+
+    @mark.parametrize("method", ["dbscan", "hdbscan"])
+    def test_density_ari_bounded_with_sectors(
+        self,
+        comparison_with_sectors : ClusterComparison,
+        method                  : str
+    ):
+        """
+        Density methods produce bounded ARI when sector labels are
+        present and at least 2 non-noise clusters exist.
+        """
+        result = getattr(comparison_with_sectors, method)()
+        if result.ari_vs_sectors is not None:
+            assert -1 <= result.ari_vs_sectors <= 1
+
+    # ---------------------------------------------------------
+    # Validity metrics
+    # ---------------------------------------------------------
+
+    def test_validity_metrics_bounded(self, comparison: ClusterComparison):
+        """
+        Internal validity metrics fall within expected bounds
+        when present.
+        """
+        result = comparison.kmeans()
+        if result.calinski_harabasz is not None:
+            assert result.calinski_harabasz > 0
+        if result.davies_bouldin is not None:
+            assert result.davies_bouldin >= 0
+        if result.silhouette is not None:
+            assert -1 <= result.silhouette <= 1
+
+    # ---------------------------------------------------------
+    # Silhouette details
+    # ---------------------------------------------------------
+
+    def test_silhouette_details_bounded(self, comparison: ClusterComparison):
+        """
+        Per-posting silhouette coefficients fall within [-1, 1].
+        """
+        result  = comparison.kmeans()
+        details = comparison.silhouette_details(np.array(result.assignments))
+        assert (details >= -1).all() and (details <= 1).all()
+
+    def test_silhouette_details_degenerate(self, comparison: ClusterComparison):
+        """
+        Degenerate clustering (single label) returns all zeros.
+        """
+        details = comparison.silhouette_details(
+            np.zeros(len(comparison.coordinates), dtype = int)
+        )
+        assert (details == 0).all()
+
+    def test_silhouette_details_length(self, comparison: ClusterComparison):
+        """
+        Per-posting silhouette array has one entry per posting.
+        """
+        result  = comparison.kmeans()
+        details = comparison.silhouette_details(np.array(result.assignments))
+        assert len(details) == len(comparison.coordinates)

--- a/tests/clustering/test_hierarchical.py
+++ b/tests/clustering/test_hierarchical.py
@@ -1,0 +1,223 @@
+"""
+Tests for Ward-linkage hierarchical agglomerative clustering.
+
+Validates linkage structure, cophenetic correlations, cluster
+assignments, label derivation, dendrogram output, ARI computation,
+and post-hoc validation at arbitrary K values using the synthetic
+20-posting fixture chain.
+"""
+
+import numpy as np
+
+from pytest import mark
+
+from chalkline.clustering.hierarchical import HierarchicalClusterer
+
+
+class TestComputeSectorLabels:
+    """
+    Validate sector label derivation from Jaccard nearest SOC.
+    """
+
+    def test_labels_are_strings(self, sector_labels: list[str]):
+        """
+        Every sector label is a non-empty string.
+        """
+        assert all(isinstance(s, str) and s for s in sector_labels)
+
+    def test_length_matches_documents(
+        self,
+        extracted_skills : dict[str, list[str]],
+        sector_labels    : list[str]
+    ):
+        """
+        One sector label per document in the PCA reducer's row
+        order.
+        """
+        assert len(sector_labels) == len(extracted_skills)
+
+
+class TestHierarchicalClusterer:
+    """
+    Validate linkage, assignments, labels, dendrogram, and
+    validity metrics from the Ward-linkage HAC fit.
+    """
+
+    # ---------------------------------------------------------
+    # Linkage
+    # ---------------------------------------------------------
+
+    def test_cophenetic_bounded(self, clusterer: HierarchicalClusterer):
+        """
+        Cophenetic correlations fall within [-1, 1].
+        """
+        for result in clusterer.cophenetic:
+            assert -1 <= result.correlation <= 1
+
+    def test_cophenetic_count(self, clusterer: HierarchicalClusterer):
+        """
+        Three cophenetic results for ward, complete, and average
+        linkage methods.
+        """
+        assert len(clusterer.cophenetic) == 3
+
+    def test_cophenetic_methods(self, clusterer: HierarchicalClusterer):
+        """
+        Cophenetic results cover all three linkage methods.
+        """
+        methods = {result.method for result in clusterer.cophenetic}
+        assert methods == {"average", "complete", "ward"}
+
+    def test_linkage_shape(self, clusterer: HierarchicalClusterer):
+        """
+        Ward linkage matrix has shape `(n - 1, 4)` where `n` is
+        the number of postings.
+        """
+        n = len(clusterer.document_ids)
+        assert clusterer.linkage.shape == (n - 1, 4)
+
+    # ---------------------------------------------------------
+    # Assignments
+    # ---------------------------------------------------------
+
+    def test_cut_height_positive(self, clusterer: HierarchicalClusterer):
+        """
+        The inconsistency cut threshold is positive.
+        """
+        assert clusterer.cut_height > 0
+
+    def test_cut_tree_rows(self, clusterer: HierarchicalClusterer):
+        """
+        Cut tree has one row per posting.
+        """
+        n = len(clusterer.document_ids)
+        assert clusterer.cut_tree.shape[0] == n
+
+    def test_every_posting_assigned(self, clusterer: HierarchicalClusterer):
+        """
+        Every posting receives exactly one cluster assignment with
+        no unassigned labels.
+        """
+        n = len(clusterer.document_ids)
+        assert len(clusterer.assignments) == n
+        assert (clusterer.assignments > 0).all()
+
+    def test_k_positive(self, clusterer: HierarchicalClusterer):
+        """
+        At least one cluster is produced.
+        """
+        assert clusterer.k >= 1
+
+    # ---------------------------------------------------------
+    # Labels
+    # ---------------------------------------------------------
+
+    def test_labels_aligned(self, clusterer: HierarchicalClusterer):
+        """
+        Each label has matching term and weight counts.
+        """
+        for label in clusterer.labels():
+            assert len(label.terms) == len(label.weights)
+
+    def test_labels_count(self, clusterer: HierarchicalClusterer):
+        """
+        One label per unique cluster.
+        """
+        assert len(clusterer.labels()) == clusterer.k
+
+    def test_labels_readable(self, clusterer: HierarchicalClusterer):
+        """
+        Cluster label terms are human-readable strings, not
+        numeric indices.
+        """
+        for label in clusterer.labels():
+            assert all(isinstance(t, str) for t in label.terms)
+            assert all(not t.isdigit() for t in label.terms)
+
+    def test_labels_size_sums(self, clusterer: HierarchicalClusterer):
+        """
+        Cluster sizes sum to the total number of postings.
+        """
+        assert sum(
+            label.size for label in clusterer.labels()
+        ) == len(clusterer.document_ids)
+
+    def test_labels_top_n(self, clusterer: HierarchicalClusterer):
+        """
+        Requesting fewer top terms limits the returned list
+        length.
+        """
+        for label in clusterer.labels(top_n = 2):
+            assert len(label.terms) <= 2
+
+    # ---------------------------------------------------------
+    # Dendrogram
+    # ---------------------------------------------------------
+
+    def test_dendrogram_data_keys(self, clusterer: HierarchicalClusterer):
+        """
+        Dendrogram dict contains the expected scipy keys.
+        """
+        data = clusterer.dendrogram_data()
+        assert {"icoord", "dcoord", "ivl", "color_list"} <= data.keys()
+
+    def test_dendrogram_leaf_count(self, clusterer: HierarchicalClusterer):
+        """
+        Leaf labels match the number of postings.
+        """
+        data = clusterer.dendrogram_data()
+        assert len(data["ivl"]) == len(clusterer.document_ids)
+
+    def test_dendrogram_title_map(self, clusterer: HierarchicalClusterer):
+        """
+        Title map substitutes document identifiers in leaf labels.
+        """
+        title_map = {doc: f"Title {i}" for i, doc in enumerate(clusterer.document_ids)}
+        data      = clusterer.dendrogram_data(title_map = title_map)
+        assert all(label.startswith("Title ") for label in data["ivl"])
+
+    # ---------------------------------------------------------
+    # ARI and validity
+    # ---------------------------------------------------------
+
+    def test_ari_vs_sectors_bounded(
+        self,
+        clusterer     : HierarchicalClusterer,
+        sector_labels : list[str]
+    ):
+        """
+        Adjusted Rand index falls within [-1, 1].
+        """
+        assert -1 <= clusterer.ari_vs_sectors(sector_labels) <= 1
+
+    def test_silhouette_samples_length(self, clusterer: HierarchicalClusterer):
+        """
+        Per-posting silhouette array has one entry per posting.
+        """
+        n = len(clusterer.document_ids)
+        assert len(clusterer.silhouette_samples_) == n
+
+    def test_validity_metrics_populated(self, clusterer: HierarchicalClusterer):
+        """
+        Internal validity metrics are non-None when k >= 2.
+        """
+        assert clusterer.calinski_harabasz is not None
+        assert clusterer.calinski_harabasz > 0
+        assert clusterer.davies_bouldin is not None
+        assert clusterer.davies_bouldin >= 0
+        assert clusterer.silhouette is not None
+        assert -1 <= clusterer.silhouette <= 1
+
+    # ---------------------------------------------------------
+    # Validate at K
+    # ---------------------------------------------------------
+
+    @mark.parametrize("k", [2, 3])
+    def test_validate_at_k(self, clusterer: HierarchicalClusterer, k: int):
+        """
+        Assignments at a given K cover all postings and produce
+        exactly K unique clusters.
+        """
+        result = clusterer.validate_at_k(k = k)
+        assert len(result) == len(clusterer.document_ids)
+        assert len(np.unique(result)) == k

--- a/tests/clustering/test_hierarchical.py
+++ b/tests/clustering/test_hierarchical.py
@@ -12,6 +12,8 @@ import numpy as np
 from pytest import mark
 
 from chalkline.clustering.hierarchical import HierarchicalClusterer
+from chalkline.clustering.schemas      import ClusterLabel
+from chalkline.extraction.vectorize    import SkillVectorizer
 
 
 class TestComputeSectorLabels:
@@ -51,7 +53,7 @@ class TestHierarchicalClusterer:
         """
         Cophenetic correlations fall within [-1, 1].
         """
-        for result in clusterer.cophenetic:
+        for result in clusterer.cophenetic_comparison():
             assert -1 <= result.correlation <= 1
 
     def test_cophenetic_count(self, clusterer: HierarchicalClusterer):
@@ -59,13 +61,13 @@ class TestHierarchicalClusterer:
         Three cophenetic results for ward, complete, and average
         linkage methods.
         """
-        assert len(clusterer.cophenetic) == 3
+        assert len(clusterer.cophenetic_comparison()) == 3
 
     def test_cophenetic_methods(self, clusterer: HierarchicalClusterer):
         """
         Cophenetic results cover all three linkage methods.
         """
-        methods = {result.method for result in clusterer.cophenetic}
+        methods = {result.method for result in clusterer.cophenetic_comparison()}
         assert methods == {"average", "complete", "ward"}
 
     def test_linkage_shape(self, clusterer: HierarchicalClusterer):
@@ -112,42 +114,57 @@ class TestHierarchicalClusterer:
     # Labels
     # ---------------------------------------------------------
 
-    def test_labels_aligned(self, clusterer: HierarchicalClusterer):
+    def test_labels_aligned(self, cluster_labels: list[ClusterLabel]):
         """
         Each label has matching term and weight counts.
         """
-        for label in clusterer.labels():
+        for label in cluster_labels:
             assert len(label.terms) == len(label.weights)
 
-    def test_labels_count(self, clusterer: HierarchicalClusterer):
+    def test_labels_count(
+        self,
+        cluster_labels : list[ClusterLabel],
+        clusterer      : HierarchicalClusterer
+    ):
         """
         One label per unique cluster.
         """
-        assert len(clusterer.labels()) == clusterer.k
+        assert len(cluster_labels) == clusterer.k
 
-    def test_labels_readable(self, clusterer: HierarchicalClusterer):
+    def test_labels_readable(self, cluster_labels: list[ClusterLabel]):
         """
         Cluster label terms are human-readable strings, not
         numeric indices.
         """
-        for label in clusterer.labels():
+        for label in cluster_labels:
             assert all(isinstance(t, str) for t in label.terms)
             assert all(not t.isdigit() for t in label.terms)
 
-    def test_labels_size_sums(self, clusterer: HierarchicalClusterer):
+    def test_labels_size_sums(
+        self,
+        cluster_labels : list[ClusterLabel],
+        clusterer      : HierarchicalClusterer
+    ):
         """
         Cluster sizes sum to the total number of postings.
         """
-        assert sum(
-            label.size for label in clusterer.labels()
-        ) == len(clusterer.document_ids)
+        total = sum(label.size for label in cluster_labels)
+        assert total == len(clusterer.document_ids)
 
-    def test_labels_top_n(self, clusterer: HierarchicalClusterer):
+    def test_labels_top_n(
+        self,
+        clusterer        : HierarchicalClusterer,
+        skill_vectorizer : SkillVectorizer
+    ):
         """
         Requesting fewer top terms limits the returned list
         length.
         """
-        for label in clusterer.labels(top_n = 2):
+        for label in clusterer.labels(
+            feature_names = skill_vectorizer.feature_names,
+            tfidf_matrix  = skill_vectorizer.tfidf_matrix,
+            top_n         = 2
+        ):
             assert len(label.terms) <= 2
 
     # ---------------------------------------------------------
@@ -173,7 +190,7 @@ class TestHierarchicalClusterer:
         Title map substitutes document identifiers in leaf labels.
         """
         title_map = {doc: f"Title {i}" for i, doc in enumerate(clusterer.document_ids)}
-        data      = clusterer.dendrogram_data(title_map = title_map)
+        data = clusterer.dendrogram_data(title_map = title_map)
         assert all(label.startswith("Title ") for label in data["ivl"])
 
     # ---------------------------------------------------------
@@ -195,24 +212,28 @@ class TestHierarchicalClusterer:
         Per-posting silhouette array has one entry per posting.
         """
         n = len(clusterer.document_ids)
-        assert len(clusterer.silhouette_samples_) == n
+        assert len(clusterer.validation_metrics().silhouette_samples) == n
 
     def test_validity_metrics_populated(self, clusterer: HierarchicalClusterer):
         """
         Internal validity metrics are non-None when k >= 2.
         """
-        assert clusterer.calinski_harabasz is not None
-        assert clusterer.calinski_harabasz > 0
-        assert clusterer.davies_bouldin is not None
-        assert clusterer.davies_bouldin >= 0
-        assert clusterer.silhouette is not None
-        assert -1 <= clusterer.silhouette <= 1
+        metrics = clusterer.validation_metrics()
+        assert metrics.calinski_harabasz is not None
+        assert metrics.calinski_harabasz > 0
+        assert metrics.davies_bouldin is not None
+        assert metrics.davies_bouldin >= 0
+        assert metrics.silhouette is not None
+        assert -1 <= metrics.silhouette <= 1
 
     # ---------------------------------------------------------
     # Validate at K
     # ---------------------------------------------------------
 
-    @mark.parametrize("k", [2, 3])
+    @mark.parametrize("k", [
+        2,
+        3
+    ])
     def test_validate_at_k(self, clusterer: HierarchicalClusterer, k: int):
         """
         Assignments at a given K cover all postings and produce

--- a/tests/clustering/test_schemas.py
+++ b/tests/clustering/test_schemas.py
@@ -1,0 +1,158 @@
+"""
+Tests for clustering schemas.
+"""
+
+from pytest import mark, param, raises
+
+from chalkline.clustering.schemas import ClusterLabel
+from chalkline.clustering.schemas import ComparisonResult
+from chalkline.clustering.schemas import CopheneticResult
+
+
+class TestClusteringSchemas:
+    """
+    Validate field constraints and extra-field rejection across
+    clustering schema models.
+    """
+
+    # ---------------------------------------------------------
+    # ClusterLabel
+    # ---------------------------------------------------------
+
+    @mark.parametrize("kwargs, match", [
+        param(
+            {
+                "cluster_id"     : 0,
+                "extra_field"    : True,
+                "leader_node_id" : 0,
+                "size"           : 1,
+                "terms"          : ["welding"],
+                "weights"        : [0.5]
+            },
+            "Extra inputs",
+            id = "extra_field"
+        ),
+        param(
+            {
+                "cluster_id"     : -1,
+                "leader_node_id" : 0,
+                "size"           : 1,
+                "terms"          : ["welding"],
+                "weights"        : [0.5]
+            },
+            "greater than or equal",
+            id = "negative_cluster_id"
+        ),
+        param(
+            {
+                "cluster_id"     : 0,
+                "leader_node_id" : 0,
+                "size"           : 0,
+                "terms"          : ["welding"],
+                "weights"        : [0.5]
+            },
+            "greater than or equal",
+            id = "zero_size"
+        )
+    ])
+    def test_cluster_label_invalid(self, kwargs, match):
+        """
+        Invalid kwargs are rejected by Pydantic validation.
+        """
+        with raises(ValueError, match = match):
+            ClusterLabel(**kwargs)
+
+    def test_cluster_label_valid(self):
+        """
+        A well-formed label with matching terms and weights
+        validates successfully.
+        """
+        label = ClusterLabel(
+            cluster_id     = 1,
+            leader_node_id = 12,
+            size           = 5,
+            terms          = ["welding", "scaffolding"],
+            weights        = [0.8, 0.6]
+        )
+        assert label.cluster_id == 1
+        assert label.size == 5
+
+    # ---------------------------------------------------------
+    # ComparisonResult
+    # ---------------------------------------------------------
+
+    def test_comparison_result_extra_field(self):
+        """
+        Extra fields are rejected on ComparisonResult.
+        """
+        with raises(ValueError, match = "Extra inputs"):
+            ComparisonResult(
+                assignments = [0, 1],
+                extra       = True,
+                method      = "kmeans",
+                n_clusters  = 2
+            )
+
+    def test_comparison_result_negative_n_clusters(self):
+        """
+        Negative cluster counts are rejected by field validation.
+        """
+        with raises(ValueError, match = "greater than or equal"):
+            ComparisonResult(
+                assignments = [0, 1],
+                method      = "kmeans",
+                n_clusters  = -1
+            )
+
+    def test_comparison_result_valid(self):
+        """
+        A minimal result with required fields only validates.
+        """
+        result = ComparisonResult(
+            assignments = [0, 1, 0],
+            method      = "kmeans",
+            n_clusters  = 2
+        )
+        assert result.noise_count == 0
+        assert result.silhouette is None
+
+    def test_comparison_result_with_metrics(self):
+        """
+        Optional metric fields populate when provided.
+        """
+        result = ComparisonResult(
+            assignments       = [0, 1, -1],
+            calinski_harabasz = 10.5,
+            davies_bouldin    = 0.8,
+            method            = "dbscan",
+            n_clusters        = 2,
+            noise_count       = 1,
+            silhouette        = 0.35
+        )
+        assert result.calinski_harabasz == 10.5
+        assert result.noise_count == 1
+
+    # ---------------------------------------------------------
+    # CopheneticResult
+    # ---------------------------------------------------------
+
+    def test_cophenetic_result_extra_field(self):
+        """
+        Extra fields are rejected on CopheneticResult.
+        """
+        with raises(ValueError, match = "Extra inputs"):
+            CopheneticResult(
+                correlation = 0.85,
+                extra       = True,
+                method      = "ward"
+            )
+
+    def test_cophenetic_result_valid(self):
+        """
+        A cophenetic result within valid bounds validates.
+        """
+        result = CopheneticResult(
+            correlation = 0.85,
+            method      = "ward"
+        )
+        assert result.correlation == 0.85

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ Fixtures form a pipeline chain where each step's output is
 independently tappable by any test module:
 
     corpus → extracted_skills → skill_vectorizer → pca_reducer
+           ↘                                       ↓
+            sector_labels ← occupation_index    clustering
 
 Lexicon fixtures feed the extractor via the registry:
 
@@ -16,17 +18,20 @@ Lexicon fixtures feed the extractor via the registry:
 
 from json    import loads
 from pathlib import Path
-from pytest  import fixture
+from pytest  import fixture, FixtureRequest
 
-from chalkline.collection.schemas     import Posting
-from chalkline.extraction.lexicons    import LexiconRegistry
-from chalkline.extraction.loaders     import load_certifications, load_onet
-from chalkline.extraction.loaders     import load_osha, load_supplement
-from chalkline.extraction.occupations import OccupationIndex
-from chalkline.extraction.schemas     import Certification, OnetOccupation
-from chalkline.extraction.skills      import SkillExtractor
-from chalkline.extraction.vectorize   import SkillVectorizer
-from chalkline.reduction.pca          import PcaReducer
+from chalkline.clustering.comparison   import ClusterComparison
+from chalkline.clustering.hierarchical import compute_sector_labels
+from chalkline.clustering.hierarchical import HierarchicalClusterer
+from chalkline.collection.schemas      import Posting
+from chalkline.extraction.lexicons     import LexiconRegistry
+from chalkline.extraction.loaders      import load_certifications, load_onet
+from chalkline.extraction.loaders      import load_osha, load_supplement
+from chalkline.extraction.occupations  import OccupationIndex
+from chalkline.extraction.schemas      import Certification, OnetOccupation
+from chalkline.extraction.skills       import SkillExtractor
+from chalkline.extraction.vectorize    import SkillVectorizer
+from chalkline.reduction.pca           import PcaReducer
 
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -37,8 +42,8 @@ def _postings() -> list[Posting]:
     Load posting fixtures from JSON.
     """
     return [
-        Posting(**p)
-        for p in loads((FIXTURES / "collection/postings.json").read_text())
+        Posting(**raw)
+        for raw in loads((FIXTURES / "collection/postings.json").read_text())
     ]
 
 
@@ -102,11 +107,12 @@ def supplement_terms() -> list[str]:
 @fixture
 def corpus() -> dict[str, str]:
     """
-    Ten synthetic posting texts covering the fixture vocabulary.
+    Twenty synthetic posting texts covering the fixture vocabulary.
 
     Each posting targets a different skill cluster so downstream
     matrices have enough rank for `TruncatedSVD` and enough
-    variation for meaningful clustering and PMI.
+    variation for meaningful clustering, PMI, and DBSCAN density
+    estimation.
     """
     return {
         "posting-01" : "Fall protection and welding are required. "
@@ -128,7 +134,32 @@ def corpus() -> dict[str, str]:
         "posting-09" : "Electrician with laptop computers for "
                        "electrical wiring and electrical systems.",
         "posting-10" : "Equipment operators for concrete finishing "
-                       "and scaffolding. Fall protection certified."
+                       "and scaffolding. Fall protection certified.",
+        "posting-11" : "Blueprint reading and electrical wiring for "
+                       "commercial projects. Autodesk AutoCAD drafting.",
+        "posting-12" : "Electrical safety and electrical systems "
+                       "troubleshooting. Laptop computers for "
+                       "diagnostics and welding certification.",
+        "posting-13" : "Electrical wiring and scaffolding erection. "
+                       "Autodesk AutoCAD layouts and fall protection.",
+        "posting-14" : "Backhoe and excavation for site preparation. "
+                       "Operate construction equipment and building "
+                       "foundations.",
+        "posting-15" : "Concrete finishing and rebar placement. "
+                       "Spread concrete for foundations and "
+                       "excavation grading.",
+        "posting-16" : "Operate construction equipment for building "
+                       "foundations. Concrete finishing and spread "
+                       "concrete required.",
+        "posting-17" : "Welding inspection and weld quality control. "
+                       "Rigging hardware and fall protection on site.",
+        "posting-18" : "Asbestos abatement and electrical safety "
+                       "compliance. Scaffolding and fall protection.",
+        "posting-19" : "Load charts and rigging hardware for crane "
+                       "operations. Welding and scaffolding required.",
+        "posting-20" : "Concrete finishing and fall protection. "
+                       "Scaffolding and operate construction "
+                       "equipment on highway projects."
     }
 
 
@@ -201,8 +232,8 @@ def second_posting() -> Posting:
     return _postings()[1]
 
 
-@fixture(params=["47-2111", "47-2111.00"])
-def soc(request) -> str:
+@fixture(params = ["47-2111", "47-2111.00"])
+def soc(request: FixtureRequest) -> str:
     """
     Electrician SOC code in both bare and suffixed formats.
     """
@@ -234,3 +265,65 @@ def skill_vectorizer(extracted_skills: dict[str, list[str]]) -> SkillVectorizer:
     Build a vectorizer from extracted skill lists.
     """
     return SkillVectorizer(extracted_skills)
+
+
+# ---------------------------------------------------------------------
+# Clustering
+# ---------------------------------------------------------------------
+
+@fixture
+def comparison(pca_reducer: PcaReducer) -> ClusterComparison:
+    """
+    Build a comparison runner without sector labels.
+    """
+    return ClusterComparison(
+        coordinates = pca_reducer.coordinates,
+        random_seed = 42
+    )
+
+
+@fixture
+def comparison_with_sectors(
+    pca_reducer   : PcaReducer,
+    sector_labels : list[str]
+) -> ClusterComparison:
+    """
+    Build a comparison runner with sector labels for ARI.
+    """
+    return ClusterComparison(
+        coordinates   = pca_reducer.coordinates,
+        random_seed   = 42,
+        sector_labels = sector_labels
+    )
+
+
+@fixture
+def clusterer(
+    pca_reducer      : PcaReducer,
+    skill_vectorizer : SkillVectorizer
+) -> HierarchicalClusterer:
+    """
+    Build a hierarchical clusterer from the shared PCA reducer.
+    """
+    return HierarchicalClusterer(
+        coordinates   = pca_reducer.coordinates,
+        document_ids  = pca_reducer.document_ids,
+        feature_names = skill_vectorizer.feature_names,
+        tfidf_matrix  = skill_vectorizer.tfidf_matrix
+    )
+
+
+@fixture
+def sector_labels(
+    extracted_skills : dict[str, list[str]],
+    occupation_index : OccupationIndex,
+    pca_reducer      : PcaReducer
+) -> list[str]:
+    """
+    Sector labels aligned with PCA reducer document order.
+    """
+    return compute_sector_labels(
+        document_ids     = pca_reducer.document_ids,
+        extracted_skills = extracted_skills,
+        occupation_index = occupation_index
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from pytest  import fixture, FixtureRequest
 from chalkline.clustering.comparison   import ClusterComparison
 from chalkline.clustering.hierarchical import compute_sector_labels
 from chalkline.clustering.hierarchical import HierarchicalClusterer
+from chalkline.clustering.schemas      import ClusterLabel
 from chalkline.collection.schemas      import Posting
 from chalkline.extraction.lexicons     import LexiconRegistry
 from chalkline.extraction.loaders      import load_certifications, load_onet
@@ -232,7 +233,10 @@ def second_posting() -> Posting:
     return _postings()[1]
 
 
-@fixture(params = ["47-2111", "47-2111.00"])
+@fixture(params = [
+    "47-2111",
+    "47-2111.00"
+])
 def soc(request: FixtureRequest) -> str:
     """
     Electrician SOC code in both bare and suffixed formats.
@@ -298,18 +302,27 @@ def comparison_with_sectors(
 
 
 @fixture
-def clusterer(
-    pca_reducer      : PcaReducer,
+def cluster_labels(
+    clusterer        : HierarchicalClusterer,
     skill_vectorizer : SkillVectorizer
-) -> HierarchicalClusterer:
+) -> list[ClusterLabel]:
+    """
+    Cluster labels from TF-IDF centroid terms, shared across label tests.
+    """
+    return clusterer.labels(
+        feature_names = skill_vectorizer.feature_names,
+        tfidf_matrix  = skill_vectorizer.tfidf_matrix
+    )
+
+
+@fixture
+def clusterer(pca_reducer: PcaReducer) -> HierarchicalClusterer:
     """
     Build a hierarchical clusterer from the shared PCA reducer.
     """
     return HierarchicalClusterer(
-        coordinates   = pca_reducer.coordinates,
-        document_ids  = pca_reducer.document_ids,
-        feature_names = skill_vectorizer.feature_names,
-        tfidf_matrix  = skill_vectorizer.tfidf_matrix
+        coordinates  = pca_reducer.coordinates,
+        document_ids = pca_reducer.document_ids
     )
 
 

--- a/tests/extraction/test_skills.py
+++ b/tests/extraction/test_skills.py
@@ -83,12 +83,12 @@ class TestSkillExtractor:
     # Logging
     # ---------------------------------------------------------
 
-    def test_high_unmatched_rate_warns(self, extractor: SkillExtractor, caplog):
+    def test_high_unmatched_rate_warns(self, caplog, extractor: SkillExtractor):
         """
         A corpus with mostly unrecognized terms triggers a warning when the
         unmatched rate exceeds the 25% threshold.
         """
-        with caplog.at_level("WARNING", logger="chalkline.extraction.skills"):
+        with caplog.at_level("WARNING", logger = "chalkline.extraction.skills"):
             extractor.extract({
                 "a": "quantum computing blockchain artificial intelligence "
                      "machine learning deep neural networks cryptocurrency "
@@ -96,11 +96,11 @@ class TestSkillExtractor:
             })
         assert any("unmatched" in r.message.lower() for r in caplog.records)
 
-    def test_unmatched_terms_logged(self, extractor: SkillExtractor, caplog):
+    def test_unmatched_terms_logged(self, caplog, extractor: SkillExtractor):
         """
         Unmatched term diagnostics are logged at debug level.
         """
-        with caplog.at_level("DEBUG", logger="chalkline.extraction.skills"):
+        with caplog.at_level("DEBUG", logger = "chalkline.extraction.skills"):
             extractor.extract({
                 "a": "Fall protection and quantum computing required"
             })
@@ -158,9 +158,10 @@ class TestSkillExtractor:
         Filler phrases are blanked before matching so that terms within
         them do not produce false positives.
         """
-        assert "a" not in (result := extractor.extract({
+        result = extractor.extract({
             "a": "Must have years of experience with safety procedures"
-        })) or "experience" not in result.get("a", [])
+        })
+        assert "a" not in result or "experience" not in result.get("a", [])
 
     def test_semicolon_normalization(self, extractor: SkillExtractor):
         """
@@ -182,9 +183,7 @@ class TestSkillExtractor:
         assert "fall protection" in extractor.vocabulary
         assert "welding" in extractor.vocabulary
 
-    def test_vocabulary_supplement(
-        self, extractor: SkillExtractor
-    ):
+    def test_vocabulary_supplement(self, extractor: SkillExtractor):
         """
         Supplement lexicon terms appear in the extractor's vocabulary
         alongside OSHA and O*NET terms.
@@ -197,10 +196,10 @@ class TestSkillExtractor:
 
     def test_boundary_digit(self, extractor: SkillExtractor):
         """
-        Digits are alphanumeric, so a match abutting a digit is
-        rejected because `isalnum()` treats digits as word characters.
+        Digits not appearing in any lexicon pattern are treated as
+        separators, so a match abutting such a digit is valid.
         """
-        assert "welding" not in extractor.extract(
+        assert "welding" in extractor.extract(
             {"a": "3welding required on site"}
         ).get("a", [])
 


### PR DESCRIPTION
### 📐 Quick Summary

Implements hierarchical agglomerative clustering on PCA-reduced coordinates with average linkage[^27], cophenetic validation[^30], TF-IDF centroid labeling, ARI benchmarking[^24], and four comparison methods (*K-Means, DBSCAN, Mean Shift, HDBSCAN*). The spec called for Ward linkage, but a three-method cophenetic evaluation showed average linkage faithfully preserving the data's topology (*0.79 vs Ward's 0.43*), so the implementation uses average throughout.

Near-zero ARI against both the three-sector taxonomy and SOC codes prompted an extended investigation that revealed a **hub-and-spoke topology** where one large generalist core absorbs **800+** postings and trade-pure fringe clusters peel off at the periphery. Stakeholder feedback from Kelly Flagg (*Executive Director, AGC Maine*) confirmed this as the correct representation of construction career organization. See the [implementation comments](https://github.com/Jybbs/chalkline/issues/8) for the full investigation, evaluation tables, and next steps.

***

### 🧱 Key Changes

#### Clustering Modules

- Add `src/chalkline/clustering/hierarchical.py` with `HierarchicalClusterer` using average linkage[^27] with optimal leaf ordering, merge-height acceleration criterion for flat partition selection, three-method cophenetic comparison[^30], TF-IDF centroid labeling via `leaders()`, ARI benchmarking[^24], and internal validity metrics[^21][^20][^29]
- Add `src/chalkline/clustering/comparison.py` with `ClusterComparison` providing K-Means via `KneeLocator`[^26] elbow selection, DBSCAN[^22] via k-distance graph epsilon, Mean Shift[^28] with bandwidth estimation, and HDBSCAN[^25] with corpus-scaled `min_cluster_size`
- Add `src/chalkline/clustering/schemas.py` with `ClusterLabel`, `ComparisonResult`, `CopheneticResult`, and `ValidationMetrics` Pydantic models
- Add `compute_sector_labels()` mapping postings to Jaccard-nearest SOC codes for ARI evaluation

#### Extraction Preprocessing

- Refactor `SkillExtractor._preprocess` to strip non-pattern characters via a lexicon-derived character set, replacing the hardcoded bullet/semicolon regex with a pattern-aware filter that ensures word boundary checks are exact (*space or string edge*) rather than approximate (*`isalnum()`*)
- Add HTML tag stripping and entity unescaping for raw posting text
- Replace `ENGLISH_STOP_WORDS` with `wordfreq` frequency threshold for unmatched token diagnostics
- Normalize slash-separated skill terms in surface form generation

#### Tests

- Add `tests/clustering/test_hierarchical.py` with **23** tests covering linkage structure, cophenetic bounds, cluster assignments, centroid labels, dendrogram output, ARI, validity metrics, and post-hoc validation at arbitrary K
- Add `tests/clustering/test_comparison.py` with **17** tests covering all four methods, noise handling, sector ARI, validity bounds, and per-posting silhouette
- Add `tests/clustering/test_schemas.py` with **10** tests covering field constraints and extra-field rejection across all schema models
- Expand `tests/conftest.py` with clustering fixture chain and **20**-posting corpus (*up from 10*) for sufficient rank and density variation

***

## 🪚 Implementation Notes

### Linkage Method Evaluation

The spec prescribed Ward linkage, but a three-method cophenetic comparison showed Ward's **0.43** badly distorting the pairwise distance structure in PCA space, whereas average linkage's **0.79** faithfully preserves the data's topology. TF-IDF PCA coordinates produce elongated, non-spherical cluster shapes because trades share broad construction vocabulary in high-variance components and differ only in lower-variance ones, violating Ward's equal-variance assumption. `HierarchicalClusterer` uses `method="average"` throughout, superseding the Ward references in requirements 1-3.

### Hub-and-Spoke Topology

Near-zero ARI at every k from 2 through 8 prompted an investigation covering the PCA variance landscape, five clustering algorithms, alternative distance representations (*Jaccard, UMAP*), vocabulary diagnostics, and validation label quality. All paths converge on the same structure, namely one **836**-posting generalist core and **seven** trade-pure fringe clusters that remain stable across k values from 5 through 15. A **1,000**-iteration permutation test confirmed that the observed ARI falls below the **1.2** percentile of the null distribution, meaning the clustering is actively anti-aligned with the sector taxonomy rather than merely uncorrelated with it.

### Extraction Preprocessing Overhaul

The preprocessing pipeline was redesigned to improve extraction precision on the full corpus. The previous approach used a hardcoded regex for bullet and semicolon characters, leaving HTML entities, slashes, and other symbols to cause false word boundary matches. The new approach strips HTML tags, unescapes entities, then replaces any character not present in the lexicon patterns with a space, ensuring the automaton only encounters characters it can match against. This makes word boundary checks exact rather than approximate and eliminates a class of false positives that were inflating the feature space.

***

### 🔩 Related Issues

- Closes #8

***

### 📚 References

[^8]: Lukauskas, et al. 2023. "Enhancing Skills Demand Understanding through Job Ad Segmentation Using NLP and Clustering Techniques." *Applied Sciences* 13(10): 6119. https://doi.org/10.3390/app13106119

[^20]: Davies & Bouldin. 1979. "A Cluster Separation Measure." *IEEE Transactions on Pattern Analysis and Machine Intelligence* PAMI-1 (2): 224-227. https://doi.org/10.1109/TPAMI.1979.4766909

[^21]: Caliński & Harabasz. 1974. "A Dendrite Method for Cluster Analysis." *Communications in Statistics* 3 (1): 1-27. https://doi.org/10.1080/03610927408827101

[^22]: Ester, Kriegel, Sander & Xu. 1996. "A Density-Based Algorithm for Discovering Clusters in Large Spatial Databases with Noise." *KDD-96*: 226-231. https://dl.acm.org/doi/10.5555/3001460.3001507

[^24]: Hubert & Arabie. 1985. "Comparing Partitions." *Journal of Classification* 2(1): 193-218. https://doi.org/10.1007/BF01908075

[^25]: Campello, Moulavi & Sander. 2013. "Density-Based Clustering Based on Hierarchical Density Estimates." *PAKDD*: 160-172. https://doi.org/10.1007/978-3-642-37456-2_14

[^26]: Satopaa, Albrecht, Irwin & Raghavan. 2011. "Finding a 'Kneedle' in a Haystack: Detecting Knee Points in System Behavior." *ICDCS Workshops*: 166-171. https://doi.org/10.1109/ICDCSW.2011.20

[^27]: Ward. 1963. "Hierarchical Grouping to Optimize an Objective Function." *Journal of the American Statistical Association* 58(301): 236-244. https://doi.org/10.1080/01621459.1963.10500845

[^28]: Comaniciu & Meer. 2002. "Mean Shift: A Robust Approach Toward Feature Space Analysis." *IEEE Transactions on Pattern Analysis and Machine Intelligence* 24(5): 603-619. https://doi.org/10.1109/34.1000236

[^29]: Rousseeuw. 1987. "Silhouettes: A Graphical Aid to the Interpretation and Validation of Cluster Analysis." *Journal of Computational and Applied Mathematics* 20: 53-65. https://doi.org/10.1016/0377-0427(87)90125-7

[^30]: Sokal & Rohlf. 1962. "The Comparison of Dendrograms by Objective Methods." *Taxon* 11(2): 33-40. https://doi.org/10.2307/1217208
