### PR TITLE
CL-10: Implement resume matching with skill gap analysis and PMI gap ranking

### DIFF
--- a/src/chalkline/association/cooccurrence.py
+++ b/src/chalkline/association/cooccurrence.py
@@ -16,15 +16,11 @@ from functools                import cached_property
 from kneed                    import KneeLocator
 from logging                  import getLogger
 from math                     import ceil
-from scipy.sparse             import csc_array, csr_array, triu
+from scipy.sparse             import csc_array, csr_array, spmatrix, triu
 from scipy.special            import xlogy
-from typing                   import TYPE_CHECKING
 
 from chalkline.association.schemas import CommunityLabel
 from chalkline.association.schemas import GraphDiagnostics, MeasureComparison
-
-if TYPE_CHECKING:
-    from scipy.sparse import spmatrix
 
 
 logger = getLogger(__name__)
@@ -48,23 +44,23 @@ class CooccurrenceNetwork:
 
     def __init__(
         self,
-        binary_matrix   : "spmatrix",
-        feature_names   : list[str],
-        min_cooccurrence: float | str = "auto",
-        random_seed     : int         = 42
+        binary_matrix    : spmatrix,
+        feature_names    : list[str],
+        min_cooccurrence : float | str = "auto",
+        random_seed      : int         = 42
     ):
         """
         Compute the thresholded co-occurrence matrix.
 
         Args:
-            binary_matrix   : CSR binary presence/absence matrix from
-                              `SkillVectorizer.binary_matrix`.
-            feature_names   : Vocabulary in column order, matching
-                              matrix column indices.
-            min_cooccurrence: Either `"auto"` to select the threshold
-                              via modularity knee detection, or a float
-                              fraction of corpus size floored at 3.
-            random_seed     : Seed for Louvain reproducibility.
+            binary_matrix    : CSR binary presence/absence matrix from
+                               `SkillVectorizer.binary_matrix`.
+            feature_names    : Vocabulary in column order, matching
+                               matrix column indices.
+            min_cooccurrence : Either `"auto"` to select the threshold
+                               via modularity knee detection, or a float
+                               fraction of corpus size floored at 3.
+            random_seed      : Seed for Louvain reproducibility.
         """
         self.feature_names = feature_names
         self.n_docs        = binary_matrix.shape[0]
@@ -270,7 +266,7 @@ class CooccurrenceNetwork:
 
     def communities(
         self,
-        matrix: "spmatrix | None" = None
+        matrix: spmatrix | None = None
     ) -> list[CommunityLabel]:
         """
         Louvain community detection with weighted-degree labeling.
@@ -285,25 +281,22 @@ class CooccurrenceNetwork:
         """
         G = self.graph(matrix = matrix)
 
-        labels = []
-        for idx, members in enumerate(
-            sorted(
-                self._louvain(G),
-                key     = len,
-                reverse = True
-            )
-        ):
-            degrees = dict(G.subgraph(members).degree(weight = "weight"))
-            labels.append(CommunityLabel(
+        return [
+            CommunityLabel(
                 community_id        = idx,
                 size                = len(members),
                 top_skills          = sorted(
                     degrees, key = degrees.get, reverse = True
                 )[:3],
                 weighted_degree_sum = sum(degrees.values())
-            ))
-
-        return labels
+            )
+            for idx, members in enumerate(
+                sorted(self._louvain(G), key = len, reverse = True)
+            )
+            for degrees in [
+                dict(G.subgraph(members).degree(weight = "weight"))
+            ]
+        ]
 
     def compare_measures(self) -> list[MeasureComparison]:
         """
@@ -312,23 +305,22 @@ class CooccurrenceNetwork:
         Builds graphs from PPMI, NPMI, and G-test matrices and
         reports edge count, density, and community count for each.
         """
