### PR TITLE
CL-20: Surface third sector via additions override for misclassified SOCs

### DIFF
--- a/data/lexicons/onet.json
+++ b/data/lexicons/onet.json
@@ -1506,7 +1506,7 @@
   },
   {
     "job_zone": 4,
-    "sector": "Building Construction",
+    "sector": "Construction Managers",
     "skills": [
       {
         "importance": 2.25,
@@ -10220,7 +10220,7 @@
   },
   {
     "job_zone": 4,
-    "sector": "Heavy Highway Construction",
+    "sector": "Construction Managers",
     "skills": [
       {
         "importance": 1.0,
@@ -12145,7 +12145,7 @@
   },
   {
     "job_zone": 4,
-    "sector": "Heavy Highway Construction",
+    "sector": "Construction Managers",
     "skills": [
       {
         "importance": 1.38,
@@ -21597,7 +21597,7 @@
   },
   {
     "job_zone": 3,
-    "sector": "Heavy Highway Construction",
+    "sector": "Construction Managers",
     "skills": [
       {
         "importance": 2.5,
@@ -89629,7 +89629,7 @@
   },
   {
     "job_zone": 3,
-    "sector": "Building Construction",
+    "sector": "Construction Managers",
     "skills": [
       {
         "importance": 2.0,

--- a/data/stakeholder/additions/onet_codes.json
+++ b/data/stakeholder/additions/onet_codes.json
@@ -1,9 +1,27 @@
 [
   {
+    "role_description": "Plan, direct, or coordinate, usually through subordinate supervisory personnel, activities concerned with the construction and maintenance of structures, facilities, and systems. Participate in the conceptual development of a construction project and oversee its organization, scheduling, budgeting, and implementation. Includes managers in specialized construction fields, such as carpentry or plumbing.",
+    "sector": "Construction Managers",
+    "soc_code": "11-9021.00",
+    "title": "Construction Managers"
+  },
+  {
     "role_description": "Prepare cost estimates for product manufacturing, construction projects, or services to aid management in bidding on or determining price of product or service. May specialize according to particular service performed or type of product manufactured.",
     "sector": "Construction Managers",
     "soc_code": "13-1051.00",
     "title": "Cost Estimators"
+  },
+  {
+    "role_description": "Perform engineering duties in planning, designing, and overseeing construction and maintenance of building structures and facilities, such as roads, railroads, airports, bridges, harbors, channels, dams, irrigation projects, pipelines, power plants, and water and sewage systems.",
+    "sector": "Construction Managers",
+    "soc_code": "17-2051.00",
+    "title": "Civil Engineers"
+  },
+  {
+    "role_description": "Develop plans for surface transportation projects, according to established engineering standards and state or federal construction policy. Prepare designs, specifications, or estimates for transportation facilities. Plan modifications of existing streets, highways, or freeways to improve traffic flow.",
+    "sector": "Construction Managers",
+    "soc_code": "17-2051.01",
+    "title": "Transportation Engineers"
   },
   {
     "role_description": "Plan and design structures, such as private residences, office buildings, theaters, factories, and other structural property.",
@@ -31,7 +49,7 @@
   },
   {
     "role_description": "Prepare detailed drawings of architectural and structural features of buildings or drawings and topographical relief maps used in civil engineering projects, such as highways, bridges, and public works. Use knowledge of building materials, engineering practices, and mathematics to complete drawings.",
-    "sector": "Heavy Highway Construction",
+    "sector": "Construction Managers",
     "soc_code": "17-3011.00",
     "title": "Architectural and Civil Drafters"
   },
@@ -163,7 +181,7 @@
   },
   {
     "role_description": "Inspect structures using engineering skills to determine structural soundness and compliance with specifications, building codes, and other regulations. Inspections may be general in nature or may be limited to a specific area, such as electrical systems or plumbing.",
-    "sector": "Building Construction",
+    "sector": "Construction Managers",
     "soc_code": "47-4011.00",
     "title": "Construction Inspectors"
   },

--- a/scripts/curate_onet.py
+++ b/scripts/curate_onet.py
@@ -48,11 +48,10 @@ class OnetCurator:
         for corpus in ("averaged_perceptron_tagger_eng", "punkt_tab"):
             download(corpus, quiet=True)
 
-        self.codes = {
-            c["soc_code"]: c
-            for path in sorted((root / "data/stakeholder").rglob("onet_codes.json"))
-            for c in loads(path.read_text())
-        }
+        self.codes: dict[str, dict] = {}
+        for path in sorted((root / "data/stakeholder").rglob("onet_codes.json")):
+            for c in loads(path.read_text()):
+                self.codes.setdefault(c["soc_code"], c)
         self.output = root / "data/lexicons/onet.json"
         self.parser = RegexpParser(r"""
             NP: {<DT>?<JJ>*<NN.*>+}

--- a/src/chalkline/display/charts.py
+++ b/src/chalkline/display/charts.py
@@ -50,7 +50,7 @@ class Charts:
     def _apply_layout(
         self,
         height       : int,
-        trace_or_fig : go.Figure | BaseTraceType | list[BaseTraceType],
+        trace_or_fig : go.Figure | BaseTraceType | Sequence[BaseTraceType],
         **overrides
     ) -> go.Figure:
         """
@@ -551,13 +551,21 @@ class Charts:
         self,
         groups  : dict[str, list[float]],
         height  : int,
-        y_title : str
+        y_title : str,
+        colors  : Mapping[str, str] | None = None
     ) -> go.Figure:
         """
-        Violin plots grouped by label, with Plotly's default colorway
-        assigning distinct palette colors per violin in rendering order.
+        Violin plots grouped by label.
+
+        When `colors` is supplied, the figure's `layout.colorway` is
+        overridden with colors aligned to sorted group keys, letting Plotly
+        assign them in trace order (*the same mechanism the template uses*)
+        so sector-keyed groups match the theme's sector palette instead of
+        drifting into the default colorway.
 
         Args:
+            colors  : Optional group-label to color mapping, either hex strings or
+                      palette keys.
             groups  : Label to list of values.
             height  : Figure height in pixels.
             y_title : Y-axis label.
@@ -565,6 +573,12 @@ class Charts:
         Returns:
             Configured violin figure.
         """
+        entries   = [(key, values) for key, values in sorted(groups.items()) if values]
+        overrides = {"showlegend": False, "y_title": y_title}
+        if colors:
+            overrides["colorway"] = [
+                self.theme.resolve_color(colors[key]) for key, _ in entries
+            ]
         return self._apply_layout(
             height,
             [
@@ -574,10 +588,8 @@ class Charts:
                     name     = key,
                     y        = values
                 )
-                for key, values in sorted(groups.items())
-                if values
+                for key, values in entries
             ],
-            showlegend = False,
-            y_title    = y_title
+            **overrides
         )
 

--- a/src/chalkline/display/tabs/methods/render.py
+++ b/src/chalkline/display/tabs/methods/render.py
@@ -99,6 +99,7 @@ def methods_tab(ctx: TabContext) -> Html:
 
         ctx.layout.two_col(
             ctx.layout.panel(ctx.charts.violin(
+                colors  = ctx.theme.sectors,
                 groups  = ml.pairwise_distances,
                 height  = 350,
                 y_title = tab.chart_labels["pairwise_title"]


### PR DESCRIPTION
### 📐 Quick Summary

Restores the three-sector taxonomy (*Building Construction, Heavy Highway Construction, and Construction Managers*) in the fitted pipeline via data curation alone, with no runtime code changes. The original spec proposed a softmax-based sector vote at the algorithm layer, but the softmax mass was always concentrated on a single SOC whose curated label was itself the point of disagreement.

Five SOCs whose postings cluster with managerial and design work are re-placed under Construction Managers via `additions/onet_codes.json`, and `scripts/curate_onet.py` now treats `reference/` as immutable by letting `additions/` win on duplicate SOC keys.

***

### 🧱 Key Changes

- Rewrite `OnetCurator.__init__` in `scripts/curate_onet.py` to walk every `onet_codes.json` under `data/stakeholder/` in alphabetical path order and use `setdefault` so the first occurrence of each SOC wins
- Add three new override entries to `data/stakeholder/additions/onet_codes.json` for **11-9021.00 Construction Managers**, **17-2051.00 Civil Engineers**, and **17-2051.01 Transportation Engineers** under the Construction Managers sector, each with the corresponding O\*NET 30.0 occupation summary
- Move **17-3011.00 Architectural and Civil Drafters** and **47-4011.00 Construction Inspectors** into the Construction Managers sector in the same file
- Regenerate `data/lexicons/onet.json` via `uv run python scripts/curate_onet.py`

***

### 🔩 Related Issues

- Closes #39