### PR TITLE
CL-12: Implement centrality analysis and widest-path routing

### DIFF
--- a/src/chalkline/collection/collector.py
+++ b/src/chalkline/collection/collector.py
@@ -15,7 +15,7 @@ from logging  import basicConfig, getLogger, INFO
 from pathlib  import Path
 
 from chalkline.collection.schemas import Posting
-from chalkline.collection.storage import save
+from chalkline.collection.storage import CorpusStorage
 
 
 logger = getLogger(__name__)
@@ -49,6 +49,7 @@ class Collector:
         self.results_wanted = results_wanted
         self.search_terms   = search_terms
         self.sites          = sites
+        self.storage        = CorpusStorage(postings_dir)
 
     @staticmethod
     def _parse_record(record: dict) -> Posting | None:
@@ -110,10 +111,10 @@ class Collector:
         """
         Collect postings from all search terms and persist to disk.
         """
-        save([
+        self.storage.save([
             p for record in self._scrape().to_dict("records")
             if (p := self._parse_record(record))
-        ], self.postings_dir)
+        ])
 
 
 if __name__ == "__main__":

--- a/src/chalkline/collection/schemas.py
+++ b/src/chalkline/collection/schemas.py
@@ -30,7 +30,7 @@ class Posting(BaseModel, extra="forbid"):
     source_url  : NonEmptyStr
     title       : NonEmptyStr
 
-    date_collected : date               = Field(default_factory=date.today)
+    date_collected : date = Field(default_factory=date.today)
     id             : NonEmptyStr | None = None
     location       : NonEmptyStr | None = None
 

--- a/src/chalkline/collection/storage.py
+++ b/src/chalkline/collection/storage.py
@@ -13,65 +13,80 @@ from pydantic import TypeAdapter
 from chalkline.collection.schemas import Posting
 
 
-Postings = TypeAdapter(list[Posting])
-logger   = getLogger(__name__)
+logger = getLogger(__name__)
 
 
-def deduplicate(postings: list[Posting]) -> list[Posting]:
+class CorpusStorage:
     """
-    Retain the most recently collected version of each posting.
+    JSON-backed persistence for the posting corpus.
 
-    When duplicate `id` values exist, the posting with the latest
-    `date_collected` wins.
-
-    Args:
-        postings: The list of postings to deduplicate.
-
-    Returns:
-        A deduplicated list with the latest version of each.
+    Owns the `corpus.json` lifecycle within a single directory,
+    supporting incremental collection where each `save` merges
+    new postings with the existing corpus and deduplicates by
+    composite posting ID.
     """
-    return list({
-        p.id: p for p in
-        sorted(postings, key=lambda p: p.date_collected)
-    }.values())
 
+    Postings = TypeAdapter(list[Posting])
 
-def load(postings_dir: Path) -> list[Posting]:
-    """
-    Load all postings from the corpus file.
+    def __init__(self, postings_dir: Path):
+        """
+        Bind storage to a corpus directory.
 
-    Returns an empty list when `corpus.json` does not exist, allowing the
-    collector to bootstrap from an empty directory.
+        Args:
+            postings_dir: Directory containing `corpus.json`.
+        """
+        self.corpus_path  = postings_dir / "corpus.json"
+        self.postings_dir = postings_dir
 
-    Args:
-        postings_dir: The directory containing `corpus.json`.
+    def deduplicate(self, postings: list[Posting]) -> list[Posting]:
+        """
+        Retain the most recently collected version of each posting.
 
-    Returns:
-        The deserialized list of postings.
-    """
-    try:
-        return Postings.validate_json((postings_dir / "corpus.json").read_bytes())
-    except FileNotFoundError:
-        return []
+        When duplicate `id` values exist, the posting with the
+        latest `date_collected` wins.
 
+        Args:
+            postings: The list of postings to deduplicate.
 
-def save(postings: list[Posting], postings_dir: Path):
-    """
-    Persist postings to disk with deduplication.
+        Returns:
+            A deduplicated list with the latest version of each.
+        """
+        return list({
+            p.id: p for p in
+            sorted(postings, key=lambda p: p.date_collected)
+        }.values())
 
-    Merges `postings` with any existing corpus on disk, deduplicates by
-    composite `id`, and writes the result.
+    def load(self) -> list[Posting]:
+        """
+        Load all postings from the corpus file.
 
-    Args:
-        postings     : The new postings to save.
-        postings_dir : The directory to write `corpus.json` into.
-    """
-    postings_dir.mkdir(parents=True, exist_ok=True)
+        Returns an empty list when `corpus.json` does not exist,
+        allowing the collector to bootstrap from an empty directory.
 
-    (corpus_path := postings_dir / "corpus.json").write_bytes(
-        Postings.dump_json(
-            merged := deduplicate(load(postings_dir) + postings),
-            indent=2
+        Returns:
+            The deserialized list of postings.
+        """
+        try:
+            return self.Postings.validate_json(self.corpus_path.read_bytes())
+        except FileNotFoundError:
+            return []
+
+    def save(self, postings: list[Posting]):
+        """
+        Persist postings to disk with deduplication.
+
+        Merges `postings` with any existing corpus on disk,
+        deduplicates by composite `id`, and writes the result.
+
+        Args:
+            postings: The new postings to save.
+        """
+        self.postings_dir.mkdir(parents=True, exist_ok=True)
+
+        self.corpus_path.write_bytes(
+            self.Postings.dump_json(
+                merged := self.deduplicate(self.load() + postings),
+                indent=2
+            )
         )
-    )
-    logger.info(f"Saved {len(merged)} postings to {corpus_path}")
+        logger.info(f"Saved {len(merged)} postings to {self.corpus_path}")

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -9,25 +9,22 @@ and career report display. Edge direction follows a strict total order
 on (Job Zone, cluster ID), guaranteeing acyclicity.
 """
 
-import numpy as np
+import networkx as nx
+import numpy    as np
 
-from functools           import cached_property
-from itertools           import combinations
-from json                import dumps
-from kneed               import KneeLocator
-from logging             import getLogger
-from networkx            import dag_longest_path, DiGraph
-from networkx            import node_link_data, path_weight
-from networkx            import remove_node_attributes
-from networkx            import set_edge_attributes, write_graphml
-from networkx.algorithms import community
-from pathlib             import Path
-from sklearn.metrics     import adjusted_rand_score
+from functools       import cached_property
+from itertools       import combinations
+from json            import dumps
+from kneed           import KneeLocator
+from logging         import getLogger
+from pathlib         import Path
+from sklearn.metrics import adjusted_rand_score
 
 from chalkline.association.cooccurrence import CooccurrenceNetwork
 from chalkline.pathways.schemas         import AlignmentDiagnostics, GraphExport
 from chalkline.pathways.schemas         import LongestPath
-from chalkline.pipeline.schemas         import ClusterProfile
+from chalkline.pipeline.schemas         import ApprenticeshipContext
+from chalkline.pipeline.schemas         import ClusterProfile, ProgramRecommendation
 
 
 logger = getLogger(__name__)
@@ -45,9 +42,9 @@ class CareerPathwayGraph:
 
     def __init__(
         self,
-        network           : CooccurrenceNetwork,
-        profiles          : dict[int, ClusterProfile],
-        max_graph_density : float = 0.05
+        network     : CooccurrenceNetwork,
+        profiles    : dict[int, ClusterProfile],
+        max_density : float = 0.05
     ):
         """
         Build the career pathway graph from pre-enriched upstream
@@ -56,23 +53,33 @@ class CareerPathwayGraph:
         Edge weights are thresholded via knee detection on the
         sorted weight curve, matching the pattern used by
         `CooccurrenceNetwork._find_threshold`. The
-        `max_graph_density` ceiling serves as a secondary guard
+        `max_density` ceiling serves as a secondary guard
         when the knee still produces a graph too dense for
         career pathway navigation.
 
         Args:
-            network           : NPMI matrix, vocabulary, and
-                                Louvain partition.
-            profiles          : Enriched cluster characteristics from the
-                                orchestrator.
-            max_graph_density : Density ceiling for edge pruning.
+            network     : NPMI matrix, vocabulary, and Louvain partition.
+            profiles    : Enriched cluster characteristics from the
+                          orchestrator.
+            max_density : Density ceiling for edge pruning.
         """
-        self.max_graph_density = max_graph_density
-        self.network           = network
-        self.profiles          = profiles
-
+        self.network     = network
+        self.profiles    = profiles
+        self.max_density = max_density
         self.cluster_ids = sorted(self.profiles)
         self.graph       = self._build_graph()
+
+    @cached_property
+    def apprenticeships(self) -> list[ApprenticeshipContext]:
+        """
+        Deduplicated apprenticeship contexts across all cluster
+        profiles, keyed by RAPIDS code.
+        """
+        return list({
+            p.apprenticeship.rapids_code: p.apprenticeship
+            for p in self.profiles.values()
+            if p.apprenticeship
+        }.values())
 
     @cached_property
     def alignment(self) -> AlignmentDiagnostics:
@@ -108,7 +115,7 @@ class CareerPathwayGraph:
         )
 
         if (skill_graph := self.network.graph()).size():
-            result.modularity = float(community.modularity(
+            result.modularity = float(nx.community.modularity(
                 skill_graph,
                 communities = self.network.partition,
                 weight      = "weight"
@@ -123,13 +130,25 @@ class CareerPathwayGraph:
         if not self.graph:
             return LongestPath(path=[], path_weight=0.0)
 
-        path = dag_longest_path(
+        path = nx.dag_longest_path(
             self.graph, weight="weight", default_weight=0
         )
         return LongestPath(
             path        = path,
-            path_weight = path_weight(self.graph, path, "weight")
+            path_weight = nx.path_weight(self.graph, path, "weight")
         )
+
+    @cached_property
+    def programs(self) -> list[ProgramRecommendation]:
+        """
+        Deduplicated program recommendations across all cluster
+        profiles, keyed by (institution, program name).
+        """
+        return list({
+            (p.institution, p.program): p
+            for profile in self.profiles.values()
+            for p in profile.programs
+        }.values())
 
     @cached_property
     def skill_to_cluster(self) -> dict[str, int]:
@@ -147,7 +166,7 @@ class CareerPathwayGraph:
             for s in p.skills
         }
 
-    def _build_graph(self) -> DiGraph:
+    def _build_graph(self) -> nx.DiGraph:
         """
         Construct the directed weighted career graph.
 
@@ -166,8 +185,8 @@ class CareerPathwayGraph:
                 f"degrades edge weight discrimination"
             )
 