-        results = []
-        for name, matrix in [
-            ("ppmi",   self.ppmi_matrix),
-            ("npmi",   self.npmi_matrix),
-            ("g-test", self.gtest_matrix)
-        ]:
-            G = self.graph(matrix = matrix)
-            results.append(MeasureComparison(
+        return [
+            MeasureComparison(
                 density       = nx.density(G),
                 edge_count    = G.number_of_edges(),
                 measure       = name,
                 n_communities = len(
                     self._louvain(G)
                 ) if G.number_of_edges() > 0 else 0
-            ))
-
-        return results
+            )
+            for name, matrix in [
+                ("ppmi",   self.ppmi_matrix),
+                ("npmi",   self.npmi_matrix),
+                ("g-test", self.gtest_matrix)
+            ]
+            for G in [self.graph(matrix = matrix)]
+        ]
 
     def diagnostics(
         self,
@@ -348,8 +340,8 @@ class CooccurrenceNetwork:
         """
         G = graph or self.graph()
 
-        components = list(nx.connected_components(G))
-        isolates   = list(nx.isolates(G))
+        components    = list(nx.connected_components(G))
+        isolate_count = sum(1 for c in components if len(c) == 1)
 
         modularity  = None
         coverage    = 0.0
@@ -365,18 +357,18 @@ class CooccurrenceNetwork:
             )
 
         if G.number_of_nodes() > 0 and (
-            isolate_rate := len(isolates) / G.number_of_nodes()
+            isolate_rate := isolate_count / G.number_of_nodes()
         ) > 0.30:
             logger.warning(
                 f"{isolate_rate:.0%} of skills are isolate nodes "
-                f"({len(isolates)} of {G.number_of_nodes()})"
+                f"({isolate_count} of {G.number_of_nodes()})"
             )
 
         return GraphDiagnostics(
             connected_components = len(components),
             coverage             = coverage,
             edge_count           = G.number_of_edges(),
-            isolate_count        = len(isolates),
+            isolate_count        = isolate_count,
             largest_component    = max(
                 (len(c) for c in components), default = 0
             ),
@@ -387,7 +379,7 @@ class CooccurrenceNetwork:
 
     def graph(
         self,
-        matrix: "spmatrix | None" = None
+        matrix: spmatrix | None = None
     ) -> nx.Graph:
         """
         Build a NetworkX graph from a sparse weight matrix.
@@ -399,11 +391,13 @@ class CooccurrenceNetwork:
             matrix: Optional sparse weight matrix to override the
                     default NPMI matrix.
         """
-        G = nx.from_scipy_sparse_array(
-            matrix if matrix is not None else self.npmi_matrix,
-            edge_attribute = "weight"
+        return nx.relabel_nodes(
+            nx.from_scipy_sparse_array(
+                matrix if matrix is not None else self.npmi_matrix,
+                edge_attribute = "weight"
+            ),
+            dict(enumerate(self.feature_names))
         )
-        return nx.relabel_nodes(G, dict(enumerate(self.feature_names)))
 
     def pmi_dataframe(self) -> pd.DataFrame:
         """

--- a/src/chalkline/matching/matcher.py
+++ b/src/chalkline/matching/matcher.py
@@ -1,0 +1,421 @@
+"""
+Resume matching with skill gap analysis and PMI-based gap ranking.
+
+Projects an uploaded resume into the fitted PCA space, matches it to
+the nearest career family via cluster centroids, identifies skill gaps
+from neighboring postings, and ranks gaps by PPMI relevance scoped to
+the matched cluster's TF-IDF centroid terms. Cross-references gaps
+against AGC apprenticeship programs and educational programs for
+actionable recommendations.
+"""
+
+import numpy  as np
+import pandas as pd
+
+from sklearn.neighbors import NearestNeighbors
+from sklearn.pipeline  import Pipeline
+
+from chalkline.clustering.schemas import ClusterLabel
+from chalkline.matching.schemas   import ClusterDistance, MatchResult
+from chalkline.matching.schemas   import NeighborMatch, RankedGap
+from chalkline.pipeline.schemas   import ApprenticeshipContext
+from chalkline.pipeline.schemas   import DistanceMetric, ProgramRecommendation
+
+
+# -------------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------------
+
+def _prefix_set(text: str) -> set[str]:
+    """
+    Extract 4-character word prefixes from text.
+
+    Filters to words of 4+ characters and truncates to 4-char
+    prefixes, catching inflectional variants across the
+    construction domain (welding/welder, electrical/electrician,
+    scaffolding/scaffold).
+    """
+    return {w[:4] for w in text.lower().split() if len(w) >= 4}
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    """
+    Jaccard similarity between two skill sets.
+
+        J(A, B) = |A ∩ B| / |A ∪ B|
+
+    Returns 0.0 when both sets are empty to guard against
+    division by zero.
+    """
+    union = a | b
+    return len(a & b) / len(union) if union else 0.0
+
+
+# -------------------------------------------------------------------------
+# Matcher
+# -------------------------------------------------------------------------
+
+class ResumeMatcher:
+    """
+    Resume projection into fitted PCA space with cluster matching
+    and PPMI gap ranking.
+
+    Receives fitted pipeline artifacts, computes cluster centroids,
+    and exposes a `match()` method that projects a resume's skill
+    list into the shared coordinate space, assigns it to the nearest
+    career family, identifies skill gaps from neighboring postings,
+    and ranks gaps by centroid-scoped mean PPMI relevance.
+    """
+
+    def __init__(
+        self,
+        apprenticeships   : list[dict],
+        assignments       : np.ndarray,
+        cluster_labels    : list[ClusterLabel],
+        coordinates       : np.ndarray,
+        distance_metric   : DistanceMetric,
+        document_ids      : list[str],
+        extracted_skills  : dict[str, list[str]],
+        geometry_pipeline : Pipeline,
+        ppmi_df           : pd.DataFrame,
+        programs          : list[ProgramRecommendation],
+        top_k_gaps        : int
+    ):
+        """
+        Compute cluster centroids and fit nearest-neighbor models.
+
+        The geometry pipeline must be a fitted sklearn `Pipeline`
+        chaining `DictVectorizer`, `TfidfTransformer`, `Normalizer`,
+        `TruncatedSVD`, and `StandardScaler` so that a single
+        `transform([skill_dict])` call projects a resume into the
+        shared PCA space without refitting.
+
+        Args:
+            apprenticeships   : Raw dicts from `apprenticeships.json`
+                                with `title`, `rapids_code`, and
+                                `term_hours` keys.
+            assignments       : Cluster ID per posting from
+                                `HierarchicalClusterer.assignments`.
+            cluster_labels    : TF-IDF centroid labels with terms per
+                                cluster for PPMI scoping (top-50
+                                recommended).
+            coordinates       : PCA-scaled posting coordinates of
+                                shape `(n_postings, n_selected)`.
+            distance_metric   : Distance function for neighbor
+                                queries.
+            document_ids      : Posting identifiers in matrix row
+                                order.
+            extracted_skills  : Mapping from document identifier to
+                                sorted canonical skill names.
+            geometry_pipeline : Fitted sklearn `Pipeline` chaining
+                                vectorization through scaling.
+            ppmi_df           : Symmetric PPMI DataFrame indexed by
+                                canonical skill names.
+            programs          : Normalized educational program records
+                                from `load_programs`.
+            top_k_gaps        : Default number of ranked gaps to
+                                return.
+        """
+        self.assignments       = assignments
+        self.coordinates       = coordinates
+        self.document_ids      = document_ids
+        self.extracted_skills  = extracted_skills
+        self.geometry_pipeline = geometry_pipeline
+        self.ppmi_df           = ppmi_df
+        self.programs          = programs
+        self.top_k_gaps        = top_k_gaps
+
+        self._skill_sets = {
+            doc: set(skills)
+            for doc, skills in extracted_skills.items()
+        }
+
+        self._metric = (
+            "cosine" if distance_metric == DistanceMetric.COSINE
+            else "euclidean"
+        )
+
+        centroids_df     = pd.DataFrame(coordinates).groupby(assignments).mean()
+        self.cluster_ids = centroids_df.index.to_numpy()
+
+        self._centroid_nn = NearestNeighbors(
+            metric      = self._metric,
+            n_neighbors = len(self.cluster_ids)
+        ).fit(centroids_df.values)
+
+        self._centroid_scope = {
+            label.cluster_id: set(label.terms)
+            for label in cluster_labels
+        }
+
+        self._apprenticeship_models = [
+            ApprenticeshipContext(
+                rapids_code = a["rapids_code"],
+                term_hours  = a["term_hours"],
+                trade       = a["title"]
+            )
+            for a in apprenticeships
+        ]
+
+        self._trade_prefixes = {
+            a.rapids_code: _prefix_set(a.trade)
+            for a in self._apprenticeship_models
+        }
+        self._program_prefixes = {
+            (p.institution, p.program): _prefix_set(p.program)
+            for p in self.programs
+        }
+
+    # -----------------------------------------------------------------
+    # Private methods
+    # -----------------------------------------------------------------
+
+    def _find_apprenticeships(self, skill: str) -> list[ApprenticeshipContext]:
+        """
+        Find apprenticeship trades matching a skill via word-root
+        overlap.
+        """
+        prefixes = _prefix_set(skill)
+        return [
+            a for a in self._apprenticeship_models
+            if prefixes & self._trade_prefixes[a.rapids_code]
+        ]
+
+    def _find_programs(self, skill: str) -> list[ProgramRecommendation]:
+        """
+        Find educational programs matching a skill via word-root
+        overlap with the program name.
+        """
+        prefixes = _prefix_set(skill)
+        return [
+            p for p in self.programs
+            if prefixes & self._program_prefixes[p.institution, p.program]
+        ]
+
+    def _nearest_in_family(
+        self,
+        cluster_id : int,
+        coords     : np.ndarray,
+        resume_set : set[str]
+    ) -> list[NeighborMatch]:
+        """
+        Find the top nearest-neighbor postings within a cluster,
+        falling back to Jaccard-ranked corpus neighbors when the
+        cluster is too small.
+
+        When the assigned cluster has 5+ postings, neighbors are
+        found by PCA-space distance within the family. When the
+        cluster is smaller, PCA distances are unreliable because
+        the sparse feature space concentrates all postings near
+        the origin, so the search falls back to Jaccard similarity
+        on discrete skill sets across the full corpus. This
+        produces skill-relevant neighbors even when the geometric
+        representation lacks discriminative power.
+        """
+        indices = np.nonzero(self.assignments == cluster_id)[0]
+
+        if len(indices) >= 5:
+            family_docs = [self.document_ids[i] for i in indices]
+            nn = NearestNeighbors(
+                metric      = self._metric,
+                n_neighbors = min(5, len(family_docs))
+            ).fit(self.coordinates[indices])
+            distances, nn_indices = nn.kneighbors(coords)
+
+            return [
+                NeighborMatch(
+                    distance    = float(dist),
+                    document_id = doc,
+                    jaccard     = jaccard(
+                        resume_set, self._skill_sets[doc]
+                    ),
+                    skills      = self.extracted_skills[doc]
+                )
+                for dist, idx in zip(distances[0], nn_indices[0])
+                for doc in [family_docs[idx]]
+            ]
+
+        scored = sorted(
+            (
+                (doc, jaccard(resume_set, skill_set))
+                for doc, skill_set in self._skill_sets.items()
+            ),
+            key     = lambda pair: pair[1],
+            reverse = True
+        )[:5]
+
+        return [
+            NeighborMatch(
+                distance    = 1.0 - sim,
+                document_id = doc,
+                jaccard     = sim,
+                skills      = self.extracted_skills[doc]
+            )
+            for doc, sim in scored
+            if sim > 0
+        ]
+
+    def _rank_gaps(
+        self,
+        cluster_id : int,
+        resume_set : set[str],
+        skill_gaps : list[str],
+        top_k      : int
+    ) -> tuple[list[RankedGap], list[str]]:
+        """
+        Rank skill gaps by centroid-scoped mean PPMI relevance.
+
+            relevance(g) = (1 / |S_r|) · Σ PPMI(g, s)  for s ∈ S_r
+
+        where S_r is the resume's existing skills restricted to the
+        cluster's centroid scope. Skills outside the centroid scope
+        fall back to the full PPMI matrix. Skills absent from the
+        PPMI index or with zero mean relevance are returned as
+        unrankable.
+
+        Relevance scores are computed via vectorized DataFrame
+        operations across two groups (centroid-scoped and unscoped)
+        rather than per-gap label lookups. Enrichment with
+        apprenticeship and program annotations is deferred until
+        after the top-k selection to avoid wasted lookups on
+        gaps that will be discarded.
+
+        Args:
+            cluster_id : Assigned cluster for centroid scoping.
+            resume_set : Resume skill names as a set.
+            skill_gaps : Sorted list of gap skill names.
+            top_k      : Maximum number of ranked gaps to return.
+        """
+        centroid_scope = self._centroid_scope.get(cluster_id, set())
+        all_ref        = resume_set & set(self.ppmi_df.columns)
+
+        if not all_ref:
+            return [], sorted(skill_gaps)
+
+        valid_set   = set(self.ppmi_df.index)
+        valid       = [g for g in skill_gaps if g in valid_set]
+        invalid_set = set(skill_gaps) - set(valid)
+
+        if not valid:
+            return [], sorted(invalid_set)
+
+        scoped_ref  = all_ref & centroid_scope
+        scoped_cols = list(scoped_ref) if scoped_ref else list(all_ref)
+        full_cols   = list(all_ref)
+
+        in_scope  = [g for g in valid if g in centroid_scope]
+        out_scope = [g for g in valid if g not in centroid_scope]
+
+        parts = []
+        if in_scope:
+            parts.append(
+                self.ppmi_df.loc[in_scope, scoped_cols].mean(axis = 1)
+            )
+        if out_scope:
+            parts.append(
+                self.ppmi_df.loc[out_scope, full_cols].mean(axis = 1)
+            )
+
+        relevances = pd.concat(parts)
+        positive   = relevances[relevances > 0].nlargest(top_k)
+
+        unrankable = sorted(
+            invalid_set | (set(valid) - set(positive.index))
+        )
+
+        ranked = [
+            RankedGap(
+                apprenticeships = self._find_apprenticeships(gap),
+                programs        = self._find_programs(gap),
+                relevance       = float(rel),
+                skill           = gap
+            )
+            for gap, rel in positive.items()
+        ]
+
+        return ranked, unrankable
+
+    # -----------------------------------------------------------------
+    # Public methods
+    # -----------------------------------------------------------------
+
+    def match(
+        self,
+        resume_skills : list[str],
+        top_k         : int | None = None
+    ) -> MatchResult:
+        """
+        Project a resume into PCA space and match to career families.
+
+        Converts the resume's canonical skill names to a binary dict,
+        projects through the fitted geometry pipeline, assigns to the
+        nearest cluster centroid, finds top-5 neighbors within the
+        cluster, computes skill gaps, ranks gaps by PPMI relevance,
+        and cross-references gaps against apprenticeship and
+        educational program reference data.
+
+        Args:
+            resume_skills : Sorted canonical skill names from
+                            `SkillExtractor.extract()`.
+            top_k         : Override for the default `top_k_gaps`.
+                            Returns at most this many ranked gaps.
+        """
+        coords = self.geometry_pipeline.transform(
+            [dict.fromkeys(resume_skills, 1)]
+        )
+
+        distances, indices = self._centroid_nn.kneighbors(coords)
+        cluster_id = int(self.cluster_ids[indices[0, 0]])
+
+        cluster_distances = [
+            ClusterDistance(
+                cluster_id = int(self.cluster_ids[idx]),
+                distance   = float(dist)
+            )
+            for dist, idx in zip(distances[0], indices[0])
+        ]
+
+        resume_set = set(resume_skills)
+        neighbors  = self._nearest_in_family(
+            cluster_id = cluster_id,
+            coords     = coords,
+            resume_set = resume_set
+        )
+
+        skill_gaps = sorted(
+            {skill for n in neighbors for skill in n.skills}
+            - resume_set
+        )
+        ranked_gaps, unrankable = self._rank_gaps(
+            cluster_id = cluster_id,
+            resume_set = resume_set,
+            skill_gaps = skill_gaps,
+            top_k      = top_k if top_k is not None else self.top_k_gaps
+        )
+
+        seen_trades          = set()
+        seen_programs        = set()
+        all_apprenticeships  = []
+        all_programs         = []
+
+        for gap in ranked_gaps:
+            for a in gap.apprenticeships:
+                if a.rapids_code not in seen_trades:
+                    seen_trades.add(a.rapids_code)
+                    all_apprenticeships.append(a)
+            for p in gap.programs:
+                if (p.institution, p.program) not in seen_programs:
+                    seen_programs.add((p.institution, p.program))
+                    all_programs.append(p)
+
+        return MatchResult(
+            cluster_distances = cluster_distances,
+            cluster_id        = cluster_id,
+            nearest_neighbors = neighbors,
+            programs          = all_programs,
+            ranked_gaps       = ranked_gaps,
+            resume_skills     = sorted(resume_skills),
+            skill_gaps        = skill_gaps,
+            trade_paths       = all_apprenticeships,
+            unrankable_gaps   = unrankable
+        )

--- a/src/chalkline/matching/schemas.py
+++ b/src/chalkline/matching/schemas.py
@@ -1,0 +1,83 @@
+"""
+Data models for resume matching results.
+
+Captures cluster assignments, nearest-neighbor postings with Jaccard
+similarities, and ranked skill gaps with apprenticeship and educational
+program enrichment annotations.
+"""
+
+from pydantic import BaseModel, Field
+
+from chalkline.pipeline.schemas import ApprenticeshipContext
+from chalkline.pipeline.schemas import ProgramRecommendation
+
+
+class ClusterDistance(BaseModel, extra="forbid"):
+    """
+    Distance from the resume to a single cluster centroid.
+
+    Provides both the cluster identifier and the geometric distance
+    in PCA space, enabling the career report to show proximity to
+    all career families rather than only the assigned one.
+    """
+
+    cluster_id : int = Field(ge = 0)
+    distance   : float
+
+
+class NeighborMatch(BaseModel, extra="forbid"):
+    """
+    A single nearest-neighbor posting within the assigned career
+    family.
+
+    Carries both the geometric distance in PCA space and the
+    Jaccard similarity on discrete skill sets, giving two
+    complementary views of how closely the resume resembles the
+    posting.
+    """
+
+    distance    : float
+    document_id : str
+    jaccard     : float = Field(ge = 0, le = 1)
+    skills      : list[str]
+
+
+class RankedGap(BaseModel, extra="forbid"):
+    """
+    A single skill gap ranked by PPMI relevance to the resume.
+
+    The relevance score is the mean PPMI between the gap skill and
+    the resume's existing skills, scoped to the matched cluster's
+    TF-IDF centroid terms. Apprenticeship and program annotations
+    provide actionable next steps when the gap aligns with a known
+    training pathway.
+    """
+
+    relevance : float
+    skill     : str
+
+    apprenticeships : list[ApprenticeshipContext] = Field(default_factory = list)
+    programs        : list[ProgramRecommendation] = Field(default_factory = list)
+
+
+class MatchResult(BaseModel, extra="forbid"):
+    """
+    Full result of projecting a resume into PCA space and matching
+    to career families.
+
+    Captures the nearest career family, distances to all clusters,
+    top-5 nearest postings with Jaccard scores, the raw skill gap,
+    PPMI-ranked gaps with enrichment annotations, and aggregate
+    apprenticeship and program recommendations across all gaps.
+    """
+
+    cluster_distances : list[ClusterDistance]
+    cluster_id        : int = Field(ge = 0)
+    nearest_neighbors : list[NeighborMatch]
+    resume_skills     : list[str]
+    skill_gaps        : list[str]
+
+    programs        : list[ProgramRecommendation] = Field(default_factory = list)
+    ranked_gaps     : list[RankedGap]             = Field(default_factory = list)
+    trade_paths     : list[ApprenticeshipContext] = Field(default_factory = list)
+    unrankable_gaps : list[str]                   = Field(default_factory = list)

--- a/src/chalkline/pipeline/programs.py
+++ b/src/chalkline/pipeline/programs.py
@@ -1,0 +1,70 @@
+"""
+Shared educational program loader with field normalization.
+
+Loads community college degree programs, statewide workforce
+initiatives, and university programs from stakeholder reference data,
+normalizing all three into a consistent `ProgramRecommendation`
+schema. Consumed by resume matching, career pathway construction,
+and report generation.
+"""
+
+from json    import loads
+from pathlib import Path
+
+from chalkline.pipeline.schemas import ProgramRecommendation
+
+
+def load_programs(reference_dir: Path) -> list[ProgramRecommendation]:
+    """
+    Load and normalize educational programs from stakeholder
+    reference data.
+
+    Reads three source types from `cc_programs.json` and
+    `umaine_programs.json`, normalizing each into the unified
+    `ProgramRecommendation` schema:
+
+    - CC degree programs (`college` to `institution`, `credential`
+      kept as-is)
+    - CC workforce initiatives (`initiative` to `program`,
+      `best_for` to `credential`, institution set to `"Statewide"`)
+    - UMaine system programs (`campus` to `institution`, `degree`
+      to `credential`)
+
+    Initiatives without a URL are included with an empty string
+    because they still carry actionable program descriptions in
+    the `best_for` field.
+
+    Args:
+        reference_dir: Path to `data/stakeholder/reference/`.
+    """
+    programs: list[ProgramRecommendation] = []
+
+    if (cc_path := reference_dir / "cc_programs.json").exists():
+        cc_data = loads(cc_path.read_text())
+
+        for entry in cc_data.get("degrees", []):
+            programs.append(ProgramRecommendation(
+                credential  = entry["credential"],
+                institution = entry["college"],
+                program     = entry["program"],
+                url         = entry["url"]
+            ))
+
+        for entry in cc_data.get("initiatives", []):
+            programs.append(ProgramRecommendation(
+                credential  = entry["best_for"],
+                institution = "Statewide",
+                program     = entry["initiative"],
+                url         = entry.get("url", "")
+            ))
+
+    if (umaine_path := reference_dir / "umaine_programs.json").exists():
+        for entry in loads(umaine_path.read_text()):
+            programs.append(ProgramRecommendation(
+                credential  = entry["degree"],
+                institution = entry["campus"],
+                program     = entry["program"],
+                url         = entry["url"]
+            ))
+
+    return programs

--- a/src/chalkline/pipeline/schemas.py
+++ b/src/chalkline/pipeline/schemas.py
@@ -1,9 +1,9 @@
 """
-Pipeline configuration with validated parameters.
+Pipeline configuration and shared reference data schemas.
 
-Centralizes directory paths, thresholds, and hyperparameters that propagate
-through every pipeline step. The `extra="forbid"` policy surfaces typos and
-stale fields immediately.
+Centralizes pipeline hyperparameters alongside shared data models for
+apprenticeship and educational program reference data consumed across
+matching, pathways, and report generation modules.
 """
 
 from enum     import StrEnum
@@ -11,6 +11,19 @@ from pathlib  import Path
 from pydantic import BaseModel
 
 from chalkline import UnitInterval
+
+
+class ApprenticeshipContext(BaseModel, extra="forbid"):
+    """
+    AGC-registered apprenticeship program linked to a skill gap.
+
+    Maps a gap skill to a RAPIDS-coded trade with term hours,
+    providing a concrete training timeline for skill acquisition.
+    """
+
+    rapids_code : str
+    term_hours  : str
+    trade       : str
 
 
 class DistanceMetric(StrEnum):
@@ -48,3 +61,19 @@ class PipelineConfig(BaseModel, extra="forbid"):
     reference_dir      : Path           = Path("data/stakeholder/reference")
     top_k_gaps         : int            = 10
     variance_threshold : UnitInterval   = 0.85
+
+
+class ProgramRecommendation(BaseModel, extra="forbid"):
+    """
+    Normalized educational program recommendation.
+
+    Unifies community college programs (where the institution field
+    is `college` and credential is `credential`) and university
+    programs (where institution is `campus` and credential is
+    `degree`) into a consistent schema.
+    """
+
+    credential  : str
+    institution : str
+    program     : str
+    url         : str

--- a/tests/association/test_apriori.py
+++ b/tests/association/test_apriori.py
@@ -5,8 +5,7 @@ Validates rule generation, support threshold behavior, and Jaccard
 overlap computation using the synthetic 20-posting fixture chain.
 """
 
-from chalkline.association.apriori      import AprioriComparison
-from chalkline.association.cooccurrence import CooccurrenceNetwork
+from chalkline.association.apriori import AprioriComparison
 
 
 class TestAprioriComparison:
@@ -17,15 +16,6 @@ class TestAprioriComparison:
     # ---------------------------------------------------------
     # Rules
     # ---------------------------------------------------------
-
-    def test_mine_valid(self, apriori: AprioriComparison):
-        """
-        Mining produces an AprioriResult with non-negative counts.
-        """
-        result = apriori.mine()
-        assert result.n_itemsets >= 0
-        assert result.n_rules >= 0
-        assert result.min_support > 0
 
     def test_rules_are_pairs(self, apriori: AprioriComparison):
         """
@@ -39,16 +29,6 @@ class TestAprioriComparison:
             assert len(rule["consequents"]) >= 1
             assert len(set(rule["antecedents"]) | set(rule["consequents"])) >= 2
 
-    def test_rules_have_metrics(self, apriori: AprioriComparison):
-        """
-        Each rule in the summary has support, confidence, and lift.
-        """
-        result = apriori.mine()
-        for rule in result.rules_summary:
-            assert "support" in rule
-            assert "confidence" in rule
-            assert "lift" in rule
-
     def test_support_monotonic(self, apriori: AprioriComparison):
         """
         Lowering the support threshold increases or maintains the
@@ -57,24 +37,3 @@ class TestAprioriComparison:
         high = apriori.mine(min_support = 0.30)
         low  = apriori.mine(min_support = 0.05)
         assert low.n_itemsets >= high.n_itemsets
-
-    # ---------------------------------------------------------
-    # Overlap
-    # ---------------------------------------------------------
-
-    def test_overlap_bounded(
-        self,
-        apriori : AprioriComparison,
-        network : CooccurrenceNetwork
-    ):
-        """
-        Jaccard overlap is bounded to [0, 1].
-        """
-        names      = network.feature_names
-        rows, cols = network.ppmi_matrix.nonzero()
-        pairs = {
-            (names[r], names[c])
-            for r, c in zip(rows, cols)
-            if r < c
-        }
-        assert 0 <= apriori.overlap(pairs) <= 1

--- a/tests/association/test_cooccurrence.py
+++ b/tests/association/test_cooccurrence.py
@@ -6,7 +6,10 @@ construction, community detection, and diagnostic reporting using
 the synthetic 20-posting fixture chain.
 """
 
-import logging
+import numpy as np
+
+from logging import WARNING
+from pytest  import LogCaptureFixture
 
 from chalkline.association.cooccurrence import CooccurrenceNetwork
 from chalkline.extraction.vectorize     import SkillVectorizer
@@ -73,21 +76,48 @@ class TestCooccurrenceNetwork:
             assert npmi.data.min() >= 0
             assert npmi.data.max() <= 1.0 + 1e-10
 
-    def test_npmi_capped_at_one(self, network: CooccurrenceNetwork):
+    def test_npmi_formula(self, network: CooccurrenceNetwork):
         """
-        NPMI values never exceed 1.0, even for pairs that
-        co-occur in every document where either skill appears.
+        NPMI for a known pair equals the manual formula, catching
+        data-ordering mismatches between PMI and co-occurrence
+        sparse arrays that would silently corrupt all downstream
+        graph weights and gap ranking.
+
+        Picks the first nonzero entry and computes:
+
+            NPMI = clip(PMI / -log(C_xy / n), 0, 1)
         """
         npmi = network.npmi_matrix
-        if npmi.nnz > 0:
-            assert npmi.data.max() <= 1.0
+        if npmi.nnz == 0:
+            return
 
-    def test_pmi_has_entries(self, network: CooccurrenceNetwork):
+        rows, cols = npmi.nonzero()
+        r, c       = int(rows[0]), int(cols[0])
+
+        c_xy  = float(network.cooccurrence[r, c])
+        n     = float(network.n_docs)
+        df_r  = float(network.doc_freq[r])
+        df_c  = float(network.doc_freq[c])
+
+        pmi_val   = np.log(n * c_xy / (df_r * df_c))
+        denom_val = np.log(n / c_xy)
+        expected  = (
+            max(0.0, min(1.0, pmi_val / denom_val))
+            if denom_val > 0 else 1.0
+        )
+
+        assert abs(float(npmi[r, c]) - expected) < 1e-10
+
+    def test_pmi_symmetric(self, network: CooccurrenceNetwork):
         """
-        PMI matrix has nonzero entries when co-occurrences exist.
+        Raw PMI matrix is symmetric. Asymmetry would be masked by
+        NPMI positive clipping but would corrupt PPMI values for
+        pairs where only one direction has positive PMI.
         """
-        if network.cooccurrence.nnz > 0:
-            assert network.pmi_matrix.nnz > 0
+        pmi  = network.pmi_matrix
+        diff = pmi - pmi.T
+        if diff.nnz > 0:
+            assert abs(diff.data).max() < 1e-10
 
     def test_ppmi_nonnegative(self, network: CooccurrenceNetwork):
         """
@@ -112,6 +142,18 @@ class TestCooccurrenceNetwork:
             == network.graph().number_of_edges()
         )
 
+    def test_gtest_no_nan(self, network: CooccurrenceNetwork):
+        """
+        No NaN or inf values in the G-test matrix. A negative
+        contingency cell from a co-occurrence or doc-frequency
+        mismatch would produce NaN via `xlogy` that silently
+        propagates through graph weights and community detection.
+        """
+        G = network.gtest_matrix
+        if G.nnz > 0:
+            assert not np.any(np.isnan(G.data))
+            assert not np.any(np.isinf(G.data))
+
     def test_gtest_nonnegative(self, network: CooccurrenceNetwork):
         """
         G-test statistics are non-negative because they are
@@ -133,42 +175,12 @@ class TestCooccurrenceNetwork:
     # Graph
     # ---------------------------------------------------------
 
-    def test_edge_weights_positive(self, network: CooccurrenceNetwork):
-        """
-        All NPMI graph edge weights are positive.
-        """
-        assert all(
-            w > 0 for _, _, w in network.graph().edges(data = "weight")
-        )
-
-    def test_graph_undirected(self, network: CooccurrenceNetwork):
-        """
-        Co-occurrence graph is undirected.
-        """
-        assert not network.graph().is_directed()
-
     def test_node_names_strings(self, network: CooccurrenceNetwork):
         """
         Graph nodes are canonical skill name strings, not integer
         indices.
         """
         assert all(isinstance(node, str) for node in network.graph().nodes())
-
-    def test_threshold_changes_edges(self, vectorizer: SkillVectorizer):
-        """
-        Changing the co-occurrence threshold changes the edge count.
-        """
-        loose = CooccurrenceNetwork(
-            binary_matrix    = vectorizer.binary_matrix,
-            feature_names    = vectorizer.feature_names,
-            min_cooccurrence = 0.01
-        )
-        strict = CooccurrenceNetwork(
-            binary_matrix    = vectorizer.binary_matrix,
-            feature_names    = vectorizer.feature_names,
-            min_cooccurrence = 0.50
-        )
-        assert loose.graph().number_of_edges() != strict.graph().number_of_edges()
 
     def test_zero_edge_graceful(self, vectorizer: SkillVectorizer):
         """
@@ -193,15 +205,6 @@ class TestCooccurrenceNetwork:
     # ---------------------------------------------------------
     # Communities
     # ---------------------------------------------------------
-
-    def test_community_labels_strings(self, network: CooccurrenceNetwork):
-        """
-        Community top skills are human-readable strings, not
-        numeric indices.
-        """
-        for label in network.communities():
-            assert all(isinstance(s, str) for s in label.top_skills)
-            assert all(not s.isdigit() for s in label.top_skills)
 
     def test_community_reproducible(self, vectorizer: SkillVectorizer):
         """
@@ -233,7 +236,11 @@ class TestCooccurrenceNetwork:
     # Diagnostics
     # ---------------------------------------------------------
 
-    def test_diagnostics_isolate_warning(self, vectorizer: SkillVectorizer, caplog):
+    def test_diagnostics_isolate_warning(
+        self,
+        caplog     : LogCaptureFixture,
+        vectorizer : SkillVectorizer
+    ):
         """
         A high-threshold network where most skills are isolates
         triggers the 30% isolate warning.
@@ -243,25 +250,9 @@ class TestCooccurrenceNetwork:
             feature_names    = vectorizer.feature_names,
             min_cooccurrence = 0.50
         )
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(WARNING):
             sparse.diagnostics()
         assert any("isolate nodes" in msg for msg in caplog.messages)
-
-    def test_diagnostics_populated(self, network: CooccurrenceNetwork):
-        """
-        Diagnostic fields are populated with plausible values,
-        including community quality metrics when edges exist.
-        """
-        diag = network.diagnostics()
-        assert diag.node_count > 0
-        assert diag.edge_count >= 0
-        assert diag.connected_components >= 0
-        assert diag.isolate_count >= 0
-        assert diag.largest_component >= 0
-        if diag.edge_count > 0:
-            assert diag.modularity is not None
-            assert 0.0 <= diag.coverage <= 1.0
-            assert 0.0 <= diag.performance <= 1.0
 
     # ---------------------------------------------------------
     # Measure comparison
@@ -287,19 +278,3 @@ class TestCooccurrenceNetwork:
         assert list(df.index) == list(df.columns)
         assert list(df.index) == network.feature_names
         assert (df.values == df.values.T).all()
-
-    # ---------------------------------------------------------
-    # Trade alignment
-    # ---------------------------------------------------------
-
-    def test_trade_alignment(self, network: CooccurrenceNetwork):
-        """
-        Trade alignment returns a dict with expected keys.
-        """
-        trades = [
-            {"rapids_code" : "90046", "title" : "Electrician"},
-            {"rapids_code" : "90884", "title" : "Welder"}
-        ]
-        result = network.trade_alignment(trades)
-        assert {"alignments", "matched_count", "total_trades"} <= result.keys()
-        assert result["total_trades"] == 2

--- a/tests/association/test_schemas.py
+++ b/tests/association/test_schemas.py
@@ -41,18 +41,6 @@ class TestAssociationSchemas:
                 n_rules     = 0
             )
 
-    def test_apriori_valid(self):
-        """
-        A minimal AprioriResult with defaults validates.
-        """
-        result = AprioriResult(
-            min_support = 0.05,
-            n_itemsets  = 10,
-            n_rules     = 3
-        )
-        assert result.overlap_jaccard is None
-        assert result.rules_summary == []
-
     # ---------------------------------------------------------
     # CommunityLabel
     # ---------------------------------------------------------
@@ -97,19 +85,6 @@ class TestAssociationSchemas:
         with raises(ValueError, match = match):
             CommunityLabel(**kwargs)
 
-    def test_community_label_valid(self):
-        """
-        A well-formed community label validates successfully.
-        """
-        label = CommunityLabel(
-            community_id        = 0,
-            size                = 10,
-            top_skills          = ["welding", "scaffolding", "rigging"],
-            weighted_degree_sum = 25.5
-        )
-        assert label.community_id == 0
-        assert len(label.top_skills) == 3
-
     # ---------------------------------------------------------
     # GraphDiagnostics
     # ---------------------------------------------------------
@@ -130,39 +105,6 @@ class TestAssociationSchemas:
                 performance          = 0.7
             )
 
-    def test_diagnostics_no_modularity(self):
-        """
-        Modularity defaults to None for degenerate graphs.
-        """
-        diag = GraphDiagnostics(
-            connected_components = 0,
-            coverage             = 0.0,
-            edge_count           = 0,
-            isolate_count        = 0,
-            largest_component    = 0,
-            node_count           = 0,
-            performance          = 0.0
-        )
-        assert diag.modularity is None
-
-    def test_diagnostics_valid(self):
-        """
-        A complete diagnostics object with optional modularity
-        validates.
-        """
-        diag = GraphDiagnostics(
-            connected_components = 3,
-            coverage             = 0.85,
-            edge_count           = 50,
-            isolate_count        = 5,
-            largest_component    = 20,
-            modularity           = 0.45,
-            node_count           = 30,
-            performance          = 0.72
-        )
-        assert diag.modularity == 0.45
-        assert diag.edge_count == 50
-
     # ---------------------------------------------------------
     # MeasureComparison
     # ---------------------------------------------------------
@@ -179,15 +121,3 @@ class TestAssociationSchemas:
                 measure       = "npmi",
                 n_communities = 5
             )
-
-    def test_measure_valid(self):
-        """
-        A well-formed measure comparison validates.
-        """
-        result = MeasureComparison(
-            density       = 0.05,
-            edge_count    = 100,
-            measure       = "npmi",
-            n_communities = 5
-        )
-        assert result.measure == "npmi"

--- a/tests/clustering/test_comparison.py
+++ b/tests/clustering/test_comparison.py
@@ -31,22 +31,6 @@ class TestClusterComparison:
         result = getattr(comparison, method)()
         assert len(result.assignments) == len(comparison.coordinates)
 
-    @mark.parametrize("method", ["kmeans", "mean_shift"])
-    def test_no_noise(self, comparison: ClusterComparison, method: str):
-        """
-        Partitioning methods produce no noise points.
-        """
-        result = getattr(comparison, method)()
-        assert result.noise_count == 0
-
-    @mark.parametrize("method", ["dbscan", "hdbscan"])
-    def test_noise_nonnegative(self, comparison: ClusterComparison, method: str):
-        """
-        Density methods report non-negative noise counts.
-        """
-        result = getattr(comparison, method)()
-        assert result.noise_count >= 0
-
     # ---------------------------------------------------------
     # K-Means specifics
     # ---------------------------------------------------------
@@ -56,14 +40,6 @@ class TestClusterComparison:
         K-Means produces at least 2 clusters from the elbow method.
         """
         assert comparison.kmeans().n_clusters >= 2
-
-    def test_kmeans_with_sectors(self, comparison_with_sectors: ClusterComparison):
-        """
-        K-Means ARI against sector labels falls within [-1, 1].
-        """
-        result = comparison_with_sectors.kmeans()
-        if result.ari_vs_sectors is not None:
-            assert -1 <= result.ari_vs_sectors <= 1
 
     # ---------------------------------------------------------
     # Sector ARI
@@ -76,48 +52,21 @@ class TestClusterComparison:
         result = comparison.kmeans()
         assert result.ari_vs_sectors is None
 
-    @mark.parametrize("method", ["dbscan", "hdbscan"])
-    def test_density_ari_bounded_with_sectors(
-        self,
-        comparison_with_sectors : ClusterComparison,
-        method                  : str
-    ):
+    def test_ari_with_sectors(self, comparison_with_sectors: ClusterComparison):
         """
-        Density methods produce bounded ARI when sector labels are
-        present and at least 2 non-noise clusters exist.
+        ARI is computed when sector labels are provided. The
+        sector-label masking in `_build_result` must align the
+        mask across both `sector_labels` and `assignments`. A
+        misalignment would produce a meaningless ARI that the
+        comparison report presents as valid.
         """
-        result = getattr(comparison_with_sectors, method)()
-        if result.ari_vs_sectors is not None:
-            assert -1 <= result.ari_vs_sectors <= 1
-
-    # ---------------------------------------------------------
-    # Validity metrics
-    # ---------------------------------------------------------
-
-    def test_validity_metrics_bounded(self, comparison: ClusterComparison):
-        """
-        Internal validity metrics fall within expected bounds
-        when present.
-        """
-        result = comparison.kmeans()
-        if result.calinski_harabasz is not None:
-            assert result.calinski_harabasz > 0
-        if result.davies_bouldin is not None:
-            assert result.davies_bouldin >= 0
-        if result.silhouette is not None:
-            assert -1 <= result.silhouette <= 1
+        result = comparison_with_sectors.kmeans()
+        assert result.ari_vs_sectors is not None
+        assert -1.0 <= result.ari_vs_sectors <= 1.0
 
     # ---------------------------------------------------------
     # Silhouette details
     # ---------------------------------------------------------
-
-    def test_silhouette_details_bounded(self, comparison: ClusterComparison):
-        """
-        Per-posting silhouette coefficients fall within [-1, 1].
-        """
-        result  = comparison.kmeans()
-        details = comparison.silhouette_details(np.array(result.assignments))
-        assert (details >= -1).all() and (details <= 1).all()
 
     def test_silhouette_details_degenerate(self, comparison: ClusterComparison):
         """
@@ -127,11 +76,3 @@ class TestClusterComparison:
             np.zeros(len(comparison.coordinates), dtype = int)
         )
         assert (details == 0).all()
-
-    def test_silhouette_details_length(self, comparison: ClusterComparison):
-        """
-        Per-posting silhouette array has one entry per posting.
-        """
-        result  = comparison.kmeans()
-        details = comparison.silhouette_details(np.array(result.assignments))
-        assert len(details) == len(comparison.coordinates)

--- a/tests/clustering/test_hierarchical.py
+++ b/tests/clustering/test_hierarchical.py
@@ -21,12 +21,6 @@ class TestComputeSectorLabels:
     Validate sector label derivation from Jaccard nearest SOC.
     """
 
-    def test_labels_are_strings(self, sector_labels: list[str]):
-        """
-        Every sector label is a non-empty string.
-        """
-        assert all(isinstance(s, str) and s for s in sector_labels)
-
     def test_length_matches_documents(
         self,
         extracted_skills : dict[str, list[str]],
@@ -49,26 +43,12 @@ class TestHierarchicalClusterer:
     # Linkage
     # ---------------------------------------------------------
 
-    def test_cophenetic_bounded(self, clusterer: HierarchicalClusterer):
-        """
-        Cophenetic correlations fall within [-1, 1].
-        """
-        for result in clusterer.cophenetic_comparison():
-            assert -1 <= result.correlation <= 1
-
     def test_cophenetic_count(self, clusterer: HierarchicalClusterer):
         """
         Three cophenetic results for ward, complete, and average
         linkage methods.
         """
         assert len(clusterer.cophenetic_comparison()) == 3
-
-    def test_cophenetic_methods(self, clusterer: HierarchicalClusterer):
-        """
-        Cophenetic results cover all three linkage methods.
-        """
-        methods = {result.method for result in clusterer.cophenetic_comparison()}
-        assert methods == {"average", "complete", "ward"}
 
     def test_linkage_shape(self, clusterer: HierarchicalClusterer):
         """
@@ -82,19 +62,6 @@ class TestHierarchicalClusterer:
     # Assignments
     # ---------------------------------------------------------
 
-    def test_cut_height_positive(self, clusterer: HierarchicalClusterer):
-        """
-        The inconsistency cut threshold is positive.
-        """
-        assert clusterer.cut_height > 0
-
-    def test_cut_tree_rows(self, clusterer: HierarchicalClusterer):
-        """
-        Cut tree has one row per posting.
-        """
-        n = len(clusterer.document_ids)
-        assert clusterer.cut_tree.shape[0] == n
-
     def test_every_posting_assigned(self, clusterer: HierarchicalClusterer):
         """
         Every posting receives exactly one cluster assignment with
@@ -103,12 +70,6 @@ class TestHierarchicalClusterer:
         n = len(clusterer.document_ids)
         assert len(clusterer.assignments) == n
         assert (clusterer.assignments > 0).all()
-
-    def test_k_positive(self, clusterer: HierarchicalClusterer):
-        """
-        At least one cluster is produced.
-        """
-        assert clusterer.k >= 1
 
     # ---------------------------------------------------------
     # Labels
@@ -130,15 +91,6 @@ class TestHierarchicalClusterer:
         One label per unique cluster.
         """
         assert len(cluster_labels) == clusterer.k
-
-    def test_labels_readable(self, cluster_labels: list[ClusterLabel]):
-        """
-        Cluster label terms are human-readable strings, not
-        numeric indices.
-        """
-        for label in cluster_labels:
-            assert all(isinstance(t, str) for t in label.terms)
-            assert all(not t.isdigit() for t in label.terms)
 
     def test_labels_size_sums(
         self,
@@ -171,13 +123,6 @@ class TestHierarchicalClusterer:
     # Dendrogram
     # ---------------------------------------------------------
 
-    def test_dendrogram_data_keys(self, clusterer: HierarchicalClusterer):
-        """
-        Dendrogram dict contains the expected scipy keys.
-        """
-        data = clusterer.dendrogram_data()
-        assert {"icoord", "dcoord", "ivl", "color_list"} <= data.keys()
-
     def test_dendrogram_leaf_count(self, clusterer: HierarchicalClusterer):
         """
         Leaf labels match the number of postings.
@@ -197,46 +142,10 @@ class TestHierarchicalClusterer:
         assert all(label.startswith("Title ") for label in data["ivl"])
 
     # ---------------------------------------------------------
-    # ARI and validity
-    # ---------------------------------------------------------
-
-    def test_ari_vs_sectors_bounded(
-        self,
-        clusterer     : HierarchicalClusterer,
-        sector_labels : list[str]
-    ):
-        """
-        Adjusted Rand index falls within [-1, 1].
-        """
-        assert -1 <= clusterer.ari_vs_sectors(sector_labels) <= 1
-
-    def test_silhouette_samples_length(self, clusterer: HierarchicalClusterer):
-        """
-        Per-posting silhouette array has one entry per posting.
-        """
-        n = len(clusterer.document_ids)
-        assert len(clusterer.validation_metrics().silhouette_samples) == n
-
-    def test_validity_metrics_populated(self, clusterer: HierarchicalClusterer):
-        """
-        Internal validity metrics are non-None when k >= 2.
-        """
-        metrics = clusterer.validation_metrics()
-        assert metrics.calinski_harabasz is not None
-        assert metrics.calinski_harabasz > 0
-        assert metrics.davies_bouldin is not None
-        assert metrics.davies_bouldin >= 0
-        assert metrics.silhouette is not None
-        assert -1 <= metrics.silhouette <= 1
-
-    # ---------------------------------------------------------
     # Validate at K
     # ---------------------------------------------------------
 
-    @mark.parametrize("k", [
-        2,
-        3
-    ])
+    @mark.parametrize("k", [2, 3])
     def test_validate_at_k(self, clusterer: HierarchicalClusterer, k: int):
         """
         Assignments at a given K cover all postings and produce

--- a/tests/clustering/test_schemas.py
+++ b/tests/clustering/test_schemas.py
@@ -4,8 +4,7 @@ Tests for clustering schemas.
 
 from pytest import mark, param, raises
 
-from chalkline.clustering.schemas import ClusterLabel
-from chalkline.clustering.schemas import ComparisonResult
+from chalkline.clustering.schemas import ClusterLabel, ComparisonResult
 from chalkline.clustering.schemas import CopheneticResult
 
 
@@ -62,21 +61,6 @@ class TestClusteringSchemas:
         with raises(ValueError, match = match):
             ClusterLabel(**kwargs)
 
-    def test_cluster_label_valid(self):
-        """
-        A well-formed label with matching terms and weights
-        validates successfully.
-        """
-        label = ClusterLabel(
-            cluster_id     = 1,
-            leader_node_id = 12,
-            size           = 5,
-            terms          = ["welding", "scaffolding"],
-            weights        = [0.8, 0.6]
-        )
-        assert label.cluster_id == 1
-        assert label.size == 5
-
     # ---------------------------------------------------------
     # ComparisonResult
     # ---------------------------------------------------------
@@ -104,34 +88,6 @@ class TestClusteringSchemas:
                 n_clusters  = -1
             )
 
-    def test_comparison_result_valid(self):
-        """
-        A minimal result with required fields only validates.
-        """
-        result = ComparisonResult(
-            assignments = [0, 1, 0],
-            method      = "kmeans",
-            n_clusters  = 2
-        )
-        assert result.noise_count == 0
-        assert result.silhouette is None
-
-    def test_comparison_result_with_metrics(self):
-        """
-        Optional metric fields populate when provided.
-        """
-        result = ComparisonResult(
-            assignments       = [0, 1, -1],
-            calinski_harabasz = 10.5,
-            davies_bouldin    = 0.8,
-            method            = "dbscan",
-            n_clusters        = 2,
-            noise_count       = 1,
-            silhouette        = 0.35
-        )
-        assert result.calinski_harabasz == 10.5
-        assert result.noise_count == 1
-
     # ---------------------------------------------------------
     # CopheneticResult
     # ---------------------------------------------------------
@@ -146,13 +102,3 @@ class TestClusteringSchemas:
                 extra       = True,
                 method      = "ward"
             )
-
-    def test_cophenetic_result_valid(self):
-        """
-        A cophenetic result within valid bounds validates.
-        """
-        result = CopheneticResult(
-            correlation = 0.85,
-            method      = "ward"
-        )
-        assert result.correlation == 0.85

--- a/tests/collection/test_collector.py
+++ b/tests/collection/test_collector.py
@@ -5,7 +5,6 @@ Validates record parsing from JobSpy DataFrame rows into `Posting` records.
 """
 
 from chalkline.collection.collector import Collector
-from chalkline.collection.schemas   import Posting
 
 
 class TestParseRecord:
@@ -19,6 +18,21 @@ class TestParseRecord:
         A row missing required fields returns `None` instead of raising.
         """
         assert Collector._parse_record({"company": "Cianbro"}) is None
+
+    def test_nan_description(self):
+        """
+        A NaN description coerces to empty string and fails the
+        minimum-length validation, returning `None` rather than
+        allowing contentless postings into the corpus.
+        """
+        assert Collector._parse_record({
+            "company"     : "Cianbro",
+            "date_posted" : "2026-03-01",
+            "description" : float("nan"),
+            "job_url"     : "https://example.com",
+            "location"    : "Portland, ME",
+            "title"       : "Electrician"
+        }) is None
 
     def test_nan_fields(self):
         """
@@ -35,17 +49,3 @@ class TestParseRecord:
         assert result.date_posted is None
         assert result.location is None
 
-    def test_valid_record(self):
-        """
-        A complete row converts to a `Posting` with correct field mapping.
-        """
-        result = Collector._parse_record({
-            "company"     : "Cianbro",
-            "date_posted" : "2026-03-01",
-            "description" : "x" * 50,
-            "job_url"     : "https://example.com",
-            "location"    : "Portland, ME",
-            "title"       : "Electrician"
-        })
-        assert isinstance(result, Posting)
-        assert result.company == "Cianbro"

--- a/tests/collection/test_schemas.py
+++ b/tests/collection/test_schemas.py
@@ -11,23 +11,10 @@ from pytest   import mark, raises
 from chalkline.collection.schemas import Posting
 
 
-FILLER_DESCRIPTION = "x" * 50
-
-
 class TestPosting:
     """
     Validate `Posting` model constraints and composite key generation.
     """
-
-    def test_auto_id(self, sample_posting: Posting):
-        """
-        Omitting `id` auto-computes it from company, date, and title.
-        """
-        assert sample_posting.id == Posting.make_id(
-            sample_posting.company,
-            sample_posting.date_posted,
-            sample_posting.title
-        )
 
     def test_composite_key_format(self):
         """
@@ -38,27 +25,21 @@ class TestPosting:
             == "cianbro_electrician_2026-03-01"
         )
 
-    def test_date_coercion(self):
+    @mark.parametrize("date_str", ["2026-03-01 14:30:00", "2026-03-01T14:30:00Z"])
+    def test_date_coercion(self, date_str: str, sample_posting: Posting):
         """
-        Timestamp `date_posted` values are truncated to date and reflected
-        in the composite key.
+        Timestamp `date_posted` values in both space-separated
+        and ISO formats are truncated to date by the `[:10]`
+        slice.
         """
-        posting = Posting.model_validate({
-            "company"     : "Cianbro",
-            "date_posted" : "2026-03-01T14:30:00Z",
-            "description" : FILLER_DESCRIPTION,
-            "source_url"  : "https://example.com",
-            "title"       : "Electrician"
-        })
+        posting = Posting.model_validate(
+            sample_posting.model_dump() | {"date_posted" : date_str}
+        )
         assert posting.date_posted == date(2026, 3, 1)
         assert "2026-03-01" in posting.id
 
     @mark.parametrize("field", ["company", "source_url", "title"])
-    def test_empty_string(
-        self,
-        sample_posting : Posting,
-        field          : str
-    ):
+    def test_empty_string(self, sample_posting: Posting, field: str):
         """
         Empty strings on `NonEmptyStr` fields raise `ValidationError`.
         """
@@ -75,7 +56,7 @@ class TestPosting:
         posting = Posting(
             company     = "Cianbro",
             date_posted = date(2026, 3, 1),
-            description = FILLER_DESCRIPTION,
+            description = "x" * 50,
             id          = "custom-id",
             source_url  = "https://example.com",
             title       = "Worker"
@@ -105,6 +86,21 @@ class TestPosting:
             "R.J. Grondin & Sons", date(2026, 1, 1), "Heavy Equip. Operator"
         ))
 
+    def test_make_id_stopword_collision(self):
+        """
+        Companies differing only by a stopword produce identical
+        composite keys, documenting the collision boundary so that
+        changes to stopword handling are caught.
+        """
+        assert (
+            Posting.make_id(
+                "Reed and Sons", date(2026, 1, 1), "Laborer"
+            )
+            == Posting.make_id(
+                "Reed Sons", date(2026, 1, 1), "Laborer"
+            )
+        )
+
     def test_make_id_strips_stopwords(self):
         """
         Stopwords "and", "of", "the" are removed from slugs.
@@ -126,10 +122,3 @@ class TestPosting:
                 title       = "Worker"
             )
 
-    def test_valid_posting_roundtrip(self, sample_posting: Posting):
-        """
-        A valid posting serializes and deserializes without loss.
-        """
-        assert Posting.model_validate(
-            sample_posting.model_dump(mode="json")
-        ) == sample_posting

--- a/tests/collection/test_storage.py
+++ b/tests/collection/test_storage.py
@@ -54,32 +54,7 @@ class TestStorage:
         """
         assert load(tmp_path / "nonexistent") == []
 
-    def test_no_duplicates(
-        self,
-        sample_posting : Posting,
-        second_posting : Posting
-    ):
-        """
-        Non-duplicate postings are all retained.
-        """
-        assert len(deduplicate([sample_posting, second_posting])) == 2
-
-    def test_save_creates_parents(
-        self,
-        sample_posting : Posting,
-        tmp_path       : Path
-    ):
-        """
-        Saving to a non-existent nested directory creates it.
-        """
-        save([sample_posting], (nested := tmp_path / "a" / "b"))
-        assert load(nested) == [sample_posting]
-
-    def test_save_deduplicates(
-        self,
-        sample_posting : Posting,
-        tmp_path       : Path
-    ):
+    def test_save_deduplicates(self, sample_posting: Posting, tmp_path: Path):
         """
         Saving the same posting twice retains only one copy.
         """
@@ -87,11 +62,7 @@ class TestStorage:
         save([sample_posting], tmp_path)
         assert len(load(tmp_path)) == 1
 
-    def test_save_load_roundtrip(
-        self,
-        sample_posting : Posting,
-        tmp_path       : Path
-    ):
+    def test_save_load_roundtrip(self, sample_posting: Posting, tmp_path: Path):
         """
         Save followed by load produces identical postings.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ Fixtures form a pipeline chain where each step's output is
 independently tappable by any test module:
 
     corpus → extracted_skills → vectorizer → pca_reducer
-           ↘                    ↓                   ↓
-            sector_labels    network             clustering
+           ↘                        ↓            ↓
+             sector_labels       network     clusterer → matcher
 
 Lexicon fixtures feed the extractor via the registry:
 
@@ -16,25 +16,32 @@ Lexicon fixtures feed the extractor via the registry:
     supplement_terms┘
 """
 
-from json    import loads
-from pathlib import Path
-from pytest  import fixture, FixtureRequest
+import pandas as pd
 
-from chalkline.association.apriori       import AprioriComparison
-from chalkline.association.cooccurrence  import CooccurrenceNetwork
-from chalkline.clustering.comparison     import ClusterComparison
-from chalkline.clustering.hierarchical   import compute_sector_labels
-from chalkline.clustering.hierarchical   import HierarchicalClusterer
-from chalkline.clustering.schemas        import ClusterLabel
-from chalkline.collection.schemas        import Posting
-from chalkline.extraction.lexicons       import LexiconRegistry
-from chalkline.extraction.loaders        import load_certifications, load_onet
-from chalkline.extraction.loaders        import load_osha, load_supplement
-from chalkline.extraction.occupations    import OccupationIndex
-from chalkline.extraction.schemas        import Certification, OnetOccupation
-from chalkline.extraction.skills         import SkillExtractor
-from chalkline.extraction.vectorize      import SkillVectorizer
-from chalkline.reduction.pca             import PcaReducer
+from json             import loads
+from pathlib          import Path
+from pytest           import fixture, FixtureRequest
+from sklearn.pipeline import Pipeline
+
+from chalkline.association.apriori      import AprioriComparison
+from chalkline.association.cooccurrence import CooccurrenceNetwork
+from chalkline.clustering.comparison    import ClusterComparison
+from chalkline.clustering.hierarchical  import compute_sector_labels
+from chalkline.clustering.hierarchical  import HierarchicalClusterer
+from chalkline.clustering.schemas       import ClusterLabel
+from chalkline.collection.schemas       import Posting
+from chalkline.extraction.lexicons      import LexiconRegistry
+from chalkline.extraction.loaders       import load_certifications, load_onet
+from chalkline.extraction.loaders       import load_osha, load_supplement
+from chalkline.extraction.occupations   import OccupationIndex
+from chalkline.extraction.schemas       import Certification, OnetOccupation
+from chalkline.extraction.skills        import SkillExtractor
+from chalkline.extraction.vectorize     import SkillVectorizer
+from chalkline.matching.matcher         import ResumeMatcher
+from chalkline.matching.schemas         import MatchResult
+from chalkline.pipeline.programs        import load_programs
+from chalkline.pipeline.schemas         import DistanceMetric, ProgramRecommendation
+from chalkline.reduction.pca            import PcaReducer
 
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -235,10 +242,7 @@ def second_posting() -> Posting:
     return _postings()[1]
 
 
-@fixture(params = [
-    "47-2111",
-    "47-2111.00"
-])
+@fixture(params = ["47-2111", "47-2111.00"])
 def soc(request: FixtureRequest) -> str:
     """
     Electrician SOC code in both bare and suffixed formats.
@@ -306,6 +310,31 @@ def network(vectorizer: SkillVectorizer) -> CooccurrenceNetwork:
 # ---------------------------------------------------------------------
 
 @fixture
+def cluster_labels(
+    clusterer  : HierarchicalClusterer,
+    vectorizer : SkillVectorizer
+) -> list[ClusterLabel]:
+    """
+    Cluster labels from TF-IDF centroid terms, shared across label tests.
+    """
+    return clusterer.labels(
+        feature_names = vectorizer.feature_names,
+        tfidf_matrix  = vectorizer.tfidf_matrix
+    )
+
+
+@fixture
+def clusterer(pca_reducer: PcaReducer) -> HierarchicalClusterer:
+    """
+    Build a hierarchical clusterer from the shared PCA reducer.
+    """
+    return HierarchicalClusterer(
+        coordinates  = pca_reducer.coordinates,
+        document_ids = pca_reducer.document_ids
+    )
+
+
+@fixture
 def comparison(pca_reducer: PcaReducer) -> ClusterComparison:
     """
     Build a comparison runner without sector labels.
@@ -332,31 +361,6 @@ def comparison_with_sectors(
 
 
 @fixture
-def cluster_labels(
-    clusterer  : HierarchicalClusterer,
-    vectorizer : SkillVectorizer
-) -> list[ClusterLabel]:
-    """
-    Cluster labels from TF-IDF centroid terms, shared across label tests.
-    """
-    return clusterer.labels(
-        feature_names = vectorizer.feature_names,
-        tfidf_matrix  = vectorizer.tfidf_matrix
-    )
-
-
-@fixture
-def clusterer(pca_reducer: PcaReducer) -> HierarchicalClusterer:
-    """
-    Build a hierarchical clusterer from the shared PCA reducer.
-    """
-    return HierarchicalClusterer(
-        coordinates  = pca_reducer.coordinates,
-        document_ids = pca_reducer.document_ids
-    )
-
-
-@fixture
 def sector_labels(
     extracted_skills : dict[str, list[str]],
     occupation_index : OccupationIndex,
@@ -370,3 +374,101 @@ def sector_labels(
         extracted_skills = extracted_skills,
         occupation_index = occupation_index
     )
+
+
+# ---------------------------------------------------------------------
+# Matching
+# ---------------------------------------------------------------------
+
+@fixture
+def apprenticeships() -> list[dict]:
+    """
+    Synthetic apprenticeship reference data for matching tests.
+    """
+    return loads((FIXTURES / "matching/apprenticeships.json").read_text())
+
+
+@fixture
+def geometry_pipeline(pca_reducer: PcaReducer, vectorizer: SkillVectorizer) -> Pipeline:
+    """
+    Combined geometry pipeline from vectorization through scaling.
+
+    Chains the fitted steps from `SkillVectorizer.pipeline` and
+    `PcaReducer.pipeline` into a single `Pipeline` whose
+    `transform([skill_dict])` projects a resume directly into
+    PCA-scaled coordinates.
+    """
+    vec_steps = vectorizer.pipeline.named_steps
+    pca_steps = pca_reducer.pipeline.named_steps
+    return Pipeline([
+        ("vec",    vec_steps["vec"]),
+        ("tfidf",  vec_steps["tfidf"]),
+        ("norm",   vec_steps["norm"]),
+        ("svd",    pca_steps["svd"]),
+        ("scaler", pca_steps["scaler"])
+    ])
+
+
+@fixture
+def match_result(matcher: ResumeMatcher, resume_skills: list[str]) -> MatchResult:
+    """
+    Default match result from the partial resume skill set.
+    """
+    return matcher.match(resume_skills)
+
+
+@fixture
+def matcher(
+    apprenticeships   : list[dict],
+    clusterer         : HierarchicalClusterer,
+    extracted_skills  : dict[str, list[str]],
+    geometry_pipeline : Pipeline,
+    network           : CooccurrenceNetwork,
+    programs          : list[ProgramRecommendation],
+    vectorizer        : SkillVectorizer
+) -> ResumeMatcher:
+    """
+    Build a resume matcher from the full fixture pipeline.
+    """
+    cluster_labels_50 = clusterer.labels(
+        feature_names = vectorizer.feature_names,
+        tfidf_matrix  = vectorizer.tfidf_matrix,
+        top_n         = 50
+    )
+    ppmi_df = pd.DataFrame(
+        network.ppmi_matrix.toarray(),
+        columns = network.feature_names,
+        index   = network.feature_names
+    )
+    return ResumeMatcher(
+        apprenticeships   = apprenticeships,
+        assignments       = clusterer.assignments,
+        cluster_labels    = cluster_labels_50,
+        coordinates       = clusterer.coordinates,
+        distance_metric   = DistanceMetric.EUCLIDEAN,
+        document_ids      = clusterer.document_ids,
+        extracted_skills  = extracted_skills,
+        geometry_pipeline = geometry_pipeline,
+        ppmi_df           = ppmi_df,
+        programs          = programs,
+        top_k_gaps        = 10
+    )
+
+
+@fixture
+def programs(tmp_path: Path) -> list[ProgramRecommendation]:
+    """
+    Load and normalize synthetic educational program fixtures.
+    """
+    for name in ("cc_programs.json", "umaine_programs.json"):
+        (tmp_path / name).write_text((FIXTURES / "matching" / name).read_text())
+    return load_programs(tmp_path)
+
+
+@fixture
+def resume_skills() -> list[str]:
+    """
+    A partial resume skill set that will produce gaps against
+    the fixture corpus.
+    """
+    return ["electrical wiring", "fall protection", "scaffolding"]

--- a/tests/extraction/test_lexicons.py
+++ b/tests/extraction/test_lexicons.py
@@ -34,11 +34,7 @@ class TestLexiconRegistry:
         "operate construction equipment",
         "spread concrete"
     ])
-    def test_decompose_sub_phrase(
-        self,
-        phrase   : str,
-        registry : LexiconRegistry
-    ):
+    def test_decompose_sub_phrase(self, phrase: str, registry: LexiconRegistry):
         """
         Sub-phrases from decomposed tasks and DWAs normalize to
         themselves rather than the parent sentence, covering both
@@ -68,39 +64,6 @@ class TestLexiconRegistry:
             osha_terms  = []
         ).normalize("anything") is None
 
-    def test_explicit_none_supplement(
-        self,
-        occupations : list[OnetOccupation],
-        osha_terms  : list[str]
-    ):
-        """
-        Passing `None` for `supplement_terms` builds the index without
-        supplement data, equivalent to omitting the argument.
-        """
-        registry = LexiconRegistry(
-            occupations      = occupations,
-            osha_terms       = osha_terms,
-            supplement_terms = None
-        )
-        assert registry.normalize("fall protection") == "fall protection"
-        assert registry.normalize("rebar") is None
-
-    @mark.parametrize("term", ["Autodesk AutoCAD", "fall protection"])
-    def test_lemma_index_terms(self, registry: LexiconRegistry, term: str):
-        """
-        Both O*NET and OSHA terms appear in the merged index.
-        """
-        assert term in registry.lemma_index.values()
-
-    def test_lemmatize_caches_words(self, registry: LexiconRegistry):
-        """
-        The word-level cache is populated after lemmatization so that
-        repeated tokens across postings skip the WordNet lookup.
-        """
-        registry.lemmatize("scaffoldings welding")
-        assert "scaffoldings" in registry.lemma_cache
-        assert "welding" in registry.lemma_cache
-
     def test_lemmatize_noun_default(self, registry: LexiconRegistry):
         """
         Noun-default lemmatization reduces plurals without POS tagging,
@@ -108,14 +71,6 @@ class TestLexiconRegistry:
         """
         assert registry.lemmatize("scaffoldings") == "scaffolding"
         assert registry.lemmatize("installing") == "installing"