-        (G := DiGraph()).add_nodes_from(
-            (cid, profile.model_dump())
+        (G := nx.DiGraph()).add_nodes_from(
+            (cid, profile.model_dump(mode="json"))
             for cid, profile in self.profiles.items()
         )
 
@@ -183,14 +202,14 @@ class CareerPathwayGraph:
             threshold = self._find_threshold(weights)
 
             max_edges = int(
-                self.max_graph_density * n * (n - 1) / 2
+                self.max_density * n * (n - 1) / 2
             ) if n > 1 else 0
             if max_edges and sum(1 for w in weights if w >= threshold) > max_edges:
                 threshold = weights[-max_edges]
                 logger.info(
                     f"Density cap raised threshold to {threshold:.3f} "
                     f"({max_edges} edges at density "
-                    f"{self.max_graph_density})"
+                    f"{self.max_density})"
                 )
 
             G.add_weighted_edges_from(
@@ -203,22 +222,11 @@ class CareerPathwayGraph:
                 for cid, p in self.profiles.items()
                 if p.apprenticeship
             }
-            set_edge_attributes(G, {
-                (s, t): str(hours[t] - hours[s])
+            nx.set_edge_attributes(G, {
+                (s, t): hours[t] - hours[s]
                 for s, t in G.edges()
                 if s in hours and t in hours
             }, "term_hours_delta")
-
-        G.graph["apprenticeships"] = list({
-            p.apprenticeship.rapids_code: p.apprenticeship
-            for p in self.profiles.values()
-            if p.apprenticeship
-        }.values())
-        G.graph["programs"] = list({
-            (p.institution, p.program): p
-            for profile in self.profiles.values()
-            for p in profile.programs
-        }.values())
 
         return G
 
@@ -313,26 +321,20 @@ class CareerPathwayGraph:
 
         graphml_path = output_dir / "career_graph.graphml"
         scalar_graph = self.graph.copy()
-        scalar_graph.graph.pop("apprenticeships", None)
-        scalar_graph.graph.pop("programs", None)
-        remove_node_attributes(
+        nx.remove_node_attributes(
             scalar_graph, "apprenticeship", "programs", "skills", "terms"
         )
+
         for _, _, data in scalar_graph.edges(data=True):
             for attr in ("apprenticeships", "bridging_skills", "programs"):
                 data.pop(attr, None)
-        write_graphml(scalar_graph, graphml_path)
+        nx.write_graphml(scalar_graph, graphml_path)
 
         json_path = output_dir / "career_graph.json"
-        nld = node_link_data(self.graph)
-        nld["graph"]["apprenticeships"] = [
-            a.model_dump(mode="json")
-            for a in nld["graph"]["apprenticeships"]
-        ]
-        nld["graph"]["programs"] = [
-            p.model_dump(mode="json")
-            for p in nld["graph"]["programs"]
-        ]
+        nld       = nx.node_link_data(self.graph)
+        dump      = lambda items: [x.model_dump(mode="json") for x in items]
+        nld["apprenticeships"] = dump(self.apprenticeships)
+        nld["programs"]        = dump(self.programs)
         json_path.write_text(dumps(nld, indent=2))
 
         return GraphExport(

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -11,18 +11,18 @@ on (Job Zone, cluster ID), guaranteeing acyclicity.
 
 import numpy as np
 
-from functools                     import cached_property
-from itertools                     import combinations
-from json                          import dumps
-from kneed                         import KneeLocator
-from logging                       import getLogger
-from networkx                      import dag_longest_path, DiGraph
-from networkx                      import node_link_data, path_weight
-from networkx                      import remove_node_attributes
-from networkx                      import set_edge_attributes, write_graphml
-from networkx.algorithms.community import modularity
-from pathlib                       import Path
-from sklearn.metrics               import adjusted_rand_score
+from functools           import cached_property
+from itertools           import combinations
+from json                import dumps
+from kneed               import KneeLocator
+from logging             import getLogger
+from networkx            import dag_longest_path, DiGraph
+from networkx            import node_link_data, path_weight
+from networkx            import remove_node_attributes
+from networkx            import set_edge_attributes, write_graphml
+from networkx.algorithms import community
+from pathlib             import Path
+from sklearn.metrics     import adjusted_rand_score
 
 from chalkline.association.cooccurrence import CooccurrenceNetwork
 from chalkline.pathways.schemas         import AlignmentDiagnostics, GraphExport
@@ -108,7 +108,7 @@ class CareerPathwayGraph:
         )
 
         if (skill_graph := self.network.graph()).size():
-            result.modularity = float(modularity(
+            result.modularity = float(community.modularity(
                 skill_graph,
                 communities = self.network.partition,
                 weight      = "weight"
@@ -209,6 +209,17 @@ class CareerPathwayGraph:
                 if s in hours and t in hours
             }, "term_hours_delta")
 
+        G.graph["apprenticeships"] = list({
+            p.apprenticeship.rapids_code: p.apprenticeship
+            for p in self.profiles.values()
+            if p.apprenticeship
+        }.values())
+        G.graph["programs"] = list({
+            (p.institution, p.program): p
+            for profile in self.profiles.values()
+            for p in profile.programs
+        }.values())
+
         return G
 
     def _find_threshold(self, weights: list[float]) -> float:
@@ -302,6 +313,8 @@ class CareerPathwayGraph:
 
         graphml_path = output_dir / "career_graph.graphml"
         scalar_graph = self.graph.copy()
+        scalar_graph.graph.pop("apprenticeships", None)
+        scalar_graph.graph.pop("programs", None)
         remove_node_attributes(
             scalar_graph, "apprenticeship", "programs", "skills", "terms"
         )
@@ -311,9 +324,16 @@ class CareerPathwayGraph:
         write_graphml(scalar_graph, graphml_path)
 
         json_path = output_dir / "career_graph.json"
-        json_path.write_text(
-            dumps(node_link_data(self.graph), indent=2)
-        )
+        nld = node_link_data(self.graph)
+        nld["graph"]["apprenticeships"] = [
+            a.model_dump(mode="json")
+            for a in nld["graph"]["apprenticeships"]
+        ]
+        nld["graph"]["programs"] = [
+            p.model_dump(mode="json")
+            for p in nld["graph"]["programs"]
+        ]
+        json_path.write_text(dumps(nld, indent=2))
 
         return GraphExport(
             graphml_path = graphml_path,

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -305,6 +305,9 @@ class CareerPathwayGraph:
         remove_node_attributes(
             scalar_graph, "apprenticeship", "programs", "skills", "terms"
         )
+        for _, _, data in scalar_graph.edges(data=True):
+            for attr in ("apprenticeships", "bridging_skills", "programs"):
+                data.pop(attr, None)
         write_graphml(scalar_graph, graphml_path)
 
         json_path = output_dir / "career_graph.json"

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -99,7 +99,7 @@ class CareerPathwayGraph:
 
         if not shared:
             logger.warning("No shared skills for ARI computation")
-            return AlignmentDiagnostics(ari=0.0)
+            return AlignmentDiagnostics()
 
         if len(self.profiles) > len(shared) / 2:
             logger.warning(
@@ -128,12 +128,13 @@ class CareerPathwayGraph:
         Longest weighted path through the career graph.
         """
         if not self.graph:
-            return LongestPath(path=[], path_weight=0.0)
+            return LongestPath()
 
         path = nx.dag_longest_path(
             self.graph, weight="weight", default_weight=0
         )
         return LongestPath(
+            edge_count  = self.graph.number_of_edges(),
             path        = path,
             path_weight = nx.path_weight(self.graph, path, "weight")
         )
@@ -227,6 +228,14 @@ class CareerPathwayGraph:
                 for s, t in G.edges()
                 if s in hours and t in hours
             }, "term_hours_delta")
+
+        if not G.number_of_edges():
+            logger.warning(
+                f"Career graph has zero edges from {n} clusters "
+                f"and {n_postings} postings; co-occurrence floor "
+                f"of {self.network.threshold} may exceed corpus "
+                f"density"
+            )
 
         return G
 

--- a/src/chalkline/pathways/routing.py
+++ b/src/chalkline/pathways/routing.py
@@ -85,6 +85,13 @@ class CareerRouter:
         Compute four centrality measures, store as node attributes
         on the career DAG, and return the typed schema.
         """
+        if not self.graph.number_of_edges():
+            n = self.graph.number_of_nodes()
+            logger.warning(
+                f"Edgeless graph; all centrality measures are "
+                f"degenerate (PageRank uniform at 1/{n})"
+            )
+
         metrics = CentralityMetrics(
             betweenness = nx.betweenness_centrality(self.graph, weight="weight"),
             in_degree   = nx.in_degree_centrality(self.graph),

--- a/src/chalkline/pathways/routing.py
+++ b/src/chalkline/pathways/routing.py
@@ -11,12 +11,12 @@ progression rather than the fewest transitions.
 
 from functools          import cached_property
 from logging            import getLogger
-from networkx           import ancestors, betweenness_centrality, descendants
+from networkx           import all_simple_paths, ancestors
+from networkx           import betweenness_centrality, descendants
 from networkx           import get_node_attributes, has_path
 from networkx           import in_degree_centrality, out_degree_centrality
-from networkx           import pagerank, set_node_attributes
-from networkx           import shortest_path, subgraph_view
-from networkx.algorithms.simple_paths import all_simple_paths
+from networkx           import pagerank, set_edge_attributes
+from networkx           import set_node_attributes, shortest_path, subgraph_view
 from networkx.utils     import pairwise
 
 from chalkline.pathways.graph   import CareerPathwayGraph
@@ -134,42 +134,37 @@ class CareerRouter:
         G        = self.pathway_graph.graph
         profiles = self.pathway_graph.profiles
 
-        prefix = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
-
-        apprenticeships = list({
-            p.apprenticeship.rapids_code: p.apprenticeship
-            for p in profiles.values()
-            if p.apprenticeship
-        }.values())
-        programs = list({
-            (p.institution, p.program): p
-            for profile in profiles.values()
-            for p in profile.programs
-        }.values())
-
-        trade_pf = {a.rapids_code: prefix(a.title) for a in apprenticeships}
+        prefix   = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
+        apps     = G.graph["apprenticeships"]
+        progs    = G.graph["programs"]
+        trade_pf = {a.rapids_code: prefix(a.title) for a in apps}
         prog_pf  = {
             (p.institution, p.program): prefix(p.program)
-            for p in programs
+            for p in progs
         }
 
+        enrichment = {}
         for s, t, edge in G.edges(data=True):
             bridging = sorted(
                 set(profiles[t].skills) - set(profiles[s].skills)
             )
             skill_pf = {p for skill in bridging for p in prefix(skill)}
+            delta    = edge.get("term_hours_delta")
 
-            delta = edge.get("term_hours_delta")
-            edge["apprenticeships"] = [
-                a for a in apprenticeships
-                if skill_pf & trade_pf[a.rapids_code]
-            ]
-            edge["bridging_skills"] = bridging
-            edge["estimated_hours"] = int(delta) if delta is not None else None
-            edge["programs"] = [
-                p for p in programs
-                if skill_pf & prog_pf[p.institution, p.program]
-            ]
+            enrichment[s, t] = {
+                "apprenticeships" : [
+                    a for a in apps
+                    if skill_pf & trade_pf[a.rapids_code]
+                ],
+                "bridging_skills" : bridging,
+                "estimated_hours" : int(delta) if delta is not None else None,
+                "programs"        : [
+                    p for p in progs
+                    if skill_pf & prog_pf[p.institution, p.program]
+                ],
+            }
+
+        set_edge_attributes(G, enrichment)
 
     def _route_from_path(self, path: list[int]) -> CareerRoute:
         """
@@ -259,16 +254,11 @@ class CareerRouter:
             self.pathway_graph.graph, source, target
         )
         if sp != route.path:
-            paths = all_simple_paths(
-                self.pathway_graph.graph, source, target
+            logger.info(
+                f"Widest path {route.path} diverges from "
+                f"shortest path {sp} between clusters "
+                f"{source} and {target}"
             )
-            next(paths)
-            if next(paths, None) is not None:
-                logger.info(
-                    f"Widest path {route.path} diverges from "
-                    f"shortest path {sp} between clusters "
-                    f"{source} and {target}"
-                )
 
         hours = [
             s.estimated_hours for s in route.steps

--- a/src/chalkline/pathways/routing.py
+++ b/src/chalkline/pathways/routing.py
@@ -1,0 +1,341 @@
+"""
+Career routing with centrality analysis and widest-path computation.
+
+Consumes the career pathway DAG from `CareerPathwayGraph`, computes
+four centrality measures as node attributes, and provides on-demand
+widest-path routing with skill gap bridging and enrichment annotation
+per transition step. The widest-path algorithm maximizes the minimum
+edge weight along the route, identifying the most achievable career
+progression rather than the fewest transitions.
+"""
+
+from functools          import cached_property
+from logging            import getLogger
+from networkx           import ancestors, betweenness_centrality, descendants
+from networkx           import get_node_attributes, has_path
+from networkx           import in_degree_centrality, out_degree_centrality
+from networkx           import pagerank, set_node_attributes
+from networkx           import shortest_path, subgraph_view
+from networkx.algorithms.simple_paths import all_simple_paths
+from networkx.utils     import pairwise
+
+from chalkline.pathways.graph   import CareerPathwayGraph
+from chalkline.pathways.schemas import CareerRoute, CentralityMetrics
+from chalkline.pathways.schemas import LearningPlan, TransitionStep
+
+
+logger = getLogger(__name__)
+
+
+class CareerRouter:
+    """
+    Centrality analysis and widest-path routing on the career DAG.
+
+    Receives a `CareerPathwayGraph`, computes betweenness, in-degree,
+    out-degree, and PageRank centrality at construction time, and
+    exposes on-demand widest-path routing with progressive learning
+    plan generation. Bridging skills and enrichment annotations are
+    precomputed per edge during construction for downstream assembly
+    into transition steps.
+    """
+
+    def __init__(self, pathway_graph: CareerPathwayGraph):
+        """
+        Compute centrality and edge enrichment attributes eagerly.
+
+        Both passes are negligible at the expected graph scale
+        (5-21 nodes under healthy clustering). Centrality scores
+        are stored as node attributes, while bridging skills and
+        enrichment matches are stored as edge attributes.
+
+        Args:
+            pathway_graph: Career DAG with enriched profiles.
+        """
+        self.pathway_graph = pathway_graph
+        self.widest_cache: dict[tuple[int, int], list[int] | None] = {}
+
+        self._compute_centrality()
+        self._compute_edge_enrichment()
+
+    @cached_property
+    def centrality(self) -> CentralityMetrics:
+        """
+        Four centrality measures over the career DAG.
+
+        Wraps the node-attribute values computed at construction
+        into a typed schema for downstream consumption.
+        """
+        G = self.pathway_graph.graph
+        return CentralityMetrics(
+            betweenness = get_node_attributes(G, "betweenness"),
+            in_degree   = get_node_attributes(G, "in_degree"),
+            out_degree  = get_node_attributes(G, "out_degree"),
+            pagerank    = get_node_attributes(G, "pagerank")
+        )
+
+    def _build_step(self, source: int, target: int) -> TransitionStep:
+        """
+        Assemble a `TransitionStep` from precomputed edge
+        attributes.
+
+        Args:
+            source : Source cluster ID.
+            target : Target cluster ID.
+
+        Returns:
+            Populated transition step with enrichment.
+        """
+        edge = self.pathway_graph.graph[source][target]
+        return TransitionStep(
+            apprenticeships = edge["apprenticeships"],
+            bridging_skills = edge["bridging_skills"],
+            estimated_hours = edge["estimated_hours"],
+            programs        = edge["programs"],
+            source_cluster  = source,
+            target_cluster  = target,
+            weight          = edge["weight"]
+        )
+
+    def _compute_centrality(self):
+        """
+        Compute four centrality measures and store as node
+        attributes on the career DAG.
+
+        Guards PageRank against edgeless graphs where the power
+        iteration would degenerate to uniform damping.
+        """
+        G = self.pathway_graph.graph
+
+        if G.number_of_nodes() == 0:
+            return
+
+        set_node_attributes(G, betweenness_centrality(G, weight="weight"), "betweenness")
+        set_node_attributes(G, in_degree_centrality(G), "in_degree")
+        set_node_attributes(G, out_degree_centrality(G), "out_degree")
+
+        if G.number_of_edges() > 0:
+            set_node_attributes(G, pagerank(G, weight="weight"), "pagerank")
+        else:
+            uniform = 1 / G.number_of_nodes()
+            set_node_attributes(
+                G, {n: uniform for n in G.nodes()}, "pagerank"
+            )
+
+    def _compute_edge_enrichment(self):
+        """
+        Precompute bridging skills and enrichment per edge.
+
+        For each edge, stores the skill set difference between
+        target and source cluster profiles, matched apprenticeships,
+        matched programs, and estimated training hours. Enrichment
+        matching uses 4-char prefix overlap against the bridging
+        skill set, following the same approach as `ResumeMatcher`.
+        """
+        G        = self.pathway_graph.graph
+        profiles = self.pathway_graph.profiles
+
+        prefix = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
+
+        apprenticeships = list({
+            p.apprenticeship.rapids_code: p.apprenticeship
+            for p in profiles.values()
+            if p.apprenticeship
+        }.values())
+        programs = list({
+            (p.institution, p.program): p
+            for profile in profiles.values()
+            for p in profile.programs
+        }.values())
+
+        trade_pf = {a.rapids_code: prefix(a.title) for a in apprenticeships}
+        prog_pf  = {
+            (p.institution, p.program): prefix(p.program)
+            for p in programs
+        }
+
+        for s, t, edge in G.edges(data=True):
+            bridging = sorted(
+                set(profiles[t].skills) - set(profiles[s].skills)
+            )
+            skill_pf = {p for skill in bridging for p in prefix(skill)}
+
+            delta = edge.get("term_hours_delta")
+            edge["apprenticeships"] = [
+                a for a in apprenticeships
+                if skill_pf & trade_pf[a.rapids_code]
+            ]
+            edge["bridging_skills"] = bridging
+            edge["estimated_hours"] = int(delta) if delta is not None else None
+            edge["programs"] = [
+                p for p in programs
+                if skill_pf & prog_pf[p.institution, p.program]
+            ]
+
+    def _route_from_path(self, path: list[int]) -> CareerRoute:
+        """
+        Build a `CareerRoute` from an ordered list of cluster IDs.
+
+        Constructs `TransitionStep` records for each adjacent pair
+        and derives the bottleneck weight as the minimum step weight.
+
+        Args:
+            path: Ordered cluster IDs from source to target.
+
+        Returns:
+            Career route with steps and bottleneck weight.
+        """
+        steps = [self._build_step(u, v) for u, v in pairwise(path)]
+        return CareerRoute(
+            bottleneck_weight = min(
+                (s.weight for s in steps), default=0.0
+            ),
+            hops  = len(path) - 1,
+            path  = path,
+            steps = steps
+        )
+
+    def all_routes(self, source: int, target: int) -> list[CareerRoute]:
+        """
+        Enumerate all simple paths between two clusters with
+        bottleneck weights and transition steps.
+
+        The DAG property guarantees termination. Routes are sorted
+        by descending bottleneck weight so the most achievable
+        career progression appears first.
+
+        Args:
+            source : Source cluster ID.
+            target : Target cluster ID.
+
+        Returns:
+            All simple paths as `CareerRoute` records, or an empty
+            list if the target is unreachable.
+        """
+        routes = [
+            self._route_from_path(path)
+            for path in all_simple_paths(
+                self.pathway_graph.graph, source, target
+            )
+        ]
+        routes.sort(key=lambda r: r.bottleneck_weight, reverse=True)
+        return routes
+
+    def leads_to(self, cluster_id: int) -> set[int]:
+        """
+        All clusters that lead to this node (upstream ancestors).
+
+        Args:
+            cluster_id: Target cluster to find predecessors of.
+
+        Returns:
+            Set of cluster IDs that can reach this node.
+        """
+        return ancestors(self.pathway_graph.graph, cluster_id)
+
+    def learning_plan(self, source: int, target: int) -> LearningPlan | None:
+        """
+        Progressive learning plan along the widest career route.
+
+        Delegates route construction to `widest_path`, then
+        aggregates bridging skills and estimated hours across
+        transition steps. Logs when the widest and shortest paths
+        diverge across pairs with multiple simple paths, since the
+        divergence reveals where the two optimization objectives
+        disagree.
+
+        Args:
+            source : Source cluster ID (from resume match).
+            target : Target cluster ID (career goal).
+
+        Returns:
+            Learning plan with per-step detail, or `None` if the
+            target is unreachable from the source.
+        """
+        route = self.widest_path(source, target)
+        if route is None:
+            return None
+
+        sp = shortest_path(
+            self.pathway_graph.graph, source, target
+        )
+        if sp != route.path:
+            paths = all_simple_paths(
+                self.pathway_graph.graph, source, target
+            )
+            next(paths)
+            if next(paths, None) is not None:
+                logger.info(
+                    f"Widest path {route.path} diverges from "
+                    f"shortest path {sp} between clusters "
+                    f"{source} and {target}"
+                )
+
+        hours = [
+            s.estimated_hours for s in route.steps
+            if s.estimated_hours is not None
+        ]
+
+        return LearningPlan(
+            all_bridging_skills = sorted({
+                s for step in route.steps
+                for s in step.bridging_skills
+            }),
+            route                 = route,
+            total_estimated_hours = sum(hours) if hours else None
+        )
+
+    def reachable_from(self, cluster_id: int) -> set[int]:
+        """
+        All clusters reachable from this node (downstream
+        descendants).
+
+        Args:
+            cluster_id: Source cluster to find successors of.
+
+        Returns:
+            Set of cluster IDs reachable from this node.
+        """
+        return descendants(self.pathway_graph.graph, cluster_id)
+
+    def widest_path(self, source: int, target: int) -> CareerRoute | None:
+        """
+        Widest (maximum bottleneck) career route between two
+        clusters.
+
+        Searches edge weight thresholds in descending order,
+        filtering the DAG via `subgraph_view` at each level and
+        checking reachability with `has_path`. The first threshold
+        where a path exists yields the maximum bottleneck value.
+
+        Args:
+            source : Source cluster ID.
+            target : Target cluster ID.
+
+        Returns:
+            Career route with bottleneck weight and transition
+            steps, or `None` if unreachable.
+        """
+        if source == target:
+            return self._route_from_path([source])
+
+        key = (source, target)
+        if key in self.widest_cache:
+            cached = self.widest_cache[key]
+            return self._route_from_path(cached) if cached else None
+
+        G = self.pathway_graph.graph
+
+        for w in sorted(
+            {w for _, _, w in G.edges(data="weight")}, reverse=True
+        ):
+            view = subgraph_view(
+                G,
+                filter_edge=lambda u, v, w=w: G[u][v]["weight"] >= w
+            )
+            if has_path(view, source, target):
+                path = shortest_path(view, source, target)
+                self.widest_cache[key] = path
+                return self._route_from_path(path)
+
+        self.widest_cache[key] = None
+        return None

--- a/src/chalkline/pathways/routing.py
+++ b/src/chalkline/pathways/routing.py
@@ -11,7 +11,8 @@ progression rather than the fewest transitions.
 
 import networkx as nx
 
-from logging import getLogger
+from itertools import accumulate, takewhile
+from logging   import getLogger
 
 from chalkline.pathways.schemas import CareerRoute, CentralityMetrics
 from chalkline.pathways.schemas import LearningPlan, TransitionStep
@@ -196,12 +197,11 @@ class CareerRouter:
     def widest_path(self, source: int, target: int) -> CareerRoute | None:
         """
         Widest (maximum bottleneck) career route between two
-        clusters.
+        clusters via topological DP.
 
-        Enumerates all simple paths and selects the route with the
-        maximum bottleneck weight. DAG acyclicity bounds the path
-        count and makes full enumeration tractable at the expected
-        graph scale.
+        Walks nodes in topological order, relaxing each edge with
+        max-min bottleneck semantics in O(V + E). DAG acyclicity
+        guarantees a single topological pass suffices.
 
         Args:
             source : Source cluster ID.
@@ -211,14 +211,20 @@ class CareerRouter:
             Career route with bottleneck weight and transition
             steps, or `None` if unreachable.
         """
-        if source == target:
-            return self._route_from_path([source])
+        best = {source: (float("inf"), None)}
 
-        return max(
-            [
-                self._route_from_path(p)
-                for p in nx.all_simple_paths(self.graph, source, target)
-            ],
-            default = None,
-            key     = lambda r: r.bottleneck_weight
-        )
+        for node in nx.topological_sort(self.graph):
+            if (state := best.get(node)) is None:
+                continue
+            best |= {
+                n: (c, node)
+                for n, d in self.graph[node].items()
+                if (c := min(state[0], d["weight"])) > best.get(n, (0,))[0]
+            }
+
+        return self._route_from_path([
+            *takewhile(
+                lambda n: n is not None,
+                accumulate(best, lambda n, _: best[n][1], initial=target)
+            )
+        ][::-1]) if best.get(target) else None

--- a/src/chalkline/pathways/routing.py
+++ b/src/chalkline/pathways/routing.py
@@ -1,7 +1,7 @@
 """
 Career routing with centrality analysis and widest-path computation.
 
-Consumes the career pathway DAG from `CareerPathwayGraph`, computes
+Consumes a career pathway DAG and cluster profiles, computes
 four centrality measures as node attributes, and provides on-demand
 widest-path routing with skill gap bridging and enrichment annotation
 per transition step. The widest-path algorithm maximizes the minimum
@@ -9,19 +9,13 @@ edge weight along the route, identifying the most achievable career
 progression rather than the fewest transitions.
 """
 
-from functools          import cached_property
-from logging            import getLogger
-from networkx           import all_simple_paths, ancestors
-from networkx           import betweenness_centrality, descendants
-from networkx           import get_node_attributes, has_path
-from networkx           import in_degree_centrality, out_degree_centrality
-from networkx           import pagerank, set_edge_attributes
-from networkx           import set_node_attributes, shortest_path, subgraph_view
-from networkx.utils     import pairwise
+import networkx as nx
 
-from chalkline.pathways.graph   import CareerPathwayGraph
+from logging import getLogger
+
 from chalkline.pathways.schemas import CareerRoute, CentralityMetrics
 from chalkline.pathways.schemas import LearningPlan, TransitionStep
+from chalkline.pipeline.schemas import ClusterProfile
 
 
 logger = getLogger(__name__)
@@ -31,15 +25,20 @@ class CareerRouter:
     """
     Centrality analysis and widest-path routing on the career DAG.
 
-    Receives a `CareerPathwayGraph`, computes betweenness, in-degree,
-    out-degree, and PageRank centrality at construction time, and
-    exposes on-demand widest-path routing with progressive learning
-    plan generation. Bridging skills and enrichment annotations are
-    precomputed per edge during construction for downstream assembly
-    into transition steps.
+    Accepts a NetworkX DiGraph and cluster profiles directly,
+    computes betweenness, in-degree, out-degree, and PageRank
+    centrality at construction time, and exposes on-demand
+    widest-path routing with progressive learning plan generation.
+    Bridging skills and enrichment annotations are precomputed per
+    edge during construction for downstream assembly into
+    transition steps.
     """
 
-    def __init__(self, pathway_graph: CareerPathwayGraph):
+    def __init__(
+        self,
+        graph    : nx.DiGraph,
+        profiles : dict[int, ClusterProfile]
+    ):
         """
         Compute centrality and edge enrichment attributes eagerly.
 
@@ -49,29 +48,14 @@ class CareerRouter:
         enrichment matches are stored as edge attributes.
 
         Args:
-            pathway_graph: Career DAG with enriched profiles.
+            graph    : Career DAG with weighted edges.
+            profiles : Enriched cluster characteristics keyed by
+                       cluster ID.
         """
-        self.pathway_graph = pathway_graph
-        self.widest_cache: dict[tuple[int, int], list[int] | None] = {}
-
-        self._compute_centrality()
+        self.graph       = graph
+        self.profiles    = profiles
+        self.centrality  = self._compute_centrality()
         self._compute_edge_enrichment()
-
-    @cached_property
-    def centrality(self) -> CentralityMetrics:
-        """
-        Four centrality measures over the career DAG.
-
-        Wraps the node-attribute values computed at construction
-        into a typed schema for downstream consumption.
-        """
-        G = self.pathway_graph.graph
-        return CentralityMetrics(
-            betweenness = get_node_attributes(G, "betweenness"),
-            in_degree   = get_node_attributes(G, "in_degree"),
-            out_degree  = get_node_attributes(G, "out_degree"),
-            pagerank    = get_node_attributes(G, "pagerank")
-        )
 
     def _build_step(self, source: int, target: int) -> TransitionStep:
         """
@@ -85,7 +69,7 @@ class CareerRouter:
         Returns:
             Populated transition step with enrichment.
         """
-        edge = self.pathway_graph.graph[source][target]
+        edge = self.graph[source][target]
         return TransitionStep(
             apprenticeships = edge["apprenticeships"],
             bridging_skills = edge["bridging_skills"],
@@ -96,30 +80,22 @@ class CareerRouter:
             weight          = edge["weight"]
         )
 
-    def _compute_centrality(self):
+    def _compute_centrality(self) -> CentralityMetrics:
         """
-        Compute four centrality measures and store as node
-        attributes on the career DAG.
-
-        Guards PageRank against edgeless graphs where the power
-        iteration would degenerate to uniform damping.
+        Compute four centrality measures, store as node attributes
+        on the career DAG, and return the typed schema.
         """
-        G = self.pathway_graph.graph
+        metrics = CentralityMetrics(
+            betweenness = nx.betweenness_centrality(self.graph, weight="weight"),
+            in_degree   = nx.in_degree_centrality(self.graph),
+            out_degree  = nx.out_degree_centrality(self.graph),
+            pagerank    = nx.pagerank(self.graph, weight="weight")
+        )
 
-        if G.number_of_nodes() == 0:
-            return
+        for name, values in metrics:
+            nx.set_node_attributes(self.graph, values, name)
 
-        set_node_attributes(G, betweenness_centrality(G, weight="weight"), "betweenness")
-        set_node_attributes(G, in_degree_centrality(G), "in_degree")
-        set_node_attributes(G, out_degree_centrality(G), "out_degree")
-
-        if G.number_of_edges() > 0:
-            set_node_attributes(G, pagerank(G, weight="weight"), "pagerank")
-        else:
-            uniform = 1 / G.number_of_nodes()
-            set_node_attributes(
-                G, {n: uniform for n in G.nodes()}, "pagerank"
-            )
+        return metrics
 
     def _compute_edge_enrichment(self):
         """
@@ -131,40 +107,29 @@ class CareerRouter:
         matching uses 4-char prefix overlap against the bridging
         skill set, following the same approach as `ResumeMatcher`.
         """
-        G        = self.pathway_graph.graph
-        profiles = self.pathway_graph.profiles
+        prefix = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
+        apps   = [
+            p.apprenticeship for p in self.profiles.values()
+            if p.apprenticeship
+        ]
+        progs  = [
+            p for prof in self.profiles.values()
+            for p in prof.programs
+        ]
 
-        prefix   = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
-        apps     = G.graph["apprenticeships"]
-        progs    = G.graph["programs"]
-        trade_pf = {a.rapids_code: prefix(a.title) for a in apps}
-        prog_pf  = {
-            (p.institution, p.program): prefix(p.program)
-            for p in progs
-        }
-
-        enrichment = {}
-        for s, t, edge in G.edges(data=True):
-            bridging = sorted(
-                set(profiles[t].skills) - set(profiles[s].skills)
-            )
+        for s, t, data in self.graph.edges(data=True):
+            bridging = sorted(self.profiles[t].skills - self.profiles[s].skills)
             skill_pf = {p for skill in bridging for p in prefix(skill)}
-            delta    = edge.get("term_hours_delta")
+            matched  = lambda items, attr: [
+                x for x in items if skill_pf & prefix(getattr(x, attr))
+            ]
 
-            enrichment[s, t] = {
-                "apprenticeships" : [
-                    a for a in apps
-                    if skill_pf & trade_pf[a.rapids_code]
-                ],
+            data |= {
+                "apprenticeships" : matched(apps, "title"),
                 "bridging_skills" : bridging,
-                "estimated_hours" : int(delta) if delta is not None else None,
-                "programs"        : [
-                    p for p in progs
-                    if skill_pf & prog_pf[p.institution, p.program]
-                ],
+                "estimated_hours" : data.get("term_hours_delta"),
+                "programs"        : matched(progs, "program")
             }
-
-        set_edge_attributes(G, enrichment)
 
     def _route_from_path(self, path: list[int]) -> CareerRoute:
         """
@@ -179,53 +144,16 @@ class CareerRouter:
         Returns:
             Career route with steps and bottleneck weight.
         """
-        steps = [self._build_step(u, v) for u, v in pairwise(path)]
-        return CareerRoute(
-            bottleneck_weight = min(
-                (s.weight for s in steps), default=0.0
-            ),
-            hops  = len(path) - 1,
-            path  = path,
-            steps = steps
-        )
-
-    def all_routes(self, source: int, target: int) -> list[CareerRoute]:
-        """
-        Enumerate all simple paths between two clusters with
-        bottleneck weights and transition steps.
-
-        The DAG property guarantees termination. Routes are sorted
-        by descending bottleneck weight so the most achievable
-        career progression appears first.
-
-        Args:
-            source : Source cluster ID.
-            target : Target cluster ID.
-
-        Returns:
-            All simple paths as `CareerRoute` records, or an empty
-            list if the target is unreachable.
-        """
-        routes = [
-            self._route_from_path(path)
-            for path in all_simple_paths(
-                self.pathway_graph.graph, source, target
-            )
+        steps = [
+            self._build_step(u, v)
+            for u, v in nx.utils.pairwise(path)
         ]
-        routes.sort(key=lambda r: r.bottleneck_weight, reverse=True)
-        return routes
-
-    def leads_to(self, cluster_id: int) -> set[int]:
-        """
-        All clusters that lead to this node (upstream ancestors).
-
-        Args:
-            cluster_id: Target cluster to find predecessors of.
-
-        Returns:
-            Set of cluster IDs that can reach this node.
-        """
-        return ancestors(self.pathway_graph.graph, cluster_id)
+        return CareerRoute(
+            bottleneck_weight = min((s.weight for s in steps), default=0.0),
+            hops              = len(path) - 1,
+            path              = path,
+            steps             = steps
+        )
 
     def learning_plan(self, source: int, target: int) -> LearningPlan | None:
         """
@@ -246,56 +174,27 @@ class CareerRouter:
             Learning plan with per-step detail, or `None` if the
             target is unreachable from the source.
         """
-        route = self.widest_path(source, target)
-        if route is None:
+        if (route := self.widest_path(source, target)) is None:
             return None
 
-        sp = shortest_path(
-            self.pathway_graph.graph, source, target
-        )
-        if sp != route.path:
+        if (sp := nx.shortest_path(self.graph, source, target)) != route.path:
             logger.info(
                 f"Widest path {route.path} diverges from "
                 f"shortest path {sp} between clusters "
                 f"{source} and {target}"
             )
 
-        hours = [
-            s.estimated_hours for s in route.steps
-            if s.estimated_hours is not None
-        ]
-
-        return LearningPlan(
-            all_bridging_skills = sorted({
-                s for step in route.steps
-                for s in step.bridging_skills
-            }),
-            route                 = route,
-            total_estimated_hours = sum(hours) if hours else None
-        )
-
-    def reachable_from(self, cluster_id: int) -> set[int]:
-        """
-        All clusters reachable from this node (downstream
-        descendants).
-
-        Args:
-            cluster_id: Source cluster to find successors of.
-
-        Returns:
-            Set of cluster IDs reachable from this node.
-        """
-        return descendants(self.pathway_graph.graph, cluster_id)
+        return LearningPlan(route=route)
 
     def widest_path(self, source: int, target: int) -> CareerRoute | None:
         """
         Widest (maximum bottleneck) career route between two
         clusters.
 
-        Searches edge weight thresholds in descending order,
-        filtering the DAG via `subgraph_view` at each level and
-        checking reachability with `has_path`. The first threshold
-        where a path exists yields the maximum bottleneck value.
+        Enumerates all simple paths and selects the route with the
+        maximum bottleneck weight. DAG acyclicity bounds the path
+        count and makes full enumeration tractable at the expected
+        graph scale.
 
         Args:
             source : Source cluster ID.
@@ -308,24 +207,11 @@ class CareerRouter:
         if source == target:
             return self._route_from_path([source])
 
-        key = (source, target)
-        if key in self.widest_cache:
-            cached = self.widest_cache[key]
-            return self._route_from_path(cached) if cached else None
-
-        G = self.pathway_graph.graph
-
-        for w in sorted(
-            {w for _, _, w in G.edges(data="weight")}, reverse=True
-        ):
-            view = subgraph_view(
-                G,
-                filter_edge=lambda u, v, w=w: G[u][v]["weight"] >= w
-            )
-            if has_path(view, source, target):
-                path = shortest_path(view, source, target)
-                self.widest_cache[key] = path
-                return self._route_from_path(path)
-
-        self.widest_cache[key] = None
-        return None
+        return max(
+            [
+                self._route_from_path(p)
+                for p in nx.all_simple_paths(self.graph, source, target)
+            ],
+            default = None,
+            key     = lambda r: r.bottleneck_weight
+        )

--- a/src/chalkline/pathways/schemas.py
+++ b/src/chalkline/pathways/schemas.py
@@ -24,7 +24,7 @@ class AlignmentDiagnostics(BaseModel, extra="forbid"):
     between the geometric and co-occurrence views of the career landscape.
     """
 
-    ari        : float
+    ari        : float        = 0.0
     modularity : float | None = None
 
 
@@ -141,5 +141,6 @@ class LongestPath(BaseModel, extra="forbid"):
     career progression chain from entry-level to advanced roles.
     """
 
-    path        : list[int]
-    path_weight : float
+    edge_count  : int        = Field(default=0, ge=0)
+    path        : list[int]  = Field(default_factory=list)
+    path_weight : float      = 0.0

--- a/src/chalkline/pathways/schemas.py
+++ b/src/chalkline/pathways/schemas.py
@@ -7,8 +7,9 @@ for widest-path routing, longest-path results, progressive learning
 plans, and export artifact paths.
 """
 
-from pathlib  import Path
-from pydantic import BaseModel, Field
+from functools import cached_property
+from pathlib   import Path
+from pydantic  import BaseModel, Field
 
 from chalkline.pipeline.schemas import ApprenticeshipContext, ProgramRecommendation
 
@@ -76,10 +77,10 @@ class CentralityMetrics(BaseModel, extra="forbid"):
     PageRank incorporates full graph topology as a prestige measure.
     """
 
-    betweenness : dict[int, float]
-    in_degree   : dict[int, float]
-    out_degree  : dict[int, float]
-    pagerank    : dict[int, float]
+    betweenness : dict[int, float] = Field(default_factory=dict)
+    in_degree   : dict[int, float] = Field(default_factory=dict)
+    out_degree  : dict[int, float] = Field(default_factory=dict)
+    pagerank    : dict[int, float] = Field(default_factory=dict)
 
 
 class GraphExport(BaseModel, extra="forbid"):
@@ -105,10 +106,30 @@ class LearningPlan(BaseModel, extra="forbid"):
     and route-level summary metrics.
     """
 
-    all_bridging_skills   : list[str]
-    route                 : CareerRoute
+    route : CareerRoute
 
-    total_estimated_hours : int | None = None
+    @cached_property
+    def bridging_skills(self) -> list[str]:
+        """
+        Sorted union of bridging skills across all transition
+        steps in the route.
+        """
+        return sorted({
+            s for step in self.route.steps
+            for s in step.bridging_skills
+        })
+
+    @cached_property
+    def estimated_hours(self) -> int | None:
+        """
+        Sum of estimated training hours across steps where
+        available, or `None` when no step carries hour data.
+        """
+        hours = [
+            s.estimated_hours for s in self.route.steps
+            if s.estimated_hours is not None
+        ]
+        return sum(hours) if hours else None
 
 
 class LongestPath(BaseModel, extra="forbid"):

--- a/src/chalkline/pathways/schemas.py
+++ b/src/chalkline/pathways/schemas.py
@@ -1,13 +1,16 @@
 """
-Schemas for career pathway graph diagnostics and export.
+Schemas for career pathway graph diagnostics, routing, and export.
 
 Defines alignment diagnostics between Louvain communities and HAC
-clusters, longest-path results, export artifact paths, and the top-level
-diagnostic summary consumed by the career report.
+clusters, centrality metrics, career route and transition step models
+for widest-path routing, longest-path results, progressive learning
+plans, and export artifact paths.
 """
 
 from pathlib  import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from chalkline.pipeline.schemas import ApprenticeshipContext, ProgramRecommendation
 
 
 class AlignmentDiagnostics(BaseModel, extra="forbid"):
@@ -24,6 +27,61 @@ class AlignmentDiagnostics(BaseModel, extra="forbid"):
     modularity : float | None = None
 
 
+class TransitionStep(BaseModel, extra="forbid"):
+    """
+    A single career transition between adjacent clusters on a
+    widest-path route.
+
+    Bridging skills are the set difference between the target and
+    source cluster skill profiles. Apprenticeship and program
+    annotations are matched against the bridging skills via 4-char
+    prefix overlap, identifying training pathways that address the
+    specific skills needed at this transition step.
+    """
+
+    bridging_skills : list[str]
+    source_cluster  : int = Field(ge=0)
+    target_cluster  : int = Field(ge=0)
+    weight          : float
+
+    apprenticeships : list[ApprenticeshipContext] = Field(default_factory=list)
+    estimated_hours : int | None                  = None
+    programs        : list[ProgramRecommendation] = Field(default_factory=list)
+
+
+class CareerRoute(BaseModel, extra="forbid"):
+    """
+    A complete path through the career DAG with aggregate metrics.
+
+    The bottleneck weight is the minimum edge weight along the path,
+    representing the weakest skill co-occurrence link in the career
+    progression. Used by widest-path routing to maximize the minimum
+    association strength across all transitions.
+    """
+
+    bottleneck_weight : float
+    hops              : int = Field(ge=0)
+    path              : list[int]
+
+    steps : list[TransitionStep] = Field(default_factory=list)
+
+
+class CentralityMetrics(BaseModel, extra="forbid"):
+    """
+    Four centrality measures computed over the career pathway DAG.
+
+    Betweenness identifies gateway roles connecting multiple career
+    tracks. In-degree measures convergence (many paths lead here).
+    Out-degree measures launch potential (many paths forward).
+    PageRank incorporates full graph topology as a prestige measure.
+    """
+
+    betweenness : dict[int, float]
+    in_degree   : dict[int, float]
+    out_degree  : dict[int, float]
+    pagerank    : dict[int, float]
+
+
 class GraphExport(BaseModel, extra="forbid"):
     """
     Paths to exported graph serialization artifacts.
@@ -36,6 +94,21 @@ class GraphExport(BaseModel, extra="forbid"):
 
     graphml_path : Path
     json_path    : Path
+
+
+class LearningPlan(BaseModel, extra="forbid"):
+    """
+    Progressive learning plan along a career route.
+
+    Aggregates all bridging skills across transition steps into a
+    unified development sequence with per-step enrichment detail
+    and route-level summary metrics.
+    """
+
+    all_bridging_skills   : list[str]
+    route                 : CareerRoute
+
+    total_estimated_hours : int | None = None
 
 
 class LongestPath(BaseModel, extra="forbid"):

--- a/src/chalkline/pipeline/schemas.py
+++ b/src/chalkline/pipeline/schemas.py
@@ -9,7 +9,7 @@ matching, pathways, and report generation modules.
 from enum      import StrEnum
 from functools import cached_property
 from pathlib   import Path
-from pydantic  import BaseModel, Field, field_validator
+from pydantic  import BaseModel, Field
 
 from chalkline import UnitInterval
 
@@ -43,7 +43,7 @@ class ClusterProfile(BaseModel, extra="forbid"):
     job_zone   : int      = Field(ge=1, le=5)
     sector     : str
     size       : int      = Field(ge=1)
-    skills     : list[str]
+    skills     : set[str]
     terms      : list[str] = Field(default_factory=list)
 
     apprenticeship : ApprenticeshipContext | None = None
@@ -58,15 +58,6 @@ class ClusterProfile(BaseModel, extra="forbid"):
         edges flow from entry-level to advanced roles.
         """
         return (self.job_zone, self.cluster_id)
-
-    @field_validator("skills", mode="before")
-    @classmethod
-    def sort_skills(cls, v: set[str] | list[str]) -> list[str]:
-        """
-        Accept a set or list and store as a sorted list for
-        stable node attribute output.
-        """
-        return sorted(v)
 
 
 class DistanceMetric(StrEnum):

--- a/tests/collection/test_storage.py
+++ b/tests/collection/test_storage.py
@@ -7,27 +7,40 @@ deduplication that retains the most recently collected version.
 
 from datetime import date
 from pathlib  import Path
+from pytest   import fixture
 
 from chalkline.collection.schemas import Posting
-from chalkline.collection.storage import deduplicate, load, save
+from chalkline.collection.storage import CorpusStorage
 
 
-class TestStorage:
+@fixture
+def storage(tmp_path: Path) -> CorpusStorage:
+    """
+    Fresh corpus storage backed by a temporary directory.
+    """
+    return CorpusStorage(tmp_path)
+
+
+class TestCorpusStorage:
     """
     Validate storage operations and deduplication behavior.
     """
 
-    def test_deduplicate_empty(self):
+    def test_deduplicate_empty(self, storage: CorpusStorage):
         """
         Deduplicating an empty list returns an empty list.
         """
-        assert deduplicate([]) == []
+        assert storage.deduplicate([]) == []
 
-    def test_duplicate_keeps_latest(self, sample_posting: Posting):
+    def test_duplicate_keeps_latest(
+        self,
+        sample_posting : Posting,
+        storage        : CorpusStorage
+    ):
         """
         When two postings share an ID, the later `date_collected` wins.
         """
-        assert len(result := deduplicate([
+        assert len(result := storage.deduplicate([
             sample_posting.model_copy(
                 update={"date_collected": date(2026, 3, 1)}
             ),
@@ -39,32 +52,40 @@ class TestStorage:
         self,
         sample_posting : Posting,
         second_posting : Posting,
-        tmp_path       : Path
+        storage        : CorpusStorage
     ):
         """
         Saving new postings merges with existing ones on disk.
         """
-        save([sample_posting], tmp_path)
-        save([second_posting], tmp_path)
-        assert len(load(tmp_path)) == 2
+        storage.save([sample_posting])
+        storage.save([second_posting])
+        assert len(storage.load()) == 2
 
     def test_load_empty_directory(self, tmp_path: Path):
         """
         Loading from a non-existent corpus returns an empty list.
         """
-        assert load(tmp_path / "nonexistent") == []
+        assert CorpusStorage(tmp_path / "nonexistent").load() == []
 
-    def test_save_deduplicates(self, sample_posting: Posting, tmp_path: Path):
+    def test_save_deduplicates(
+        self,
+        sample_posting : Posting,
+        storage        : CorpusStorage
+    ):
         """
         Saving the same posting twice retains only one copy.
         """
-        save([sample_posting], tmp_path)
-        save([sample_posting], tmp_path)
-        assert len(load(tmp_path)) == 1
+        storage.save([sample_posting])
+        storage.save([sample_posting])
+        assert len(storage.load()) == 1
 
-    def test_save_load_roundtrip(self, sample_posting: Posting, tmp_path: Path):
+    def test_save_load_roundtrip(
+        self,
+        sample_posting : Posting,
+        storage        : CorpusStorage
+    ):
         """
         Save followed by load produces identical postings.
         """
-        save([sample_posting], tmp_path)
-        assert load(tmp_path) == [sample_posting]
+        storage.save([sample_posting])
+        assert storage.load() == [sample_posting]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -560,4 +560,4 @@ def router(pathway_graph: CareerPathwayGraph) -> CareerRouter:
     """
     Build a career router from the full fixture pipeline.
     """
-    return CareerRouter(pathway_graph)
+    return CareerRouter(pathway_graph.graph, pathway_graph.profiles)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ from chalkline.extraction.vectorize     import SkillVectorizer
 from chalkline.matching.matcher         import ResumeMatcher
 from chalkline.matching.schemas         import MatchResult
 from chalkline.pathways.graph           import CareerPathwayGraph
+from chalkline.pathways.routing         import CareerRouter
 from chalkline.pipeline.programs        import load_programs
 from chalkline.pipeline.schemas         import ApprenticeshipContext, ClusterProfile
 from chalkline.pipeline.schemas         import DistanceMetric, ProgramRecommendation
@@ -515,7 +516,7 @@ def pathway_graph(
     size_map  = {cl.cluster_id: cl.size for cl in cluster_labels}
     terms_map = {cl.cluster_id: cl.terms for cl in cluster_labels}
 
-    prefix = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
+    prefix   = lambda t: {w[:4] for w in t.lower().split() if len(w) >= 4}
     trade_pf = {a.rapids_code: prefix(a.title) for a in apprenticeships}
     prog_pf  = {
         (p.institution, p.program): prefix(p.program) for p in programs
@@ -552,3 +553,11 @@ def pathway_graph(
         network  = network,
         profiles = profiles
     )
+
+
+@fixture
+def router(pathway_graph: CareerPathwayGraph) -> CareerRouter:
+    """
+    Build a career router from the full fixture pipeline.
+    """
+    return CareerRouter(pathway_graph)

--- a/tests/pathways/test_routing.py
+++ b/tests/pathways/test_routing.py
@@ -1,0 +1,437 @@
+"""
+Validate centrality analysis, widest-path routing, and learning plan
+generation on deterministic DAG fixtures and the synthetic 20-posting
+fixture chain.
+"""
+
+from networkx import DiGraph
+from types    import SimpleNamespace
+
+from chalkline.pathways.routing import CareerRouter
+from chalkline.pathways.schemas import LearningPlan
+from chalkline.pipeline.schemas import ApprenticeshipContext
+from chalkline.pipeline.schemas import ClusterProfile, ProgramRecommendation
+
+
+def _make_linear_router() -> CareerRouter:
+    """
+    Build a 4-node linear DAG router for deterministic tests.
+
+    C0(JZ=1) --0.8--> C1(JZ=2) --0.5--> C2(JZ=3) --0.9--> C3(JZ=4)
+
+    Skills: C0={concrete,welding}, C1={scaffolding,welding},
+            C2={electrical safety,scaffolding},
+            C3={electrical safety,electrical wiring}
+    Bridging: 0->1={scaffolding}, 1->2={electrical safety},
+              2->3={electrical wiring}
+    Widest path bottleneck: 0.5 (the C1->C2 edge)
+    """
+    profiles = {
+        0: ClusterProfile(
+            apprenticeship = ApprenticeshipContext(
+                rapids_code = "001",
+                term_hours  = "2000",
+                title       = "Laborer"
+            ),
+            cluster_id = 0,
+            job_zone   = 1,
+            sector     = "Heavy Highway Construction",
+            size       = 5,
+            skills     = ["concrete", "welding"]
+        ),
+        1: ClusterProfile(
+            cluster_id = 1,
+            job_zone   = 2,
+            sector     = "Heavy Highway Construction",
+            size       = 5,
+            skills     = ["scaffolding", "welding"]
+        ),
+        2: ClusterProfile(
+            cluster_id = 2,
+            job_zone   = 3,
+            sector     = "Building Construction",
+            size       = 5,
+            skills     = ["electrical safety", "scaffolding"]
+        ),
+        3: ClusterProfile(
+            apprenticeship = ApprenticeshipContext(
+                rapids_code = "002",
+                term_hours  = "8000",
+                title       = "Electrician"
+            ),
+            cluster_id = 3,
+            job_zone   = 4,
+            programs   = [ProgramRecommendation(
+                credential  = "AAS",
+                institution = "CMCC",
+                program     = "Electrical Technology",
+                url         = "https://example.com"
+            )],
+            sector     = "Building Construction",
+            size       = 5,
+            skills     = ["electrical safety", "electrical wiring"]
+        )
+    }
+
+    G = DiGraph()
+    for cid, profile in profiles.items():
+        G.add_node(cid, **profile.model_dump())
+
+    G.add_weighted_edges_from([
+        (0, 1, 0.8),
+        (1, 2, 0.5),
+        (2, 3, 0.9)
+    ], direction_source="job_zone")
+    G.edges[0, 1]["term_hours_delta"] = "1000"
+    G.edges[2, 3]["term_hours_delta"] = "3000"
+
+    return CareerRouter(SimpleNamespace(
+        graph    = G,
+        profiles = profiles
+    ))
+
+
+def _make_diamond_router() -> CareerRouter:
+    """
+    Build a 4-node diamond DAG with two paths for route comparison.
+
+    C0(JZ=1) --0.8--> C1(JZ=2) --0.3--> C3(JZ=4)
+    C0(JZ=1) --0.4--> C2(JZ=3) --0.9--> C3(JZ=4)
+
+    Path via C1: bottleneck = min(0.8, 0.3) = 0.3
+    Path via C2: bottleneck = min(0.4, 0.9) = 0.4
+    Widest path: C0 -> C2 -> C3 (bottleneck 0.4)
+    """
+    profiles = {
+        0: ClusterProfile(
+            cluster_id = 0,
+            job_zone   = 1,
+            sector     = "Heavy Highway Construction",
+            size       = 5,
+            skills     = ["a", "b"]
+        ),
+        1: ClusterProfile(
+            cluster_id = 1,
+            job_zone   = 2,
+            sector     = "Heavy Highway Construction",
+            size       = 5,
+            skills     = ["b", "c"]
+        ),
+        2: ClusterProfile(
+            cluster_id = 2,
+            job_zone   = 3,
+            sector     = "Building Construction",
+            size       = 5,
+            skills     = ["a", "d"]
+        ),
+        3: ClusterProfile(
+            cluster_id = 3,
+            job_zone   = 4,
+            sector     = "Building Construction",
+            size       = 5,
+            skills     = ["c", "d", "e"]
+        )
+    }
+
+    G = DiGraph()
+    for cid, profile in profiles.items():
+        G.add_node(cid, **profile.model_dump())
+
+    G.add_weighted_edges_from([
+        (0, 1, 0.8),
+        (0, 2, 0.4),
+        (1, 3, 0.3),
+        (2, 3, 0.9)
+    ], direction_source="job_zone")
+
+    return CareerRouter(SimpleNamespace(
+        graph    = G,
+        profiles = profiles
+    ))
+
+
+class TestCareerRouter:
+    """
+    Validate centrality, widest-path routing, bridging skills,
+    learning plans, and traversal methods.
+    """
+
+    # ---------------------------------------------------------
+    # Centrality
+    # ---------------------------------------------------------
+
+    def test_centrality_bounded(self):
+        """
+        Betweenness and PageRank values fall within [0, 1].
+        """
+        c = _make_linear_router().centrality
+        assert all(0 <= v <= 1 for v in c.betweenness.values())
+        assert all(0 <= v <= 1 for v in c.pagerank.values())
+
+    def test_centrality_edgeless(self):
+        """
+        An edgeless graph produces uniform PageRank and zero
+        betweenness without raising.
+        """
+        profiles = {
+            0: ClusterProfile(
+                cluster_id = 0,
+                job_zone   = 1,
+                sector     = "Test",
+                size       = 1,
+                skills     = ["a"]
+            ),
+            1: ClusterProfile(
+                cluster_id = 1,
+                job_zone   = 2,
+                sector     = "Test",
+                size       = 1,
+                skills     = ["b"]
+            )
+        }
+
+        G = DiGraph()
+        for cid, profile in profiles.items():
+            G.add_node(cid, **profile.model_dump())
+
+        router = CareerRouter(SimpleNamespace(
+            graph    = G,
+            profiles = profiles
+        ))
+        c = router.centrality
+        assert all(v == 0.0 for v in c.betweenness.values())
+        assert abs(sum(c.pagerank.values()) - 1.0) < 1e-10
+
+    def test_centrality_keys(self):
+        """
+        Every node ID appears in each centrality dict.
+        """
+        router = _make_linear_router()
+        c      = router.centrality
+        nodes  = set(router.pathway_graph.graph.nodes())
+        assert set(c.betweenness) == nodes
+        assert set(c.in_degree) == nodes
+        assert set(c.out_degree) == nodes
+        assert set(c.pagerank) == nodes
+
+    def test_centrality_node_attrs(self):
+        """
+        Centrality values are stored as node attributes on the
+        graph for downstream consumption.
+        """
+        G = _make_linear_router().pathway_graph.graph
+        for node in G.nodes():
+            assert "betweenness" in G.nodes[node]
+            assert "pagerank" in G.nodes[node]
+
+    # ---------------------------------------------------------
+    # Widest path
+    # ---------------------------------------------------------
+
+    def test_widest_bottleneck(self):
+        """
+        Bottleneck weight equals the minimum edge weight along
+        the widest path. On the linear DAG, the bottleneck from
+        C0 to C3 is 0.5 (the C1->C2 edge).
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        assert route.bottleneck_weight == 0.5
+
+    def test_widest_diamond(self):
+        """
+        On the diamond DAG, the widest path prefers the route
+        via C2 (bottleneck 0.4) over C1 (bottleneck 0.3).
+        """
+        route = _make_diamond_router().widest_path(0, 3)
+        assert route is not None
+        assert route.path == [0, 2, 3]
+        assert route.bottleneck_weight == 0.4
+
+    def test_widest_disconnected(self):
+        """
+        Disconnected pairs return `None`.
+        """
+        assert _make_linear_router().widest_path(3, 0) is None
+
+    def test_widest_path_linear(self):
+        """
+        On the 4-node linear DAG, the widest path from C0 to C3
+        traverses all four nodes in order.
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        assert route.path == [0, 1, 2, 3]
+        assert route.hops == 3
+
+    def test_widest_self(self):
+        """
+        Source equal to target returns a single-node route.
+        """
+        route = _make_linear_router().widest_path(0, 0)
+        assert route is not None
+        assert route.path == [0]
+        assert route.hops == 0
+
+    # ---------------------------------------------------------
+    # Bridging skills
+    # ---------------------------------------------------------
+
+    def test_bridging_set_diff(self):
+        """
+        Bridging skills at each step equal the set difference
+        between target and source skill profiles.
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        assert route.steps[0].bridging_skills == ["scaffolding"]
+        assert route.steps[1].bridging_skills == ["electrical safety"]
+        assert route.steps[2].bridging_skills == ["electrical wiring"]
+
+    def test_bridging_step_hours(self):
+        """
+        Steps with `term_hours_delta` produce int hours; steps
+        without produce `None`.
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        assert route.steps[0].estimated_hours == 1000
+        assert route.steps[1].estimated_hours is None
+        assert route.steps[2].estimated_hours == 3000
+
+    def test_bridging_union(self):
+        """
+        `all_bridging_skills` on the learning plan is the sorted
+        union across all transition steps.
+        """
+        plan = _make_linear_router().learning_plan(0, 3)
+        assert plan is not None
+        assert plan.all_bridging_skills == [
+            "electrical safety", "electrical wiring", "scaffolding"
+        ]
+
+    # ---------------------------------------------------------
+    # Enrichment
+    # ---------------------------------------------------------
+
+    def test_enrichment_apprenticeship(self):
+        """
+        The C2->C3 step's bridging skill "electrical wiring"
+        matches the "Electrician" apprenticeship via the "elec"
+        prefix.
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        step_2_3 = route.steps[2]
+        trades   = [a.title for a in step_2_3.apprenticeships]
+        assert "Electrician" in trades
+
+    def test_enrichment_program(self):
+        """
+        The C2->C3 step's bridging skill "electrical wiring"
+        matches the "Electrical Technology" program via the
+        "elec" prefix.
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        step_2_3 = route.steps[2]
+        progs    = [p.program for p in step_2_3.programs]
+        assert "Electrical Technology" in progs
+
+    # ---------------------------------------------------------
+    # Learning plan
+    # ---------------------------------------------------------
+
+    def test_plan_disconnected(self):
+        """
+        Disconnected pairs return `None`.
+        """
+        assert _make_linear_router().learning_plan(3, 0) is None
+
+    def test_plan_hours(self):
+        """
+        `total_estimated_hours` sums `term_hours_delta` across
+        steps where available. The linear DAG has deltas on edges
+        0->1 (1000) and 2->3 (3000), so the total is 4000.
+        """
+        plan = _make_linear_router().learning_plan(0, 3)
+        assert plan is not None
+        assert plan.total_estimated_hours == 4000
+
+    def test_plan_step_count(self):
+        """
+        Number of steps equals the number of hops (path length
+        minus one).
+        """
+        plan = _make_linear_router().learning_plan(0, 3)
+        assert plan is not None
+        assert len(plan.route.steps) == plan.route.hops
+
+    # ---------------------------------------------------------
+    # Traversal
+    # ---------------------------------------------------------
+
+    def test_leads_to(self):
+        """
+        On the linear DAG, ancestors of C3 are {C0, C1, C2}.
+        """
+        assert _make_linear_router().leads_to(3) == {0, 1, 2}
+
+    def test_reachable_from(self):
+        """
+        On the linear DAG, descendants of C0 are {C1, C2, C3}.
+        """
+        assert _make_linear_router().reachable_from(0) == {1, 2, 3}
+
+    # ---------------------------------------------------------
+    # All routes
+    # ---------------------------------------------------------
+
+    def test_all_routes_diamond(self):
+        """
+        The diamond DAG has two simple paths from C0 to C3,
+        sorted by descending bottleneck weight.
+        """
+        routes = _make_diamond_router().all_routes(0, 3)
+        assert len(routes) == 2
+        assert routes[0].bottleneck_weight >= routes[1].bottleneck_weight
+        assert routes[0].path == [0, 2, 3]
+        assert routes[1].path == [0, 1, 3]
+
+    def test_all_routes_disconnected(self):
+        """
+        Disconnected pair returns an empty list.
+        """
+        assert _make_linear_router().all_routes(3, 0) == []
+
+    def test_all_routes_linear(self):
+        """
+        Linear DAG has exactly one simple path between any
+        connected pair.
+        """
+        routes = _make_linear_router().all_routes(0, 3)
+        assert len(routes) == 1
+        assert routes[0].path == [0, 1, 2, 3]
+
+    # ---------------------------------------------------------
+    # Integration (full fixture chain)
+    # ---------------------------------------------------------
+
+    def test_all_routes_fixture(self, router: CareerRouter):
+        """
+        `all_routes` terminates on the full fixture graph without
+        raising.
+        """
+        nodes = list(router.pathway_graph.graph.nodes())
+        if len(nodes) >= 2:
+            router.all_routes(nodes[0], nodes[-1])
+
+    def test_plan_fixture(self, router: CareerRouter):
+        """
+        `learning_plan` on the fixture graph returns a valid plan
+        or `None` without crashing.
+        """
+        nodes = list(router.pathway_graph.graph.nodes())
+        if len(nodes) >= 2:
+            result = router.learning_plan(nodes[0], nodes[-1])
+            assert result is None or isinstance(result, LearningPlan)

--- a/tests/pathways/test_routing.py
+++ b/tests/pathways/test_routing.py
@@ -5,32 +5,11 @@ fixture chain.
 """
 
 from networkx import DiGraph
-from types    import SimpleNamespace
 
 from chalkline.pathways.routing import CareerRouter
 from chalkline.pathways.schemas import LearningPlan
 from chalkline.pipeline.schemas import ApprenticeshipContext
 from chalkline.pipeline.schemas import ClusterProfile, ProgramRecommendation
-
-
-def _set_graph_metadata(
-    G        : DiGraph,
-    profiles : dict[int, ClusterProfile]
-):
-    """
-    Populate graph-level apprenticeship and program metadata,
-    mirroring `CareerPathwayGraph._build_graph`.
-    """
-    G.graph["apprenticeships"] = list({
-        p.apprenticeship.rapids_code: p.apprenticeship
-        for p in profiles.values()
-        if p.apprenticeship
-    }.values())
-    G.graph["programs"] = list({
-        (p.institution, p.program): p
-        for profile in profiles.values()
-        for p in profile.programs
-    }.values())
 
 
 def _make_linear_router() -> CareerRouter:
@@ -93,23 +72,19 @@ def _make_linear_router() -> CareerRouter:
         )
     }
 
-    G = DiGraph()
-    for cid, profile in profiles.items():
-        G.add_node(cid, **profile.model_dump())
-
+    (G := DiGraph()).add_nodes_from(
+        (cid, profile.model_dump(mode="json"))
+        for cid, profile in profiles.items()
+    )
     G.add_weighted_edges_from([
         (0, 1, 0.8),
         (1, 2, 0.5),
         (2, 3, 0.9)
     ], direction_source="job_zone")
-    G.edges[0, 1]["term_hours_delta"] = "1000"
-    G.edges[2, 3]["term_hours_delta"] = "3000"
-    _set_graph_metadata(G, profiles)
+    G.edges[0, 1]["term_hours_delta"] = 1000
+    G.edges[2, 3]["term_hours_delta"] = 3000
 
-    return CareerRouter(SimpleNamespace(
-        graph    = G,
-        profiles = profiles
-    ))
+    return CareerRouter(G, profiles)
 
 
 def _make_diamond_router() -> CareerRouter:
@@ -154,28 +129,24 @@ def _make_diamond_router() -> CareerRouter:
         )
     }
 
-    G = DiGraph()
-    for cid, profile in profiles.items():
-        G.add_node(cid, **profile.model_dump())
-
+    (G := DiGraph()).add_nodes_from(
+        (cid, profile.model_dump(mode="json"))
+        for cid, profile in profiles.items()
+    )
     G.add_weighted_edges_from([
         (0, 1, 0.8),
         (0, 2, 0.4),
         (1, 3, 0.3),
         (2, 3, 0.9)
     ], direction_source="job_zone")
-    _set_graph_metadata(G, profiles)
 
-    return CareerRouter(SimpleNamespace(
-        graph    = G,
-        profiles = profiles
-    ))
+    return CareerRouter(G, profiles)
 
 
 class TestCareerRouter:
     """
     Validate centrality, widest-path routing, bridging skills,
-    learning plans, and traversal methods.
+    and learning plans.
     """
 
     # ---------------------------------------------------------
@@ -212,17 +183,11 @@ class TestCareerRouter:
             )
         }
 
-        G = DiGraph()
-        for cid, profile in profiles.items():
-            G.add_node(cid, **profile.model_dump())
-
-        _set_graph_metadata(G, profiles)
-
-        router = CareerRouter(SimpleNamespace(
-            graph    = G,
-            profiles = profiles
-        ))
-        c = router.centrality
+        (G := DiGraph()).add_nodes_from(
+            (cid, profile.model_dump(mode="json"))
+            for cid, profile in profiles.items()
+        )
+        c = CareerRouter(G, profiles).centrality
         assert all(v == 0.0 for v in c.betweenness.values())
         assert abs(sum(c.pagerank.values()) - 1.0) < 1e-10
 
@@ -232,7 +197,7 @@ class TestCareerRouter:
         """
         router = _make_linear_router()
         c      = router.centrality
-        nodes  = set(router.pathway_graph.graph.nodes())
+        nodes  = set(router.graph.nodes())
         assert set(c.betweenness) == nodes
         assert set(c.in_degree) == nodes
         assert set(c.out_degree) == nodes
@@ -243,7 +208,7 @@ class TestCareerRouter:
         Centrality values are stored as node attributes on the
         graph for downstream consumption.
         """
-        G = _make_linear_router().pathway_graph.graph
+        G = _make_linear_router().graph
         for node in G.nodes():
             assert "betweenness" in G.nodes[node]
             assert "pagerank" in G.nodes[node]
@@ -323,17 +288,6 @@ class TestCareerRouter:
         assert route.steps[1].estimated_hours is None
         assert route.steps[2].estimated_hours == 3000
 
-    def test_bridging_union(self):
-        """
-        `all_bridging_skills` on the learning plan is the sorted
-        union across all transition steps.
-        """
-        plan = _make_linear_router().learning_plan(0, 3)
-        assert plan is not None
-        assert plan.all_bridging_skills == [
-            "electrical safety", "electrical wiring", "scaffolding"
-        ]
-
     # ---------------------------------------------------------
     # Enrichment
     # ---------------------------------------------------------
@@ -349,6 +303,16 @@ class TestCareerRouter:
         step_2_3 = route.steps[2]
         trades   = [a.title for a in step_2_3.apprenticeships]
         assert "Electrician" in trades
+
+    def test_enrichment_no_match(self):
+        """
+        Steps whose bridging skills do not prefix-match any
+        apprenticeship or program produce empty lists.
+        """
+        route = _make_linear_router().widest_path(0, 3)
+        assert route is not None
+        assert route.steps[0].apprenticeships == []
+        assert route.steps[0].programs == []
 
     def test_enrichment_program(self):
         """
@@ -366,21 +330,32 @@ class TestCareerRouter:
     # Learning plan
     # ---------------------------------------------------------
 
+    def test_plan_derived(self):
+        """
+        `LearningPlan` derives `bridging_skills` and
+        `estimated_hours` from the route's transition steps.
+        """
+        plan = _make_linear_router().learning_plan(0, 3)
+        assert plan is not None
+        assert plan.bridging_skills == [
+            "electrical safety", "electrical wiring", "scaffolding"
+        ]
+        assert plan.estimated_hours == 4000
+
     def test_plan_disconnected(self):
         """
         Disconnected pairs return `None`.
         """
         assert _make_linear_router().learning_plan(3, 0) is None
 
-    def test_plan_hours(self):
+    def test_plan_hours_none(self):
         """
-        `total_estimated_hours` sums `term_hours_delta` across
-        steps where available. The linear DAG has deltas on edges
-        0->1 (1000) and 2->3 (3000), so the total is 4000.
+        `estimated_hours` is `None` when no transition step
+        carries training hour data.
         """
-        plan = _make_linear_router().learning_plan(0, 3)
+        plan = _make_diamond_router().learning_plan(0, 3)
         assert plan is not None
-        assert plan.total_estimated_hours == 4000
+        assert plan.estimated_hours is None
 
     def test_plan_step_count(self):
         """
@@ -392,70 +367,15 @@ class TestCareerRouter:
         assert len(plan.route.steps) == plan.route.hops
 
     # ---------------------------------------------------------
-    # Traversal
-    # ---------------------------------------------------------
-
-    def test_leads_to(self):
-        """
-        On the linear DAG, ancestors of C3 are {C0, C1, C2}.
-        """
-        assert _make_linear_router().leads_to(3) == {0, 1, 2}
-
-    def test_reachable_from(self):
-        """
-        On the linear DAG, descendants of C0 are {C1, C2, C3}.
-        """
-        assert _make_linear_router().reachable_from(0) == {1, 2, 3}
-
-    # ---------------------------------------------------------
-    # All routes
-    # ---------------------------------------------------------
-
-    def test_all_routes_diamond(self):
-        """
-        The diamond DAG has two simple paths from C0 to C3,
-        sorted by descending bottleneck weight.
-        """
-        routes = _make_diamond_router().all_routes(0, 3)
-        assert len(routes) == 2
-        assert routes[0].bottleneck_weight >= routes[1].bottleneck_weight
-        assert routes[0].path == [0, 2, 3]
-        assert routes[1].path == [0, 1, 3]
-
-    def test_all_routes_disconnected(self):
-        """
-        Disconnected pair returns an empty list.
-        """
-        assert _make_linear_router().all_routes(3, 0) == []
-
-    def test_all_routes_linear(self):
-        """
-        Linear DAG has exactly one simple path between any
-        connected pair.
-        """
-        routes = _make_linear_router().all_routes(0, 3)
-        assert len(routes) == 1
-        assert routes[0].path == [0, 1, 2, 3]
-
-    # ---------------------------------------------------------
     # Integration (full fixture chain)
     # ---------------------------------------------------------
-
-    def test_all_routes_fixture(self, router: CareerRouter):
-        """
-        `all_routes` terminates on the full fixture graph without
-        raising.
-        """
-        nodes = list(router.pathway_graph.graph.nodes())
-        if len(nodes) >= 2:
-            router.all_routes(nodes[0], nodes[-1])
 
     def test_plan_fixture(self, router: CareerRouter):
         """
         `learning_plan` on the fixture graph returns a valid plan
         or `None` without crashing.
         """
-        nodes = list(router.pathway_graph.graph.nodes())
-        if len(nodes) >= 2:
-            result = router.learning_plan(nodes[0], nodes[-1])
-            assert result is None or isinstance(result, LearningPlan)
+        nodes = list(router.graph.nodes())
+        assert len(nodes) >= 2
+        result = router.learning_plan(nodes[0], nodes[-1])
+        assert result is None or isinstance(result, LearningPlan)

--- a/tests/pathways/test_routing.py
+++ b/tests/pathways/test_routing.py
@@ -13,6 +13,26 @@ from chalkline.pipeline.schemas import ApprenticeshipContext
 from chalkline.pipeline.schemas import ClusterProfile, ProgramRecommendation
 
 
+def _set_graph_metadata(
+    G        : DiGraph,
+    profiles : dict[int, ClusterProfile]
+):
+    """
+    Populate graph-level apprenticeship and program metadata,
+    mirroring `CareerPathwayGraph._build_graph`.
+    """
+    G.graph["apprenticeships"] = list({
+        p.apprenticeship.rapids_code: p.apprenticeship
+        for p in profiles.values()
+        if p.apprenticeship
+    }.values())
+    G.graph["programs"] = list({
+        (p.institution, p.program): p
+        for profile in profiles.values()
+        for p in profile.programs
+    }.values())
+
+
 def _make_linear_router() -> CareerRouter:
     """
     Build a 4-node linear DAG router for deterministic tests.
@@ -84,6 +104,7 @@ def _make_linear_router() -> CareerRouter:
     ], direction_source="job_zone")
     G.edges[0, 1]["term_hours_delta"] = "1000"
     G.edges[2, 3]["term_hours_delta"] = "3000"
+    _set_graph_metadata(G, profiles)
 
     return CareerRouter(SimpleNamespace(
         graph    = G,
@@ -143,6 +164,7 @@ def _make_diamond_router() -> CareerRouter:
         (1, 3, 0.3),
         (2, 3, 0.9)
     ], direction_source="job_zone")
+    _set_graph_metadata(G, profiles)
 
     return CareerRouter(SimpleNamespace(
         graph    = G,
@@ -193,6 +215,8 @@ class TestCareerRouter:
         G = DiGraph()
         for cid, profile in profiles.items():
             G.add_node(cid, **profile.model_dump())
+
+        _set_graph_metadata(G, profiles)
 
         router = CareerRouter(SimpleNamespace(
             graph    = G,


### PR DESCRIPTION
### 📐 Quick Summary

Adds `CareerRouter` for centrality analysis and widest-path career routing on the DAG from [CL-11](https://github.com/Jybbs/chalkline/issues/11). Four centrality measures[^49][^51] are computed eagerly at construction, while widest-path routing[^47] uses topological DP[^50] with max-min bottleneck relaxation in $`O(V + E)`$. The widest path maximizes the minimum edge weight along the route, selecting the most achievable career progression rather than the fewest transitions:

$`
\hspace{0.5cm} \displaystyle
d(v) = \max_{u \in \text{pred}(v)} \min\bigl(d(u),\, w(u, v)\bigr)
`$
<br>

Each transition step carries bridging skills (*the set difference $`S_{i+1} \setminus S_i`$ between adjacent cluster profiles*) annotated with matched apprenticeship and educational program enrichment. Several spec departures are documented in the [implementation comments](https://github.com/Jybbs/chalkline/issues/12), including topological DP over modified Dijkstra, removal of thin wrapper methods, and decoupling the router from `CareerPathwayGraph`.

***

### 🧱 Key Changes

#### Routing Module

- Add `src/chalkline/pathways/routing.py` with `CareerRouter` accepting `(graph, profiles)` directly, computing betweenness[^49], in-degree, out-degree, and PageRank[^51] centrality as node attributes, precomputing per-edge bridging skills and enrichment matches via 4-char prefix overlap, and exposing `widest_path` (*topological DP with max-min relaxation in $`O(V + E)`$*) and `learning_plan` public methods
- Add `TransitionStep`, `CareerRoute`, `CentralityMetrics`, and `LearningPlan` schemas to `src/chalkline/pathways/schemas.py`, with `LearningPlan.bridging_skills` and `LearningPlan.estimated_hours` as `@cached_property` methods derived from the route

#### Graph and Schema Refinements

- Add `apprenticeships` and `programs` cached properties to `CareerPathwayGraph`, lifting deduplicated reference lists from graph-level metadata to domain object properties
- Add `edge_count` field to `LongestPath` for disambiguating vacuous edgeless results from genuine single-node paths
- Default all fields on `LongestPath` and `AlignmentDiagnostics` so degenerate branches construct with bare schema calls
- Change `ClusterProfile.skills` from `list[str]` to `set[str]` and remove the dead `sort_skills` validator
- Rename `max_graph_density` to `max_density` on `CareerPathwayGraph`
- Add zero-edge diagnostic warning in `_build_graph` and PageRank degeneracy warning in `_compute_centrality`

#### Collection Refactor

- Refactor `CorpusStorage` from free functions into a class with `Postings` TypeAdapter, `corpus_path`, `deduplicate`, `load`, and `save` methods

#### Tests

- Add `tests/pathways/test_routing.py` with **19** tests covering centrality bounds and edgeless degeneracy, widest-path bottleneck selection on linear and diamond DAGs, bridging skill set differences, apprenticeship and program enrichment matching, learning plan derivation with null-hour handling, and full fixture chain integration
- Update `tests/collection/test_storage.py` for `CorpusStorage` class-based API

***

### 🔩 Related Issues

- Closes #12

***

### 📚 References

[^47]: Avlonitis, et al. 2023. "Career Path Recommendations for Long-term Income Maximization: A Reinforcement Learning Approach." Graph-based career navigation and optimal job-transition sequences. https://ceur-ws.org/Vol-3490/RecSysHR2023-paper_2.pdf

[^49]: Freeman. 1977. "A Set of Measures of Centrality Based on Betweenness." *Sociometry* 40(1): 35-41. https://doi.org/10.2307/3033543

[^50]: Pollack. 1960. "Letter to the Editor—The Maximum Capacity Through a Network." *Operations Research* 8 (5): 733–736. https://doi.org/10.1287/opre.8.5.733

[^51]: Page, Brin, Motwani & Winograd. 1999. "The PageRank Citation Ranking: Bringing Order to the Web." Stanford InfoLab Technical Report 1999-66. http://ilpubs.stanford.edu:8090/422/1/1999-66.pdf