-
-    def test_lemmatize_uses_cache(self, registry: LexiconRegistry):
-        """
-        A pre-populated cache entry is returned directly without
-        invoking the WordNet lemmatizer.
-        """
-        registry.lemma_cache["foo"] = "bar"
-        assert registry.lemmatize("foo") == "bar"
 
     # -------------------------------------------------------------------------
     # Normalization
@@ -141,13 +96,6 @@ class TestLexiconRegistry:
         returning `None` even though they exist in the occupation profile.
         """
         assert registry.normalize(term) is None
-
-    @mark.parametrize("term", ["Autodesk AutoCAD", "fall protection"])
-    def test_normalize_known_term(self, registry: LexiconRegistry, term: str):
-        """
-        Known O*NET and OSHA terms normalize to their canonical forms.
-        """
-        assert registry.normalize(term) == term
 
     @mark.parametrize("term", ["Asbestos", "asbestos"])
     def test_normalize_osha_exact_case(self, registry: LexiconRegistry, term: str):
@@ -177,6 +125,41 @@ class TestLexiconRegistry:
         An unrecognized term returns `None`.
         """
         assert registry.normalize("quantum computing") is None
+
+    def test_onet_collision_last_wins(self):
+        """
+        When skills across occupations share a lemmatized form, the
+        later occupation's canonical form wins via dict overwrite.
+        A refactor changing occupation iteration order would silently
+        alter every downstream TF-IDF vector.
+        """
+        occupations = [
+            OnetOccupation(
+                job_zone = 2,
+                sector   = "Heavy Highway Construction",
+                skills   = [OnetSkill(
+                    name = "concrete finishing",
+                    type = "technology"
+                )],
+                soc_code = "47-2071.00",
+                title    = "Paving Equipment Operators"
+            ),
+            OnetOccupation(
+                job_zone = 3,
+                sector   = "Building Construction",
+                skills   = [OnetSkill(
+                    name = "Concrete Finishing",
+                    type = "technology"
+                )],
+                soc_code = "47-2111.00",
+                title    = "Electricians"
+            )
+        ]
+        registry = LexiconRegistry(
+            occupations = occupations,
+            osha_terms  = []
+        )
+        assert registry.normalize("concrete finishing") == "Concrete Finishing"
 
     def test_phrases_empty(self):
         """

--- a/tests/extraction/test_occupations.py
+++ b/tests/extraction/test_occupations.py
@@ -96,36 +96,9 @@ class TestOccupationIndex:
             {"Backhoes", "Concrete finishing", "Welding"}
         ) == "47-2071.00"
 
-    def test_nearest_paving(self, occupation_index: OccupationIndex):
-        """
-        Skills unique to paving operators resolve to that occupation's SOC
-        code.
-        """
-        assert occupation_index.nearest(
-            {"Backhoes", "Concrete finishing"}
-        ) == "47-2071.00"
-
-    def test_sector(self, occupation_index: OccupationIndex, soc: str):
-        """
-        `sector` accepts both suffixed and bare prefix formats.
-        """
-        assert occupation_index.get(soc).sector == "Building Construction"
-
-    def test_skills(self, occupation_index: OccupationIndex, soc: str):
-        """
-        `skills` accepts both suffixed and bare prefix formats.
-        """
-        assert len(occupation_index.get(soc).skills) == 7
-
     def test_soc_skill_matrix_shape(self, occupation_index: OccupationIndex):
         """
         The precomputed matrix has one row per SOC code and one column per
         unique skill across all occupations.
         """
         assert occupation_index.soc_skill_matrix.shape == (2, 12)
-
-    def test_socs_sorted(self, occupation_index: OccupationIndex):
-        """
-        SOC codes are in alphabetical order for stable row indices.
-        """
-        assert occupation_index.socs == sorted(occupation_index.socs)

--- a/tests/extraction/test_schemas.py
+++ b/tests/extraction/test_schemas.py
@@ -37,12 +37,6 @@ class TestOnetSchemas:
         """
         assert sum(m.is_concrete for m in OnetSkillType) == 4
 
-    def test_confidence_tier_members(self):
-        """
-        The three confidence tiers are defined for Aho-Corasick matching.
-        """
-        assert len(ConfidenceTier) == 3
-
     def test_confidence_tier_ordering(self):
         """
         Tier values sort so that higher-confidence tiers compare lower,
@@ -54,12 +48,22 @@ class TestOnetSchemas:
             < ConfidenceTier.SINGLE_WORD.value
         )
 
-    def test_occupation_extra(self):
+    @mark.parametrize(("cls", "kwargs"), [
+        (OnetOccupation, SAMPLE_OCCUPATION),
+        (OnetSkill, SAMPLE_SKILL),
+        (CorpusStatistics, {
+            "matrix_sparsity"         : 0.9,
+            "mean_skills_per_posting" : 5.0,
+            "skill_frequency"         : {"welding" : 3},
+            "vocabulary_size"         : 10
+        })
+    ])
+    def test_extra_fields(self, cls: type, kwargs: dict):
         """
         Unknown fields raise `ValidationError` per `extra="forbid"`.
         """
         with raises(Exception, match="Extra inputs"):
-            OnetOccupation(**SAMPLE_OCCUPATION, unknown="value")
+            cls(**kwargs, unknown="value")
 
     @mark.parametrize("job_zone", [0, 6])
     def test_occupation_job_zone(self, job_zone):
@@ -76,14 +80,6 @@ class TestOnetSchemas:
         with raises(Exception):
             OnetOccupation(job_zone=3, title="Test")
 
-    def test_occupation_valid(self):
-        """
-        A complete occupation validates without error.
-        """
-        occupation = OnetOccupation(**SAMPLE_OCCUPATION)
-        assert occupation.soc_code == "47-2111.00"
-        assert len(occupation.skills) == 1
-
     def test_skill_empty_name(self):
         """
         Empty skill names violate the `NonEmptyStr` constraint.
@@ -91,52 +87,3 @@ class TestOnetSchemas:
         with raises(Exception):
             OnetSkill(name="", type="technology")
 
-    def test_skill_extra(self):
-        """
-        Unknown fields raise `ValidationError` per `extra="forbid"`.
-        """
-        with raises(Exception, match="Extra inputs"):
-            OnetSkill(**SAMPLE_SKILL, unknown="value")
-
-    def test_skill_type_coercion(self):
-        """
-        Raw strings coerce to enum members through Pydantic.
-        """
-        assert OnetSkill(name="Test Skill", type="task").type is OnetSkillType.TASK
-
-    def test_skill_type_members(self):
-        """
-        All seven O*NET element types are defined.
-        """
-        assert len(OnetSkillType) == 7
-
-    def test_skill_valid_with_ratings(self):
-        """
-        KSA-typed skills carry populated importance and level.
-        """
-        s = OnetSkill(
-            importance = 3.62,
-            level      = 3.88,
-            name       = "Critical Thinking",
-            type       = "skill"
-        )
-        assert (s.importance, s.level) == (3.62, 3.88)
-
-    def test_skill_valid_without_ratings(self):
-        """
-        Concrete-typed skills default importance and level to `None`.
-        """
-        assert ((s := OnetSkill(**SAMPLE_SKILL)).importance, s.level) == (None, None)
-
-    def test_statistics_extra(self):
-        """
-        Unknown fields raise `ValidationError` per `extra="forbid"`.
-        """
-        with raises(Exception, match="Extra inputs"):
-            CorpusStatistics(
-                matrix_sparsity         = 0.9,
-                mean_skills_per_posting = 5.0,
-                skill_frequency         = {"welding": 3},
-                unknown                 = "value",
-                vocabulary_size         = 10
-            )

--- a/tests/extraction/test_skills.py
+++ b/tests/extraction/test_skills.py
@@ -63,9 +63,7 @@ class TestSkillExtractor:
         A term present in both OSHA and O*NET resolves to the OSHA
         canonical form.
         """
-        result = extractor.extract({
-            "a": "welding certification required"
-        })
+        result = extractor.extract({"a": "welding certification required"})
         assert "welding" in result["a"]
         # OSHA "welding" is lowercase; O*NET is "Welding"
         assert "Welding" not in result["a"]
@@ -80,33 +78,6 @@ class TestSkillExtractor:
         }).get("a", [])
 
     # ---------------------------------------------------------
-    # Logging
-    # ---------------------------------------------------------
-
-    def test_high_unmatched_rate_warns(self, caplog, extractor: SkillExtractor):
-        """
-        A corpus with mostly unrecognized terms triggers a warning when the
-        unmatched rate exceeds the 25% threshold.
-        """
-        with caplog.at_level("WARNING", logger = "chalkline.extraction.skills"):
-            extractor.extract({
-                "a": "quantum computing blockchain artificial intelligence "
-                     "machine learning deep neural networks cryptocurrency "
-                     "decentralized finance web3 metaverse fall protection"
-            })
-        assert any("unmatched" in r.message.lower() for r in caplog.records)
-
-    def test_unmatched_terms_logged(self, caplog, extractor: SkillExtractor):
-        """
-        Unmatched term diagnostics are logged at debug level.
-        """
-        with caplog.at_level("DEBUG", logger = "chalkline.extraction.skills"):
-            extractor.extract({
-                "a": "Fall protection and quantum computing required"
-            })
-        assert any("unmatched" in r.message.lower() for r in caplog.records)
-
-    # ---------------------------------------------------------
     # Output format
     # ---------------------------------------------------------
 
@@ -119,17 +90,6 @@ class TestSkillExtractor:
             "a": "welding and welding, plus fall protection"
         })["a"]
         assert skills == sorted(set(skills))
-
-    def test_output_type(self, extractor: SkillExtractor):
-        """
-        The return value is a `dict[str, list[str]]`.
-        """
-        result = extractor.extract({
-            "a": "Fall protection required"
-        })
-        assert isinstance(result, dict)
-        assert isinstance(result["a"], list)
-        assert all(isinstance(s, str) for s in result["a"])
 
     # ---------------------------------------------------------
     # Preprocessing
@@ -166,33 +126,6 @@ class TestSkillExtractor:
         result = extractor.extract({"a": text})
         assert "fall protection" in result.get("a", [])
 
-    def test_semicolon_normalization(self, extractor: SkillExtractor):
-        """
-        Semicolons are normalized to sentence boundaries so that skills
-        separated by semicolons are extracted individually.
-        """
-        assert "fall protection" in extractor.extract({
-            "a": "fall protection; welding"
-        })["a"]
-
-    # ---------------------------------------------------------
-    # Vocabulary
-    # ---------------------------------------------------------
-
-    def test_vocabulary_osha(self, extractor: SkillExtractor):
-        """
-        OSHA lexicon terms appear in the extractor's vocabulary.
-        """
-        assert "fall protection" in extractor.vocabulary
-        assert "welding" in extractor.vocabulary
-
-    def test_vocabulary_supplement(self, extractor: SkillExtractor):
-        """
-        Supplement lexicon terms appear in the extractor's vocabulary
-        alongside OSHA and O*NET terms.
-        """
-        assert "rebar" in extractor.vocabulary
-
     # ---------------------------------------------------------
     # Word boundaries
     # ---------------------------------------------------------
@@ -204,15 +137,6 @@ class TestSkillExtractor:
         """
         assert "welding" in extractor.extract(
             {"a": "3welding required on site"}
-        ).get("a", [])
-
-    def test_boundary_hyphen(self, extractor: SkillExtractor):
-        """
-        Hyphens are non-alphanumeric, so terms separated by hyphens
-        are treated as valid word boundaries.
-        """
-        assert "welding" in extractor.extract(
-            {"a": "welding-certified technician needed"}
         ).get("a", [])
 
     def test_word_boundary(self, extractor: SkillExtractor):
@@ -238,17 +162,4 @@ class TestSkillExtractor:
         """
         A posting with no matching skills is excluded from output.
         """
-        assert extractor.extract({
-            "a": "Must have experience with knowledge of"
-        }) == {}
-
-    def test_zero_skills_excluded(self, extractor: SkillExtractor):
-        """
-        Postings with no matched skills are omitted from the output.
-        """
-        result = extractor.extract({
-            "a" : "This posting has no construction skills mentioned",
-            "b" : "Fall protection required"
-        })
-        assert "b" in result
-        assert "a" not in result
+        assert extractor.extract({"a": "Must have experience with knowledge of"}) == {}

--- a/tests/extraction/test_vectorize.py
+++ b/tests/extraction/test_vectorize.py
@@ -8,6 +8,7 @@ using synthetic extraction output.
 
 from joblib  import dump, load
 from pathlib import Path
+from pytest  import mark
 
 from chalkline.extraction.vectorize import SkillVectorizer
 
@@ -18,48 +19,36 @@ class TestSkillVectorizer:
     """
 
     # ---------------------------------------------------------
-    # Document identifiers
+    # Alignment
     # ---------------------------------------------------------
 
-    def test_document_ids_row_count(self, vectorizer: SkillVectorizer):
+    @mark.parametrize("skills", [
+        {
+            "doc-a" : ["welding", "scaffolding"],
+            "doc-b" : ["concrete finishing"]
+        },
+        {
+            "z-doc" : ["welding"],
+            "a-doc" : ["scaffolding", "welding"]
+        }
+    ])
+    def test_matrix_alignment(self, skills: dict[str, list[str]]):
         """
-        Document identifiers are returned in row order alongside
-        both matrices.
+        `document_ids[i]` and `feature_names[j]` correctly index
+        the binary matrix regardless of insertion or sort order.
         """
-        assert (
-            len(vectorizer.document_ids)
-            == vectorizer.tfidf_matrix.shape[0]
-            == vectorizer.binary_matrix.shape[0]
-        )
-
-    def test_document_ids_sorted(self, vectorizer: SkillVectorizer):
-        """
-        Document identifiers are in sorted order.
-        """
-        assert vectorizer.document_ids == sorted(
-            vectorizer.document_ids
-        )
+        vec = SkillVectorizer(skills)
+        for i, doc_id in enumerate(vec.document_ids):
+            row     = vec.binary_matrix[i].toarray().flatten()
+            present = {
+                vec.feature_names[j]
+                for j, v in enumerate(row) if v
+            }
+            assert present == set(skills[doc_id])
 
     # ---------------------------------------------------------
     # Feature names
     # ---------------------------------------------------------
-
-    def test_feature_names_columns(self, vectorizer: SkillVectorizer):
-        """
-        Feature names length matches matrix column count.
-        """
-        assert (
-            len(vectorizer.feature_names)
-            == vectorizer.tfidf_matrix.shape[1]
-        )
-
-    def test_feature_names_sorted(self, vectorizer: SkillVectorizer):
-        """
-        Feature names are in alphabetical order for stable column indices.
-        """
-        assert vectorizer.feature_names == sorted(
-            vectorizer.feature_names
-        )
 
     def test_transform_vocabulary(self, vectorizer: SkillVectorizer):
         """
@@ -77,27 +66,11 @@ class TestSkillVectorizer:
     # Matrices
     # ---------------------------------------------------------
 
-    def test_binary_matrix_nonempty(self, vectorizer: SkillVectorizer):
-        """
-        The binary matrix has at least one non-zero entry from the
-        synthetic extraction fixture.
-        """
-        assert vectorizer.binary_matrix.nnz > 0
-
     def test_binary_matrix_values(self, vectorizer: SkillVectorizer):
         """
         The binary matrix contains only 0s and 1s.
         """
         assert (vectorizer.binary_matrix.data == 1).all()
-
-    def test_matrices_dimensions(self, vectorizer: SkillVectorizer):
-        """
-        TF-IDF and binary matrices have the same shape.
-        """
-        assert (
-            vectorizer.tfidf_matrix.shape
-            == vectorizer.binary_matrix.shape
-        )
 
     def test_tfidf_differs_from_binary(self, vectorizer: SkillVectorizer):
         """
@@ -108,12 +81,6 @@ class TestSkillVectorizer:
             vectorizer.tfidf_matrix.toarray()
             != vectorizer.binary_matrix.toarray()
         ).any()
-
-    def test_tfidf_values_nonnegative(self, vectorizer: SkillVectorizer):
-        """
-        TF-IDF matrix values are non-negative after L2 normalization.
-        """
-        assert vectorizer.tfidf_matrix.min() >= 0
 
     # ---------------------------------------------------------
     # Serialization
@@ -147,22 +114,3 @@ class TestSkillVectorizer:
         assert vec.tfidf_matrix.shape[0] == 1
         assert vec.binary_matrix.nnz == 2
         assert vec.statistics.mean_skills_per_posting == 2.0
-
-    def test_statistics_fields(self, vectorizer: SkillVectorizer):
-        """
-        Corpus statistics report vocabulary size, sparsity, and
-        per-posting skill counts.
-        """
-        stats = vectorizer.statistics
-        assert stats.vocabulary_size > 0
-        assert 0 <= stats.matrix_sparsity <= 1
-        assert stats.mean_skills_per_posting > 0
-        assert len(stats.skill_frequency) == stats.vocabulary_size
-
-    def test_statistics_frequency(self, vectorizer: SkillVectorizer):
-        """
-        Per-skill frequency counts reflect actual document occurrences.
-        """
-        freq = vectorizer.statistics.skill_frequency
-        assert all(v >= 1 for v in freq.values())
-        assert sum(freq.values()) >= len(vectorizer.document_ids)

--- a/tests/fixtures/matching/apprenticeships.json
+++ b/tests/fixtures/matching/apprenticeships.json
@@ -1,0 +1,22 @@
+[
+  {
+    "rapids_code" : "90046",
+    "term_hours"  : "8000",
+    "title"       : "Electrician"
+  },
+  {
+    "rapids_code" : "90884",
+    "term_hours"  : "6000",
+    "title"       : "Welder"
+  },
+  {
+    "rapids_code" : "90048",
+    "term_hours"  : "4000",
+    "title"       : "Scaffold Builder"
+  },
+  {
+    "rapids_code" : "90050",
+    "term_hours"  : "6000",
+    "title"       : "Construction Equipment Operator"
+  }
+]

--- a/tests/fixtures/matching/cc_programs.json
+++ b/tests/fixtures/matching/cc_programs.json
@@ -1,0 +1,30 @@
+{
+  "degrees": [
+    {
+      "college"    : "CMCC",
+      "credential" : "AAS Degree, Certificate",
+      "program"    : "Building Construction Technology",
+      "url"        : "https://example.com/bct"
+    },
+    {
+      "college"    : "YCCC",
+      "credential" : "Short-term Training",
+      "program"    : "Industrial Welding Techniques",
+      "url"        : "https://example.com/welding"
+    },
+    {
+      "college"    : "WCCC",
+      "credential" : "Certificate",
+      "program"    : "Heavy Equipment Operations",
+      "url"        : "https://example.com/heavy-equip"
+    }
+  ],
+  "initiatives": [
+    {
+      "best_for"    : "Adults seeking immediate entry into the trades",
+      "description" : "4-week tuition-free intensive training in high-demand trades.",
+      "initiative"  : "Maine Construction Academy",
+      "url"         : "https://example.com/mca"
+    }
+  ]
+}

--- a/tests/fixtures/matching/umaine_programs.json
+++ b/tests/fixtures/matching/umaine_programs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "campus"   : "UMaine",
+    "category" : "Construction",
+    "degree"   : "B.S.",
+    "program"  : "Construction Engineering Technology",
+    "url"      : "https://example.com/cet"
+  },
+  {
+    "campus"   : "UMaine",
+    "category" : "Engineering",
+    "degree"   : "B.S.",
+    "program"  : "Electrical and Computer Engineering",
+    "url"      : "https://example.com/ece"
+  }
+]

--- a/tests/matching/test_matcher.py
+++ b/tests/matching/test_matcher.py
@@ -1,0 +1,264 @@
+"""
+Tests for resume matching, gap analysis, and PPMI gap ranking.
+"""
+
+import numpy  as np
+import pandas as pd
+
+from pytest           import mark, param
+from sklearn.pipeline import Pipeline
+
+from chalkline.matching.matcher import ResumeMatcher, _prefix_set, jaccard
+from chalkline.matching.schemas import MatchResult
+
+
+class TestResumeMatcher:
+    """
+    Verify resume projection, cluster assignment, neighbor
+    retrieval, skill gap computation, PPMI gap ranking, and
+    enrichment cross-referencing.
+    """
+
+    # -----------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------
+
+    def test_prefix_inflection(self):
+        """
+        4-char prefix catches inflectional variants that the
+        enrichment pipeline relies on for apprenticeship and
+        program matching.
+        """
+        assert _prefix_set("welding") & _prefix_set("Welder")
+        assert _prefix_set("electrical wiring") & _prefix_set("Electrician")
+        assert not _prefix_set("scaffolding") & _prefix_set("concrete")
+
+    def test_prefix_short_words(self):
+        """
+        Words shorter than 4 characters are excluded from the
+        prefix set to avoid false positives on articles and
+        prepositions.
+        """
+        assert _prefix_set("the NEC code") == {"code"}
+        assert _prefix_set("on") == set()
+
+    # -----------------------------------------------------------------
+    # Jaccard
+    # -----------------------------------------------------------------
+
+    @mark.parametrize("a, b, expected", [
+        param({"a", "b"}, {"c", "d"}, 0.0,   id = "disjoint"),
+        param(set(),      set(),      0.0,   id = "empty"),
+        param({"x", "y", "z"}, {"x", "y", "z"}, 1.0, id = "identical"),
+        param({"a", "b", "c"}, {"b", "c", "d"}, 0.5, id = "partial")
+    ])
+    def test_jaccard(self, a: set[str], b: set[str], expected: float):
+        """
+        Jaccard similarity returns the correct value for each
+        input configuration.
+        """
+        assert jaccard(a, b) == expected
+
+    # -----------------------------------------------------------------
+    # Projection and assignment
+    # -----------------------------------------------------------------
+
+    def test_assignment_singular(
+        self,
+        match_result : MatchResult,
+        matcher      : ResumeMatcher
+    ):
+        """
+        Career family assignment produces exactly one cluster.
+        """
+        assert isinstance(match_result.cluster_id, int)
+        assert match_result.cluster_id in matcher.cluster_ids
+
+    def test_cluster_distances(self, match_result: MatchResult, matcher: ResumeMatcher):
+        """
+        Cluster distances covers every cluster in sorted order.
+        """
+        assert len(match_result.cluster_distances) == len(matcher.cluster_ids)
+        distances = [cd.distance for cd in match_result.cluster_distances]
+        assert distances == sorted(distances)
+
+    def test_empty_resume(self, matcher: ResumeMatcher):
+        """
+        An empty skill list produces a valid result without
+        crashing, returning no gaps and no ranked gaps.
+        """
+        result = matcher.match([])
+        assert result.skill_gaps == [] or isinstance(result.skill_gaps, list)
+        assert result.ranked_gaps == [] or isinstance(result.ranked_gaps, list)
+        assert isinstance(result.cluster_id, int)
+
+    def test_projection_immutable(
+        self,
+        geometry_pipeline : Pipeline,
+        matcher           : ResumeMatcher,
+        resume_skills     : list[str]
+    ):
+        """
+        Projecting a resume does not mutate the fitted transforms.
+        """
+        probe  = [dict.fromkeys(resume_skills, 1)]
+        before = geometry_pipeline.transform(probe).copy()
+        matcher.match(resume_skills)
+        after = geometry_pipeline.transform(probe)
+        np.testing.assert_array_equal(before, after)
+
+    # -----------------------------------------------------------------
+    # Neighbors
+    # -----------------------------------------------------------------
+
+    def test_neighbors_bounded(self, match_result: MatchResult):
+        """
+        Nearest neighbors returns at most 5 results.
+        """
+        assert 1 <= len(match_result.nearest_neighbors) <= 5
+
+    def test_neighbors_sorted(self, match_result: MatchResult):
+        """
+        Nearest neighbors are sorted by ascending distance.
+        """
+        distances = [n.distance for n in match_result.nearest_neighbors]
+        assert distances == sorted(distances)
+
+    # -----------------------------------------------------------------
+    # Skill gaps
+    # -----------------------------------------------------------------
+
+    def test_gap_empty_perfect(
+        self,
+        extracted_skills : dict[str, list[str]],
+        matcher          : ResumeMatcher
+    ):
+        """
+        Skill gap is empty when resume contains all target skills.
+        """
+        all_skills = sorted({
+            skill for skills in extracted_skills.values()
+            for skill in skills
+        })
+        assert matcher.match(all_skills).skill_gaps == []
+
+    def test_gap_excludes_resume(
+        self,
+        match_result  : MatchResult,
+        resume_skills : list[str]
+    ):
+        """
+        No resume skill appears in the skill gap set.
+        """
+        assert set(resume_skills).isdisjoint(set(match_result.skill_gaps))
+
+    def test_gap_nonempty_partial(self, match_result: MatchResult):
+        """
+        A partial resume produces at least one skill gap.
+        """
+        assert len(match_result.skill_gaps) > 0
+
+    # -----------------------------------------------------------------
+    # Gap ranking
+    # -----------------------------------------------------------------
+
+    def test_dedup_unique(self, match_result: MatchResult):
+        """
+        Aggregate trade_paths and programs contain no duplicates.
+
+        The deduplication loop in `match()` filters by
+        `rapids_code` for apprenticeships and by
+        `(institution, program)` for programs. A broken dedup
+        would repeat entries in the career report.
+        """
+        trade_codes = [a.rapids_code for a in match_result.trade_paths]
+        prog_keys   = [
+            (p.institution, p.program) for p in match_result.programs
+        ]
+        assert len(trade_codes) == len(set(trade_codes))
+        assert len(prog_keys) == len(set(prog_keys))
+
+    def test_gaps_ranked(self, match_result: MatchResult):
+        """
+        Ranked gaps are sorted by descending PPMI relevance.
+        """
+        relevances = [g.relevance for g in match_result.ranked_gaps]
+        assert relevances == sorted(relevances, reverse = True)
+
+    def test_ranked_relevance_positive(self, match_result: MatchResult):
+        """
+        Every ranked gap has strictly positive PPMI relevance.
+        Zero-relevance gaps in the ranked list would silently
+        populate the career report with skills that have no
+        co-occurrence relationship to the resume.
+        """
+        for gap in match_result.ranked_gaps:
+            assert gap.relevance > 0
+
+    def test_scoping_affects_rank(self):
+        """
+        In-scope gaps use centroid-scoped reference columns while
+        out-of-scope gaps use the full reference set, producing
+        different relevance scores.
+
+        Constructs a minimal PPMI matrix with resume skills
+        `{"a", "b"}` and centroid scope `{"a", "x"}`. Gap "x" is
+        in scope, so its relevance uses only column "a" yielding
+        `mean([0.5]) = 0.5`. Gap "y" is out of scope, so it uses
+        both columns yielding `mean([0.8, 0.0]) = 0.4`. If the
+        scoping branch were bypassed, both gaps would get the
+        same reference set and the ordering would change.
+        """
+        ppmi = pd.DataFrame(
+            {
+                "a" : {"x" : 0.5, "y" : 0.8},
+                "b" : {"x" : 0.1, "y" : 0.0},
+                "x" : {"a" : 0.5, "b" : 0.1},
+                "y" : {"a" : 0.8, "b" : 0.0}
+            }
+        )
+        ranked, _ = ResumeMatcher._rank_gaps(
+            self         = type("Stub", (), {
+                "_centroid_scope"       : {0: {"a", "x"}},
+                "_find_apprenticeships" : lambda self, s: [],
+                "_find_programs"        : lambda self, s: [],
+                "ppmi_df"               : ppmi
+            })(),
+            cluster_id = 0,
+            resume_set = {"a", "b"},
+            skill_gaps = ["x", "y"],
+            top_k      = 10
+        )
+
+        scores = {g.skill: g.relevance for g in ranked}
+        assert scores["x"] > scores["y"]
+
+    def test_top_k_limits(self, matcher: ResumeMatcher, resume_skills: list[str]):
+        """
+        top_k parameter caps the number of ranked gaps returned.
+        """
+        assert len(matcher.match(resume_skills, top_k = 2).ranked_gaps) <= 2
+
+    def test_unrankable_separate(self, match_result: MatchResult):
+        """
+        Ranked and unrankable gaps together cover all gaps.
+        """
+        ranked_set = {g.skill for g in match_result.ranked_gaps}
+        all_gaps   = set(match_result.skill_gaps)
+        covered    = ranked_set | set(match_result.unrankable_gaps)
+        assert covered == all_gaps
+
+    # -----------------------------------------------------------------
+    # Serialization
+    # -----------------------------------------------------------------
+
+    def test_result_serializable(self, match_result: MatchResult):
+        """
+        MatchResult is JSON-serializable for Marimo cache
+        compatibility.
+        """
+        data = match_result.model_dump()
+        assert isinstance(data, dict)
+        assert "cluster_id" in data
+        roundtrip = MatchResult(**data)
+        assert roundtrip.cluster_id == match_result.cluster_id

--- a/tests/parsing/test_extract.py
+++ b/tests/parsing/test_extract.py
@@ -6,6 +6,7 @@ downstream tokenization.
 """
 
 from pathlib import Path
+from pytest  import mark
 
 from chalkline.parsing.extract import clean_text, extract_pdf
 
@@ -24,18 +25,13 @@ class TestCleanText:
         """
         assert clean_text("hello   world\n\nfoo") == "hello world foo"
 
-    def test_empty_input(self):
+    @mark.parametrize("text", ["", "   \n\n  ", "\n  1  \n  2  \n"])
+    def test_empty_output(self, text: str):
         """
-        An empty input returns an empty string without raising.
+        Degenerate inputs (empty, whitespace-only, page-numbers-only)
+        normalize to an empty string.
         """
-        assert clean_text("") == ""
-
-    def test_page_numbers_only(self):
-        """
-        Input containing only standalone page numbers normalizes to an empty
-        string.
-        """
-        assert clean_text("\n  1  \n  2  \n") == ""
+        assert clean_text(text) == ""
 
     def test_strips_non_ascii(self):
         """
@@ -50,12 +46,6 @@ class TestCleanText:
         result = clean_text("Some text\n  42  \nMore text")
         assert "42" not in result
         assert "Some text" in result
-
-    def test_whitespace_only(self):
-        """
-        Input containing only whitespace normalizes to an empty string.
-        """
-        assert clean_text("   \n\n  ") == ""
 
 
 class TestExtractPdf:
@@ -88,10 +78,3 @@ class TestExtractPdf:
         assert "Page 1" in result
         assert "Page 2" in result
 
-    def test_pdf_clean_text(self):
-        """
-        Extracted PDF text normalizes cleanly for downstream use.
-        """
-        result = clean_text(extract_pdf(FIXTURES / "sample.pdf"))
-        assert "Walt Amper" in result
-        assert "\n" not in result

--- a/tests/pipeline/test_programs.py
+++ b/tests/pipeline/test_programs.py
@@ -1,0 +1,123 @@
+"""
+Tests for the shared educational program loader.
+"""
+
+from json    import dumps
+from pathlib import Path
+from pytest  import raises
+
+from chalkline.pipeline.programs import load_programs
+
+
+class TestLoadPrograms:
+    """
+    Verify field normalization and loading from both community
+    college and university reference files.
+    """
+
+    def test_cc_normalization(self, tmp_path: Path):
+        """
+        Community college `college` field maps to `institution`.
+        """
+        (tmp_path / "cc_programs.json").write_text(dumps({
+            "degrees": [{
+                "college"    : "CMCC",
+                "credential" : "AAS Degree",
+                "program"    : "Building Construction Technology",
+                "url"        : "https://example.com"
+            }]
+        }))
+        programs = load_programs(tmp_path)
+        assert len(programs) == 1
+        assert programs[0].institution == "CMCC"
+        assert programs[0].credential == "AAS Degree"
+
+    def test_combined_count(self, tmp_path: Path):
+        """
+        Degrees, initiatives, and university programs merge into a
+        single list.
+        """
+        (tmp_path / "cc_programs.json").write_text(dumps({
+            "degrees": [
+                {"college": "A", "credential": "C", "program": "P1", "url": "u"},
+                {"college": "B", "credential": "D", "program": "P2", "url": "u"}
+            ],
+            "initiatives": [
+                {"best_for": "BF", "description": "D", "initiative": "I1", "url": "u"}
+            ]
+        }))
+        (tmp_path / "umaine_programs.json").write_text(dumps([
+            {"campus": "X", "category": "C", "degree": "D", "program": "P3", "url": "u"}
+        ]))
+        assert len(load_programs(tmp_path)) == 4
+
+    def test_initiative_missing_url(self, tmp_path: Path):
+        """
+        Initiatives without a URL default to an empty string.
+        """
+        (tmp_path / "cc_programs.json").write_text(dumps({
+            "degrees"     : [],
+            "initiatives" : [{
+                "best_for"    : "Entry-level workers",
+                "description" : "Training program.",
+                "initiative"  : "Pre-Apprenticeship"
+            }]
+        }))
+        programs = load_programs(tmp_path)
+        assert len(programs) == 1
+        assert programs[0].url == ""
+
+    def test_initiative_normalization(self, tmp_path: Path):
+        """
+        Workforce initiatives map `initiative` to `program`,
+        `best_for` to `credential`, and set institution to
+        `"Statewide"`.
+        """
+        (tmp_path / "cc_programs.json").write_text(dumps({
+            "degrees": [],
+            "initiatives": [{
+                "best_for"    : "Adults seeking entry into the trades",
+                "description" : "4-week training.",
+                "initiative"  : "Maine Construction Academy",
+                "url"         : "https://example.com/mca"
+            }]
+        }))
+        programs = load_programs(tmp_path)
+        assert len(programs) == 1
+        assert programs[0].program == "Maine Construction Academy"
+        assert programs[0].institution == "Statewide"
+        assert programs[0].credential == "Adults seeking entry into the trades"
+
+    def test_malformed_entry(self, tmp_path: Path):
+        """
+        A record missing a required key raises `KeyError` rather
+        than silently producing a corrupt program.
+        """
+        (tmp_path / "cc_programs.json").write_text(dumps({
+            "degrees" : [{"college" : "CMCC"}]
+        }))
+        with raises(KeyError):
+            load_programs(tmp_path)
+
+    def test_missing_files(self, tmp_path: Path):
+        """
+        Missing reference files produce an empty list.
+        """
+        assert load_programs(tmp_path) == []
+
+    def test_umaine_normalization(self, tmp_path: Path):
+        """
+        University `campus` maps to `institution` and `degree`
+        maps to `credential`.
+        """
+        (tmp_path / "umaine_programs.json").write_text(dumps([{
+            "campus"   : "UMaine",
+            "category" : "Construction",
+            "degree"   : "B.S.",
+            "program"  : "Construction Engineering Technology",
+            "url"      : "https://example.com"
+        }]))
+        programs = load_programs(tmp_path)
+        assert len(programs) == 1
+        assert programs[0].institution == "UMaine"
+        assert programs[0].credential == "B.S."

--- a/tests/pipeline/test_schemas.py
+++ b/tests/pipeline/test_schemas.py
@@ -1,14 +1,17 @@
 """
-Tests for pipeline configuration schemas.
+Tests for pipeline configuration and shared reference data schemas.
 
-Validates `PipelineConfig` field constraints, defaults, and the
-`extra="forbid"` policy that catches typos early.
+Validates `PipelineConfig` field constraints, defaults, the
+`extra="forbid"` policy, and shared `ApprenticeshipContext` and
+`ProgramRecommendation` data models.
 """
 
 from pathlib import Path
 from pytest  import mark, raises
 
+from chalkline.pipeline.schemas import ApprenticeshipContext
 from chalkline.pipeline.schemas import DistanceMetric, PipelineConfig
+from chalkline.pipeline.schemas import ProgramRecommendation
 
 
 class TestPipelineConfig:
@@ -29,6 +32,14 @@ class TestPipelineConfig:
             postings_dir = tmp_path,
             **overrides
         )
+
+    def test_cooccurrence_float(self, tmp_path: Path):
+        """
+        `min_cooccurrence` accepts a float fraction, not only
+        the default `"auto"` string.
+        """
+        config = self._config(tmp_path, min_cooccurrence = 0.05)
+        assert config.min_cooccurrence == 0.05
 
     @mark.parametrize("field, expected", [
         ("distance_metric",      DistanceMetric.EUCLIDEAN),
@@ -82,14 +93,6 @@ class TestPipelineConfig:
         with raises(Exception):
             PipelineConfig()
 
-    def test_override(self, tmp_path: Path):
-        """
-        Non-default values are accepted for optional fields.
-        """
-        config = self._config(tmp_path, max_components=50, random_seed=99)
-        assert config.max_components == 50
-        assert config.random_seed == 99
-
     @mark.parametrize("threshold", [0.0, 1.5])
     def test_variance_threshold_boundary(self, threshold: float, tmp_path: Path):
         """
@@ -104,3 +107,36 @@ class TestPipelineConfig:
         variance.
         """
         assert self._config(tmp_path, variance_threshold=1.0).variance_threshold == 1.0
+
+    # -----------------------------------------------------------------
+    # ApprenticeshipContext
+    # -----------------------------------------------------------------
+
+    def test_apprenticeship_extra(self):
+        """
+        Unknown fields are rejected per extra="forbid".
+        """
+        with raises(Exception, match="Extra inputs"):
+            ApprenticeshipContext(
+                rapids_code = "90046",
+                term_hours  = "8000",
+                trade       = "Electrician",
+                unknown     = True
+            )
+
+    # -----------------------------------------------------------------
+    # ProgramRecommendation
+    # -----------------------------------------------------------------
+
+    def test_program_extra(self):
+        """
+        Unknown fields are rejected per extra="forbid".
+        """
+        with raises(Exception, match="Extra inputs"):
+            ProgramRecommendation(
+                credential  = "AAS",
+                institution = "CMCC",
+                program     = "Test",
+                unknown     = True,
+                url         = "https://example.com"
+            )

--- a/tests/reduction/test_pca.py
+++ b/tests/reduction/test_pca.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from joblib  import dump, load
 from pathlib import Path
-from pytest  import mark
 
 from chalkline.extraction.vectorize import SkillVectorizer
 from chalkline.reduction.pca       import PcaReducer
@@ -25,20 +24,6 @@ class TestPcaReducer:
     # ---------------------------------------------------------
     # Component selection
     # ---------------------------------------------------------
-
-    def test_cumulative_variance(self, pca_reducer: PcaReducer):
-        """
-        Cumulative variance is reported even when the threshold
-        is not fully reached.
-        """
-        assert 0 < pca_reducer.cumulative_variance <= 1.0
-
-    def test_explained_variance_length(self, pca_reducer: PcaReducer):
-        """
-        The full variance profile contains one entry per component
-        from the analysis fit.
-        """
-        assert len(pca_reducer.explained_variance_ratio) >= pca_reducer.n_selected
 
     def test_max_components_capped(self, vectorizer: SkillVectorizer):
         """
@@ -56,20 +41,23 @@ class TestPcaReducer:
         )
         assert reducer.n_selected <= min(matrix.shape) - 1
 
-    def test_n_selected_bounded(self, pca_reducer: PcaReducer):
+    def test_threshold_minimum(self, vectorizer: SkillVectorizer):
         """
-        Selected components do not exceed the configured maximum.
+        Component selection picks the smallest k where cumulative
+        variance meets the threshold, not k+1. A very low threshold
+        should select exactly one component, verifying the
+        `searchsorted + 1` logic does not over-select.
         """
-        assert 1 <= pca_reducer.n_selected
-
-    def test_variance_ratios_bounded(self, pca_reducer: PcaReducer):
-        """
-        Explained variance ratios are non-negative and sum to at
-        most 1.0.
-        """
-        evr = pca_reducer.explained_variance_ratio
-        assert (evr >= 0).all()
-        assert evr.sum() <= 1.0 + 1e-10
+        reducer = PcaReducer(
+            document_ids       = vectorizer.document_ids,
+            feature_names      = vectorizer.feature_names,
+            max_components     = min(vectorizer.tfidf_matrix.shape) - 1,
+            random_seed        = 42,
+            tfidf_matrix       = vectorizer.tfidf_matrix,
+            variance_threshold = 0.01
+        )
+        assert reducer.n_selected == 1
+        assert reducer.cumulative_variance >= 0.01
 
     # ---------------------------------------------------------
     # Coordinates
@@ -95,19 +83,6 @@ class TestPcaReducer:
     # Loadings
     # ---------------------------------------------------------
 
-    def test_loadings_aligned(self, pca_reducer: PcaReducer):
-        """
-        Each loading has the same number of terms and weights.
-        """
-        for loading in pca_reducer.loadings():
-            assert len(loading.terms) == len(loading.weights)
-
-    def test_loadings_count(self, pca_reducer: PcaReducer):
-        """
-        One loading entry per selected component.
-        """
-        assert len(pca_reducer.loadings()) == pca_reducer.n_selected
-
     def test_loadings_skill_names(self, pca_reducer: PcaReducer):
         """
         Top-loading terms per component return skill names, not
@@ -116,22 +91,6 @@ class TestPcaReducer:
         for loading in pca_reducer.loadings():
             assert all(isinstance(t, str) for t in loading.terms)
             assert all(not t.isdigit() for t in loading.terms)
-
-    @mark.parametrize("top_n", [1, 2, 5])
-    def test_loadings_top_n(self, pca_reducer: PcaReducer, top_n: int):
-        """
-        Requesting fewer top terms limits the returned list length.
-        """
-        for loading in pca_reducer.loadings(top_n=top_n):
-            assert len(loading.terms) <= top_n
-            assert len(loading.weights) <= top_n
-
-    def test_loadings_variance_positive(self, pca_reducer: PcaReducer):
-        """
-        Each component's variance ratio is positive.
-        """
-        for loading in pca_reducer.loadings():
-            assert loading.variance_ratio > 0
 
     def test_loadings_weight_order(self, pca_reducer: PcaReducer):
         """

--- a/tests/reduction/test_schemas.py
+++ b/tests/reduction/test_schemas.py
@@ -14,24 +14,6 @@ class TestComponentLoading:
     """
 
     # ---------------------------------------------------------
-    # Construction
-    # ---------------------------------------------------------
-
-    def test_valid(self):
-        """
-        A well-formed loading with matching terms and weights
-        validates successfully.
-        """
-        loading = ComponentLoading(
-            index          = 0,
-            terms          = ["welding", "scaffolding"],
-            variance_ratio = 0.35,
-            weights        = [0.8, 0.6]
-        )
-        assert loading.index == 0
-        assert loading.terms == ["welding", "scaffolding"]
-
-    # ---------------------------------------------------------
     # Rejection
     # ---------------------------------------------------------
 
@@ -45,7 +27,7 @@ class TestComponentLoading:
                 "weights"        : [0.5]
             },
             "Extra inputs",
-            id="extra_field"
+            id = "extra_field"
         ),
         param(
             {
@@ -55,12 +37,12 @@ class TestComponentLoading:
                 "weights"        : [0.5]
             },
             "greater than or equal",
-            id="negative_index"
+            id = "negative_index"
         )
     ])
     def test_invalid(self, kwargs, match):
         """
         Invalid kwargs are rejected by Pydantic validation.
         """
-        with raises(ValueError, match=match):
+        with raises(ValueError, match = match):
             ComponentLoading(**kwargs)


### PR DESCRIPTION
### 📐 Quick Summary

Implements the resume matching module, projecting an uploaded resume into the fitted PCA space[^45] and matching it to career families via cluster centroids with configurable distance metrics[^43]. The matcher identifies skill gaps from neighboring postings[^44], ranks gaps by centroid-scoped mean PPMI relevance[^42], and cross-references gaps against AGC apprenticeship programs and educational programs[^52] for actionable recommendations. Shared reference data schemas and a program loader are extracted into `pipeline/` for reuse across matching, pathways, and report generation.

Two spec departures are documented in the implementation comments, namely abbreviated field names on `MatchResult` for code readability and deferred `pairwise_distances` multi-metric comparison pending a downstream UI consumer.

***

### 🧱 Key Changes

#### Matching Subpackage

- Add `src/chalkline/matching/matcher.py` with `ResumeMatcher` projecting resumes through the fitted geometry `Pipeline` via `dict.fromkeys(skills, 1)` binary conversion, computing cluster centroids as mean PCA-scaled coordinates, assigning to the nearest centroid via `NearestNeighbors`, and finding top-5 within-family neighbors with Jaccard similarity[^43] on discrete skill sets
- Add centroid-scoped PPMI gap ranking[^42] restricted to the matched cluster's top-50 TF-IDF centroid terms, with full-matrix fallback for out-of-scope gaps and separate collection of unrankable skills
- Add 4-character prefix enrichment matching linking gap skills to apprenticeship trades and educational programs via derivational word-root overlap, bridging inflectional variants (*welding/welder, electrical/electrician*) that standard stemmers and lemmatizers cannot resolve
- Add `src/chalkline/matching/schemas.py` with `ClusterDistance`, `NeighborMatch`, `RankedGap`, and `MatchResult` models
- Add Jaccard fallback for small clusters (*fewer than 5 postings*) using corpus-wide Jaccard similarity rather than PCA-space distances where the sparse feature space lacks discriminative power

#### Shared Reference Data

- Add `src/chalkline/pipeline/programs.py` with `load_programs` normalizing community college degrees (*`college` to `institution`*), workforce initiatives (*`initiative` to `program`, `best_for` to `credential`*), and university programs (*`campus` to `institution`, `degree` to `credential`*) into a unified `ProgramRecommendation` schema
- Add `ApprenticeshipContext` and `ProgramRecommendation` models to `src/chalkline/pipeline/schemas.py` for reuse across [CL-10](https://github.com/Jybbs/chalkline/issues/10), [CL-11](https://github.com/Jybbs/chalkline/issues/11), and [CL-12](https://github.com/Jybbs/chalkline/issues/12)

#### Co-occurrence Network Extensions

- Add `pmi_dataframe()` method to `CooccurrenceNetwork` in `src/chalkline/association/cooccurrence.py` returning a symmetric NPMI DataFrame indexed by skill names for gap ranking lookups
- Refactor `communities()` and `compare_measures()` from imperative loops to list comprehensions
- Replace `nx.isolates()` with component-based isolate counting in `diagnostics()`
- Remove `TYPE_CHECKING` guard for `spmatrix` in favor of runtime import

#### Tests

- Add `tests/matching/test_matcher.py` with **22** tests covering projection immutability, cluster assignment, neighbor bounds and sorting, Jaccard parametrized across 4 cases, skill gap computation, PPMI ranking with centroid scoping verification, top-k limiting, unrankable separation, enrichment deduplication, prefix matching, and JSON serialization round-trip
- Add `tests/pipeline/test_programs.py` with **7** tests covering field normalization for all three program types, combined loading, missing URL defaults, malformed entry rejection, and missing file graceful degradation
- Add matching fixture data in `tests/fixtures/matching/` with synthetic apprenticeships, community college programs, and university programs
- Extend `tests/conftest.py` with matching fixture chain from geometry pipeline through matcher construction
- Overhaul test suite across all domains to remove self-confirming and redundant tests, retaining only production-relevant behavioral verification

***

## 🪚 Implementation Notes

### Skill Gap and PPMI Ranking

The skill gap is the set difference between the union of neighbor skills and the resume's own skills:

$`
\hspace{0.5cm} \displaystyle
\text{gap} = S_{\text{neighbors}} \setminus S_{\text{resume}}
`$
<br>

Each gap skill is ranked by its mean PPMI[^42] against the resume's existing skills, scoped to the matched cluster's top-50 TF-IDF centroid terms to keep the ranking domain-coherent rather than corpus-wide:

$`
\hspace{0.5cm} \displaystyle
\text{relevance}(g) = \frac{1}{|S_r|} \sum_{s \in S_r} \text{PPMI}(g, s)
`$
<br>

Skills outside the centroid scope fall back to the full PPMI matrix. Skills absent from the PPMI index or with zero mean relevance are collected separately as unrankable, preventing zero-signal gaps from populating the career report.

***

### 🔩 Related Issues

- Closes #10

***

### 📚 References

[^16]: Rosenberger, et al. 2025. "CareerBERT: Matching Resumes to ESCO Jobs in a Shared Embedding Space for Generic Job Recommendations." *Expert Systems with Applications* 275: 127043. https://doi.org/10.1016/j.eswa.2025.127043

[^42]: Church & Hanks. 1990. "Word Association Norms, Mutual Information, and Lexicography." *Computational Linguistics* 16(1): 22-29. https://aclanthology.org/J90-1003/

[^43]: Levy, Shalom & Chalamish. 2025. "A Guide to Similarity Measures and Their Data Science Applications." *Journal of Big Data* 12: 188. https://doi.org/10.1186/s40537-025-01227-1

[^44]: de Groot, et al. 2021. "Job Posting-Enriched Knowledge Graph for Skills-based Matching." *RecSys in HR '21 Workshop, CEUR Workshop Proceedings, Vol. 2967*. https://arxiv.org/abs/2109.02554

[^45]: Khelkhal & Lanasri. 2025. "Smart-Hiring: An Explainable End-to-End Pipeline for CV Information Extraction and Job Matching." https://doi.org/10.48550/arXiv.2511.02537

[^52]: Frej, et al. 2024. "Course Recommender Systems Need to Consider the Job Market." *Proceedings of the 47th ACM SIGIR Conference*. https://doi.org/10.1145/3626772.3657847
