### PR TITLE
CL-43: Refresh corpus and rework wage spine, credentials, and map tiering

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The [Green Buildings Career Map](https://greenbuildingscareermap.org/) organized
 
 The premise is that postings encode implicit structure about how occupations relate to one another, which skills bridge adjacent roles, and what credentials separate one career level from the next. Occupational modeling at scale has confirmed this, showing that millions of unstructured postings yield taxonomies comparable to expert-curated frameworks[^2], and network models built from skill overlap reveal the same latent mobility structure[^1][^36]. Data-driven taxonomies extracted directly from online adverts have reached similar conclusions at smaller scale[^31], reinforcing that the signal is in the postings themselves.
 
-Chalkline works with **2,154** postings scraped from [AGC Maine](https://www.agcmaine.org/)'s listings and covers **60** [O\*NET](https://www.onetonline.org/) [SOC](https://www.bls.gov/soc/) codes across three sectors (*Building Construction, Construction Managers, Heavy Highway Construction*). A sentence transformer[^57] encodes each posting into a 768-dimensional embedding, Ward-linkage HAC[^27] clusters those embeddings into **20** career families, and a stepwise k-NN graph routes advancement and lateral moves enriched by **836** credentials (*19 apprenticeships, 787 certifications, 30 educational programs*) on a per-route basis. A joined labor table of [BLS OEWS](https://www.bls.gov/oes/) wages, growth projections, and [O\*NET Bright Outlook](https://www.onetonline.org/find/bright) designations covers **53** of the SOC codes, driving the cluster-level wage expectations that appear on every career card. Upload a resume, and the system chunks it into sentences, encodes each chunk, and projects into the same space for personalized skill-gap analysis[^44].
+Chalkline works with **2,154** postings scraped from [AGC Maine](https://www.agcmaine.org/)'s listings and covers **60** [O\*NET](https://www.onetonline.org/) [SOC](https://www.bls.gov/soc/) codes across three sectors (*Building Construction, Construction Managers, Heavy Highway Construction*). A sentence transformer[^57] encodes each posting into a 768-dimensional embedding, Ward-linkage HAC[^27] clusters those embeddings into **25** career families, and a stepwise k-NN graph routes advancement and lateral moves enriched by **836** credentials (*19 apprenticeships, 787 certifications, 30 educational programs*) on a per-route basis. A joined labor table of [BLS OEWS](https://www.bls.gov/oes/) wages, growth projections, and [O\*NET Bright Outlook](https://www.onetonline.org/find/bright) designations covers **53** of the SOC codes, driving the cluster-level wage expectations that appear on every career card. Upload a resume, and the system chunks it into sentences, encodes each chunk, and projects into the same space for personalized skill-gap analysis[^44].
 
 A chalk line snaps a straight reference path between two points. Chalkline does the same for careers.
 
@@ -65,11 +65,11 @@ Chalkline is a single-track embedding pipeline orchestrated by [Hamilton](https:
 |------|------|-----------|--------|
 | 1 | **Corpus Loading** | Deduplicate and filter JobSpy-collected postings, normalize companies and locations | `collection.collector` |
 | 2 | **Sentence Encoding** | [`Alibaba-NLP/gte-base-en-v1.5`](https://huggingface.co/Alibaba-NLP/gte-base-en-v1.5) via ONNX with CLS pooling | `pipeline.encoder` |
-| 3 | **Dimensionality Reduction** | L2-normalize embeddings, then [TruncatedSVD](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html) to **10** components | `pipeline.steps` |
-| 4 | **Clustering** | [Ward-linkage HAC](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html) at $`k = 20`$ career families | `pipeline.steps` |
+| 3 | **Dimensionality Reduction** | L2-normalize embeddings, then [TruncatedSVD](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html) to **15** components | `pipeline.steps` |
+| 4 | **Clustering** | [Ward-linkage HAC](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html) at $`k = 25`$ career families | `pipeline.steps` |
 | 5 | **SOC Assignment** | Posting-level ColBERTv2 MaxSim against Task embeddings of all **60** O\*NET occupations | `pathways.selection` |
 | 6 | **Per-Cluster Wage** | Top-K softmax expectation over labor wages weighted by SOC similarity | `pathways.clusters` |
-| 7 | **Career Graph** | Stepwise k-NN backbone (*lateral at same Job Zone, upward at next*) with per-route destination-affinity credential pool and waste-aware Pareto-knee selection | `pathways.graph` |
+| 7 | **Career Graph** | Stepwise k-NN backbone (*lateral at same wage tier, upward at next*) with per-route Reciprocal Rank Fusion[^68] candidate filter and waste-aware Pareto-knee[^69] credential selection, anchored on a single apprenticeship for the work-based path | `pathways.graph` |
 | 8 | **Resume Matching** | Sentence chunking, per-task MaxSim, BM25-weighted gap ranking, SVD projection for centroid distance | `matching.matcher` |
 
 The `SentenceEncoder` in `pipeline/encoder.py` downloads the ONNX model from HuggingFace on first use and runs inference via `onnxruntime` in fixed-size batches with CLS pooling followed by L2 normalization, with the ~430 MB model file deliberately instantiated outside the DAG, so that Hamilton's disk cache only serializes NumPy array outputs rather than the encoder weights themselves. Cold-start time for subsequent sessions drops from **~10.4s** to **~0.35s** because the encoder loads tokenizer files through `Tokenizer.from_file` and reuses `try_to_load_from_cache` rather than re-resolving the HuggingFace revision each time.
@@ -98,7 +98,7 @@ $`
 `$  
 <br>
 
-The pipeline retains $`k = 10`$ components, reducing each posting from **768** coordinates to **10** that capture the dominant structure of the original space. This generalizes latent semantic analysis[^18] to dense transformer embeddings, and the randomized SVD algorithm[^17] keeps the factorization efficient even for large matrices. Evidence suggests that cutting sentence embedding dimensions by roughly half can actually improve downstream clustering[^53].
+The pipeline retains $`k = 15`$ components, reducing each posting from **768** coordinates to **15** that capture the dominant structure of the original space. This generalizes latent semantic analysis[^18] to dense transformer embeddings, and the randomized SVD algorithm[^17] keeps the factorization efficient even for large matrices. Evidence suggests that cutting sentence embedding dimensions by roughly half can actually improve downstream clustering[^53].
 
 ### Ward-Linkage Hierarchical Clustering
 
@@ -110,7 +110,7 @@ d_{\text{Ward}}(A, B) = \sqrt{\frac{2 \cdot |A| \cdot |B|}{|A| + |B|}} \; \|\bar
 `$  
 <br>
 
-This builds a full merge hierarchy that is then cut at $`k = 20`$ to produce twenty career families. Ward linkage is the chosen criterion, because its variance-minimization objective produces the most cohesive families under the construction corpus's tight within-sector similarity.
+This builds a full merge hierarchy that is then cut at $`k = 25`$ to produce twenty-five career families. Ward linkage is the chosen criterion, because its variance-minimization objective produces the most cohesive families under the construction corpus's tight within-sector similarity.
 
 ### Cluster Quality and Connectivity
 
@@ -186,29 +186,37 @@ where $`f`$ is the term's frequency in the task, $`\ell`$ is the task length, $`
 
 ### Career Graph and Credential Filter
 
-The career graph connects the **20** career families with directed, weighted edges representing plausible career moves[^1]. Graph-based representations of occupational transitions capture mobility patterns that flat taxonomies miss[^47][^55], and the stepwise constraint ensures edges only link clusters at the same Job Zone (*lateral pivots*) or one level apart (*upward advancement*), preventing unrealistic tier-skipping jumps[^48]. Each cluster gets $`k_\text{lateral} = 2`$ bidirectional edges to clusters at the same Job Zone and $`k_\text{upward} = 2`$ unidirectional edges to clusters at the next Job Zone level.
+The career graph connects the **25** career families with directed, weighted edges representing plausible career moves[^1]. Graph-based representations of occupational transitions capture mobility patterns that flat taxonomies miss[^47][^55], and the stepwise constraint ensures edges only link clusters at the same wage tier (*lateral pivots*) or one tier apart (*upward advancement*), preventing unrealistic tier-skipping jumps[^48]. Each cluster gets $`k_\text{lateral} = 2`$ bidirectional edges to clusters at the same wage tier and $`k_\text{upward} = 2`$ unidirectional edges to clusters at the next tier.
 
-Credentials attach per route rather than per edge, meaning that `CareerPathwayGraph.credentials_for(target_id)` applies a destination-affinity filter to the full credential set on demand, so that every route the user explores receives a freshly computed, destination-specific credential pool. A credential $`\mathbf{c}`$ passes when its similarity to the destination cluster $`\mathbf{d}`$ exceeds the **80th** percentile of all credential similarities to that target:
+Credentials attach per route rather than per edge, meaning that `CareerPathwayGraph.credentials_for(target_id)` applies a Reciprocal Rank Fusion candidate filter[^68] on demand, so that every route the user explores receives a freshly computed, destination-specific credential pool. RRF combines two complementary rankings (*credential-to-cluster centroid cosine and credential-to-destination-task MaxSim*) into a single fused score:
 
 $`
 \hspace{0.5cm} \displaystyle
-\cos(\mathbf{c}, \mathbf{d}) \geq \tau_\text{dest}(\mathbf{d})
+\text{RRF}(c \mid \mathbf{d}) = \frac{1}{k + r_\text{centroid}(c, \mathbf{d})} + \frac{1}{k + r_\text{task}(c, \mathbf{d})}
 `$  
 <br>
 
-where $`\tau_\text{dest}(\mathbf{d})`$ is the **80th** percentile (*top 20%*) of credential similarities to cluster $`\mathbf{d}`$. Because career-change recommendations are about destination relevance, the filter gates only on where the user is going rather than requiring overlap with the user's current position. The filter runs per route, so the credential pool adapts to every destination the user explores rather than being frozen at fit time.
+where $`r_\text{centroid}`$ is the credential's rank by cosine to the destination cluster's mean posting embedding, $`r_\text{task}`$ is its rank by MaxSim against the destination SOC's O\*NET task vectors, and $`k = 60`$ is the Cormack 2009 default damping constant. RRF is robust to score-scale mismatch between the two signals, letting both contribute without weighted-sum tuning. Credentials passing the **top 15th-percentile** of fused score form the candidate pool.
 
 ### Gap Coverage via Waste-Aware Pareto-Knee Selection
 
-Once a route's gap set and credential pool are known, the `CredentialSelector` picks up to five credentials that jointly cover as many gaps as possible while minimizing redundant reach. The selector sweeps a waste-penalty parameter $`\alpha`$ across the candidate pool, where each step runs a greedy pass scoring credentials by
+Once a route's gap set and candidate pool are known, the `CredentialSelector` picks credentials by sweeping a waste penalty $`\alpha`$ across $`[0, 5]`$ and running a greedy gap-fill search at each setting. At step $`t`$, the picker chooses
 
 $`
 \hspace{0.5cm} \displaystyle
-\text{score}(c \mid R) = \Delta\text{gaps}(c, R) - \alpha \cdot \Delta\text{waste}(c, R)
+c^* = \arg\max_{c \in \mathcal{C} \setminus \mathcal{S}_t} \bigl| \text{reach}(c) \cap \mathcal{G}_t \bigr| - \alpha \cdot \bigl| \text{reach}(c) \setminus \mathcal{G}_t \bigr|
 `$  
 <br>
 
-where $`\Delta\text{gaps}`$ is the number of new gaps credential $`c`$ covers beyond the current residual $`R`$, and $`\Delta\text{waste}`$ is the number of positions in $`c`$'s reach that land on already-covered or non-gap tasks. Each $`\alpha`$ produces a different stack with a different trade-off between gap coverage and waste, and the set of non-dominated (*gaps filled, waste*) outcomes forms a Pareto frontier. The selector filters the frontier to stacks meeting a **coverage floor** of $`\lceil 0.80 \times |G| \rceil`$ gaps, then applies the Kneedle algorithm[^66] to find the knee point where marginal waste reduction per gap lost bends most sharply. When no stack on the frontier reaches the coverage floor, the selector falls back to the unconstrained Pareto knee. Each picked credential records its incremental `positions: frozenset[int]` (*newly covered gaps at pick time*), which the UI uses to check off only the gaps that credential contributes rather than every gap it can cover in isolation.
+where $`\mathcal{S}_t`$ is the set picked so far, $`\mathcal{G}_t`$ is the still-uncovered gap set, and the second term penalizes credentials that touch tasks outside the gap set. Sweeping $`\alpha`$ traces the Pareto frontier on the $`(\text{gaps filled}, \text{waste})`$ plane. Among frontier points meeting a configurable coverage floor (*default $`80\%`$ of gaps*), Kneedle[^69] locates the elbow where additional waste stops buying enough coverage to justify itself. Stack length is data-driven, in that the picker stops adding credentials once marginal score turns non-positive.
+
+Three strategies surface per route:
+
+- The single credential of any kind with the strongest gap-fill versus waste tradeoff, for users who want one concrete recommendation rather than a stack to assemble
+- A stack of certifications, for users who want to add training without committing to a multi-year apprenticeship
+- A single apprenticeship most aligned with the destination occupation, complemented by certifications that fill the gaps the apprenticeship leaves open, presenting the realistic shape of an apprenticeship-led career path rather than stacking multiple full apprenticeships
+
+Each picked credential records its incremental gap positions (*the gaps it newly contributes after earlier picks in the stack*), which the UI uses to check off only the gaps that credential contributes rather than every gap it can cover in isolation.
 
 ### Per-Cluster Wage Expectation
 
@@ -284,7 +292,7 @@ The matched cluster's internal composition comes from two analytical pieces that
 
 ### Methods Tab
 
-The methods tab documents the pipeline's design choices for technical audiences by combining a visual walkthrough of the Hamilton DAG with the analytical primitives that justified each step's configuration. The tab opens with a process flow diagram rendering every node's parameter-level dependency graph, accompanied by per-node timing pulled from the fit log, so that the reader can see which step dominates wall-clock cost. Bar charts of SVD explained variance reveal how much of the original 768-dimensional signal survives in the 10-component reduction, whereas sector cluster sizes and per-cluster silhouette coefficients describe the partition's balance and separation quality. A scatter plot pairs silhouette against brokerage centrality on the career graph, resulting in a two-dimensional view that distinguishes families that are well-defined but peripheral from families that are both well-defined and well-connected, and a matching brokerage bar chart ranks every cluster by its stepping-stone role in the graph. SOC-similarity heatmaps show how each cluster ranks against every O\*NET occupation, providing direct evidence for the MaxSim assignment decisions, and a node-to-file table mirrors `chalkline cache` output, so that a reader verifying an invalidation subtree can confirm which cached artifacts Hamilton will rebuild on the next fit.
+The methods tab documents the pipeline's design choices for technical audiences by combining a visual walkthrough of the Hamilton DAG with the analytical primitives that justified each step's configuration. The tab opens with a process flow diagram rendering every node's parameter-level dependency graph, accompanied by per-node timing pulled from the fit log, so that the reader can see which step dominates wall-clock cost. Bar charts of SVD explained variance reveal how much of the original 768-dimensional signal survives in the 15-component reduction, whereas sector cluster sizes and per-cluster silhouette coefficients describe the partition's balance and separation quality. A scatter plot pairs silhouette against brokerage centrality on the career graph, resulting in a two-dimensional view that distinguishes families that are well-defined but peripheral from families that are both well-defined and well-connected, and a matching brokerage bar chart ranks every cluster by its stepping-stone role in the graph. SOC-similarity heatmaps show how each cluster ranks against every O\*NET occupation, providing direct evidence for the MaxSim assignment decisions, and a node-to-file table mirrors `chalkline cache` output, so that a reader verifying an invalidation subtree can confirm which cached artifacts Hamilton will rebuild on the next fit.
 
 Interactive glossary tooltips sit throughout both analytical tabs via pipeline-specific substitutions, meaning technical terms like *silhouette*, *betweenness*, *MaxSim*, and *TruncatedSVD* render as underlined popover triggers that reveal rich definitions sourced from `display/tabs/shared/glossary.toml` without requiring the reader to leave the notebook for external documentation.
 
@@ -426,7 +434,7 @@ chalkline/
 │   │   ├── graph.py                       NetworkX stepwise k-NN backbone with per-pair credentials_for
 │   │   ├── loaders.py                     LaborLoader and StakeholderReference
 │   │   ├── schemas.py                     Credential, EncodedOccupation, Occupation, SkillType
-│   │   └── selection.py                   SOCScorer (ColBERTv2 MaxSim) and CredentialSelector (waste-aware Pareto-knee)
+│   │   └── selection.py                   SOCScorer (ColBERTv2 MaxSim) and CredentialSelector (Pareto-knee)
 │   │
 │   └── pipeline/                          Orchestration and shared types
 │       ├── encoder.py                     ONNX sentence transformer wrapper with CLS pooling
@@ -510,4 +518,6 @@ AGC provided the posting corpus, the stakeholder reference data defining the pro
 
 [^65]: Achananuparp, et al. 2025. "A Multi-Stage Framework with Taxonomy-Guided Reasoning for Occupation Classification Using Large Language Models." *arXiv preprint, accepted at ICWSM 2026*. https://doi.org/10.48550/arXiv.2503.12989
 
-[^66]: Satopaa, et al. 2011. "Finding a 'Kneedle' in a Haystack: Detecting Knee Points in System Behavior." *31st International Conference on Distributed Computing Systems Workshops*: 166-171. https://doi.org/10.1109/ICDCSW.2011.20
+[^68]: Cormack, Clarke & Buettcher. 2009. "Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods." *Proceedings of the 32nd International ACM SIGIR Conference on Research and Development in Information Retrieval*: 758-759. https://doi.org/10.1145/1571941.1572114
+
+[^69]: Satopaa, Albrecht, Irwin & Raghavan. 2011. "Finding a 'Kneedle' in a Haystack: Detecting Knee Points in System Behavior." *31st International Conference on Distributed Computing Systems Workshops*: 166-171. https://doi.org/10.1109/ICDCSW.2011.20

--- a/app/chalkline.css
+++ b/app/chalkline.css
@@ -708,6 +708,7 @@ marimo-file, marimo-file > div, marimo-file label { width: 100% !important; }
 
 .cl-pathway-map {
     & :is(.node-subtitle, .tooltip-dim)  { fill: var(--cl-muted-foreground); font-size: 10px; }
+    & .node-suffix                       { fill: var(--cl-muted-foreground); font-size: 10px; font-style: italic; }
     & :is(.edge, .matched-glow)          { fill: none; }
     & :is(.node, .node-circle)           { cursor: pointer; }
     & .node-rect                         { fill: var(--cl-border); }

--- a/app/chalkline.css
+++ b/app/chalkline.css
@@ -781,6 +781,22 @@ marimo-file, marimo-file > div, marimo-file label { width: 100% !important; }
     & :is(.tooltip-positive, .tooltip-negative) { font-size: 10px; font-weight: 600; }
     & .tooltip-positive { fill: var(--cl-secondary); }
     & .tooltip-negative { fill: var(--cl-error); }
+
+    /* ── Legend ─────────────────────────────────────────── */
+
+    & .cl-legend-bg {
+        fill    : var(--cl-card);
+        opacity : 0.92;
+        stroke  : var(--cl-border);
+    }
+
+    & .cl-legend-swatch { stroke: var(--cl-border); stroke-width: 0.5; }
+
+    & .cl-legend-label {
+        fill        : var(--cl-foreground);
+        font-size   : 11px;
+        font-weight : 600;
+    }
 }
 
 /* ── Marimo overrides ────────────────────────────────────────── */

--- a/app/chalkline.css
+++ b/app/chalkline.css
@@ -730,7 +730,8 @@ marimo-file, marimo-file > div, marimo-file label { width: 100% !important; }
         stroke-width : 1;
     }
 
-    & :is(.circle-pct, .donut-label) { font-size: 9px; }
+    & .circle-pct                    { font-size: 9px; }
+    & .donut-label                   { font-size: 10px; }
     & .circle-label  { fill: var(--cl-muted-foreground); font-size: 7px; }
     & .progress-ring { fill: var(--cl-primary); opacity: 0.7; }
 

--- a/app/main.py
+++ b/app/main.py
@@ -161,11 +161,10 @@ def _(forms, pipeline):
 # ── Map widget ─────────────────────────────────────────────────────
 
 @app.cell
-def _(labor, mo, pathway, pipeline, result, theme):
+def _(mo, pathway, pipeline, result, theme):
     widget = mo.ui.anywidget(pathway.from_graph(
         clusters   = pipeline.clusters,
         graph      = pipeline.graph,
-        labor      = labor,
         matched_id = result.cluster_id,
         matcher    = pipeline.matcher,
         result     = result,
@@ -177,11 +176,10 @@ def _(labor, mo, pathway, pipeline, result, theme):
 # ── Map filter sync ────────────────────────────────────────────────
 
 @app.cell
-def _(labor, pathway, pipeline, result, theme, wage_slider, widget):
+def _(pathway, pipeline, result, theme, wage_slider, widget):
     widget.graph_data = pathway.build_graph_data(
         clusters    = pipeline.clusters,
         graph       = pipeline.graph,
-        labor       = labor,
         matched_id  = result.cluster_id,
         matcher     = pipeline.matcher,
         result      = result,

--- a/data/lexicons/labor.json
+++ b/data/lexicons/labor.json
@@ -233,7 +233,7 @@
   },
   {
     "soc_code": "11-9041.00",
-    "soc_title": "Architectural & Engineering Managers",
+    "soc_title": "Arch. & Eng. Managers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -463,7 +463,7 @@
   },
   {
     "soc_code": "13-1082.00",
-    "soc_title": "Project Management Specialists",
+    "soc_title": "Project Specialists",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -813,7 +813,7 @@
   },
   {
     "soc_code": "17-2051.01",
-    "soc_title": "Transportation Engineers",
+    "soc_title": "Transport Engineers",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -907,7 +907,7 @@
   },
   {
     "soc_code": "17-3011.00",
-    "soc_title": "Architectural and Civil Drafters",
+    "soc_title": "Arch. & Civil Drafters",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -1022,7 +1022,7 @@
   },
   {
     "soc_code": "17-3022.00",
-    "soc_title": "Civil Engineering Technicians",
+    "soc_title": "Civil Eng. Technicians",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -1369,7 +1369,7 @@
   },
   {
     "soc_code": "47-2021.00",
-    "soc_title": "Brickmasons & Blockmasons",
+    "soc_title": "Brick & Blockmasons",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -1948,7 +1948,7 @@
   },
   {
     "soc_code": "47-2043.00",
-    "soc_title": "Floor Sanders & Finishers",
+    "soc_title": "Floor Finishers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2180,7 +2180,7 @@
   },
   {
     "soc_code": "47-2051.00",
-    "soc_title": "Cement Masons & Finishers",
+    "soc_title": "Cement Masons",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2295,7 +2295,7 @@
   },
   {
     "soc_code": "47-2053.00",
-    "soc_title": "Terrazzo Workers & Finishers",
+    "soc_title": "Terrazzo Finishers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2528,7 +2528,7 @@
   },
   {
     "soc_code": "47-2071.00",
-    "soc_title": "Paving & Tamping Operators",
+    "soc_title": "Paving Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2873,7 +2873,7 @@
   },
   {
     "soc_code": "47-2081.00",
-    "soc_title": "Drywall & Ceiling Tile Installers",
+    "soc_title": "Drywall Installers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -3336,7 +3336,7 @@
   },
   {
     "soc_code": "47-2131.00",
-    "soc_title": "Insulation Workers, Envelope",
+    "soc_title": "Envelope Insulators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -3451,7 +3451,7 @@
   },
   {
     "soc_code": "47-2132.00",
-    "soc_title": "Insulation Workers, Mechanical",
+    "soc_title": "Mechanical Insulators",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -3915,7 +3915,7 @@
   },
   {
     "soc_code": "47-2161.00",
-    "soc_title": "Plasterers & Stucco Masons",
+    "soc_title": "Plasterers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -4030,7 +4030,7 @@
   },
   {
     "soc_code": "47-2171.00",
-    "soc_title": "Reinforcing Iron & Rebar Workers",
+    "soc_title": "Rebar Workers",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -4367,7 +4367,7 @@
   },
   {
     "soc_code": "47-2221.00",
-    "soc_title": "Structural Iron and Steel Workers",
+    "soc_title": "Iron & Steel Workers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -4599,7 +4599,7 @@
   },
   {
     "soc_code": "47-4011.00",
-    "soc_title": "Construction Inspectors",
+    "soc_title": "Building Inspectors",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -4714,7 +4714,7 @@
   },
   {
     "soc_code": "47-4021.00",
-    "soc_title": "Elevator & Escalator Installers",
+    "soc_title": "Elevator Installers",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -4948,7 +4948,7 @@
   },
   {
     "soc_code": "47-4051.00",
-    "soc_title": "Highway Maintenance Workers",
+    "soc_title": "Highway Maintenance",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -5063,7 +5063,7 @@
   },
   {
     "soc_code": "47-4061.00",
-    "soc_title": "Rail-Track Laying Equipment",
+    "soc_title": "Rail-Track Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -5270,7 +5270,7 @@
   },
   {
     "soc_code": "49-9021.00",
-    "soc_title": "HVAC Mechanics & Installers",
+    "soc_title": "HVAC Mechanics",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -5502,7 +5502,7 @@
   },
   {
     "soc_code": "49-9051.00",
-    "soc_title": "Power-Line Installers & Repairers",
+    "soc_title": "Power-Line Installers",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -5619,7 +5619,7 @@
   },
   {
     "soc_code": "49-9071.00",
-    "soc_title": "General Maintenance Workers",
+    "soc_title": "General Maintenance",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -5851,7 +5851,7 @@
   },
   {
     "soc_code": "53-7021.00",
-    "soc_title": "Crane & Tower Operators",
+    "soc_title": "Crane Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -5966,7 +5966,7 @@
   },
   {
     "soc_code": "53-7041.00",
-    "soc_title": "Hoist & Winch Operators",
+    "soc_title": "Hoist Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],

--- a/data/lexicons/labor.json
+++ b/data/lexicons/labor.json
@@ -813,7 +813,7 @@
   },
   {
     "soc_code": "17-2051.01",
-    "soc_title": "Transport Engineers",
+    "soc_title": "Transportation Engineers",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -1369,7 +1369,7 @@
   },
   {
     "soc_code": "47-2021.00",
-    "soc_title": "Brick & Blockmasons",
+    "soc_title": "Brickmasons & Blockmasons",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -1948,7 +1948,7 @@
   },
   {
     "soc_code": "47-2043.00",
-    "soc_title": "Floor Finishers",
+    "soc_title": "Floor Sanders & Finishers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2180,7 +2180,7 @@
   },
   {
     "soc_code": "47-2051.00",
-    "soc_title": "Cement Masons",
+    "soc_title": "Cement Masons & Finishers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2528,7 +2528,7 @@
   },
   {
     "soc_code": "47-2071.00",
-    "soc_title": "Paving Operators",
+    "soc_title": "Paving & Tamping Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -2873,7 +2873,7 @@
   },
   {
     "soc_code": "47-2081.00",
-    "soc_title": "Drywall Installers",
+    "soc_title": "Drywall & Tile Installers",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -3915,7 +3915,7 @@
   },
   {
     "soc_code": "47-2161.00",
-    "soc_title": "Plasterers",
+    "soc_title": "Plasterers & Stucco Masons",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -4030,7 +4030,7 @@
   },
   {
     "soc_code": "47-2171.00",
-    "soc_title": "Rebar Workers",
+    "soc_title": "Reinforcing Rebar Workers",
     "outlook": {
       "bright_outlook": true,
       "outlook_reasons": [
@@ -4599,7 +4599,7 @@
   },
   {
     "soc_code": "47-4011.00",
-    "soc_title": "Building Inspectors",
+    "soc_title": "Construction Inspectors",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -5851,7 +5851,7 @@
   },
   {
     "soc_code": "53-7021.00",
-    "soc_title": "Crane Operators",
+    "soc_title": "Crane & Tower Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],
@@ -5966,7 +5966,7 @@
   },
   {
     "soc_code": "53-7041.00",
-    "soc_title": "Hoist Operators",
+    "soc_title": "Hoist & Winch Operators",
     "outlook": {
       "bright_outlook": false,
       "outlook_reasons": [],

--- a/data/lexicons/onet.json
+++ b/data/lexicons/onet.json
@@ -13826,7 +13826,7 @@
       }
     ],
     "soc_code": "17-2051.01",
-    "title": "Transport Engineers"
+    "title": "Transportation Engineers"
   },
   {
     "job_zone": 4,
@@ -27338,7 +27338,7 @@
       }
     ],
     "soc_code": "37-3013.00",
-    "title": "Tree Trimmers"
+    "title": "Tree Trimmers & Pruners"
   },
   {
     "job_zone": 1,
@@ -35589,7 +35589,7 @@
       }
     ],
     "soc_code": "47-2021.00",
-    "title": "Brick & Blockmasons"
+    "title": "Brickmasons & Blockmasons"
   },
   {
     "job_zone": 2,
@@ -44966,7 +44966,7 @@
       }
     ],
     "soc_code": "47-2043.00",
-    "title": "Floor Finishers"
+    "title": "Floor Sanders & Finishers"
   },
   {
     "job_zone": 2,
@@ -49666,7 +49666,7 @@
       }
     ],
     "soc_code": "47-2051.00",
-    "title": "Cement Masons"
+    "title": "Cement Masons & Finishers"
   },
   {
     "job_zone": 2,
@@ -55862,7 +55862,7 @@
       }
     ],
     "soc_code": "47-2071.00",
-    "title": "Paving Operators"
+    "title": "Paving & Tamping Operators"
   },
   {
     "job_zone": 2,
@@ -61464,7 +61464,7 @@
       }
     ],
     "soc_code": "47-2081.00",
-    "title": "Drywall Installers"
+    "title": "Drywall & Tile Installers"
   },
   {
     "job_zone": 2,
@@ -79639,7 +79639,7 @@
       }
     ],
     "soc_code": "47-2161.00",
-    "title": "Plasterers"
+    "title": "Plasterers & Stucco Masons"
   },
   {
     "job_zone": 2,
@@ -81042,7 +81042,7 @@
       }
     ],
     "soc_code": "47-2171.00",
-    "title": "Rebar Workers"
+    "title": "Reinforcing Rebar Workers"
   },
   {
     "job_zone": 2,
@@ -91768,7 +91768,7 @@
       }
     ],
     "soc_code": "47-4011.00",
-    "title": "Building Inspectors"
+    "title": "Construction Inspectors"
   },
   {
     "job_zone": 3,
@@ -102808,7 +102808,7 @@
       }
     ],
     "soc_code": "49-3042.00",
-    "title": "Heavy Equip. Mechanics"
+    "title": "Heavy Equipment Mechanics"
   },
   {
     "job_zone": 3,
@@ -120495,7 +120495,7 @@
       }
     ],
     "soc_code": "53-7021.00",
-    "title": "Crane Operators"
+    "title": "Crane & Tower Operators"
   },
   {
     "job_zone": 2,
@@ -121762,6 +121762,6 @@
       }
     ],
     "soc_code": "53-7041.00",
-    "title": "Hoist Operators"
+    "title": "Hoist & Winch Operators"
   }
 ]

--- a/data/lexicons/onet.json
+++ b/data/lexicons/onet.json
@@ -5636,7 +5636,7 @@
       }
     ],
     "soc_code": "11-9041.00",
-    "title": "Architectural & Engineering Managers"
+    "title": "Arch. & Eng. Managers"
   },
   {
     "job_zone": 4,
@@ -8288,7 +8288,7 @@
       }
     ],
     "soc_code": "13-1082.00",
-    "title": "Project Management Specialists"
+    "title": "Project Specialists"
   },
   {
     "job_zone": 5,
@@ -13826,7 +13826,7 @@
       }
     ],
     "soc_code": "17-2051.01",
-    "title": "Transportation Engineers"
+    "title": "Transport Engineers"
   },
   {
     "job_zone": 4,
@@ -23757,7 +23757,7 @@
       }
     ],
     "soc_code": "17-3011.00",
-    "title": "Architectural and Civil Drafters"
+    "title": "Arch. & Civil Drafters"
   },
   {
     "job_zone": 3,
@@ -25646,7 +25646,7 @@
       }
     ],
     "soc_code": "17-3022.00",
-    "title": "Civil Engineering Technicians"
+    "title": "Civil Eng. Technicians"
   },
   {
     "job_zone": 2,
@@ -27338,7 +27338,7 @@
       }
     ],
     "soc_code": "37-3013.00",
-    "title": "Tree Trimmers & Pruners"
+    "title": "Tree Trimmers"
   },
   {
     "job_zone": 1,
@@ -28697,7 +28697,7 @@
       }
     ],
     "soc_code": "45-4022.00",
-    "title": "Logging Equipment Operators"
+    "title": "Logging Operators"
   },
   {
     "job_zone": 3,
@@ -35589,7 +35589,7 @@
       }
     ],
     "soc_code": "47-2021.00",
-    "title": "Brickmasons & Blockmasons"
+    "title": "Brick & Blockmasons"
   },
   {
     "job_zone": 2,
@@ -44966,7 +44966,7 @@
       }
     ],
     "soc_code": "47-2043.00",
-    "title": "Floor Sanders & Finishers"
+    "title": "Floor Finishers"
   },
   {
     "job_zone": 2,
@@ -49666,7 +49666,7 @@
       }
     ],
     "soc_code": "47-2051.00",
-    "title": "Cement Masons & Finishers"
+    "title": "Cement Masons"
   },
   {
     "job_zone": 2,
@@ -51357,7 +51357,7 @@
       }
     ],
     "soc_code": "47-2053.00",
-    "title": "Terrazzo Workers & Finishers"
+    "title": "Terrazzo Finishers"
   },
   {
     "job_zone": 2,
@@ -55862,7 +55862,7 @@
       }
     ],
     "soc_code": "47-2071.00",
-    "title": "Paving & Tamping Operators"
+    "title": "Paving Operators"
   },
   {
     "job_zone": 2,
@@ -61464,7 +61464,7 @@
       }
     ],
     "soc_code": "47-2081.00",
-    "title": "Drywall & Ceiling Tile Installers"
+    "title": "Drywall Installers"
   },
   {
     "job_zone": 2,
@@ -69242,7 +69242,7 @@
       }
     ],
     "soc_code": "47-2131.00",
-    "title": "Insulation Workers, Envelope"
+    "title": "Envelope Insulators"
   },
   {
     "job_zone": 2,
@@ -70617,7 +70617,7 @@
       }
     ],
     "soc_code": "47-2132.00",
-    "title": "Insulation Workers, Mechanical"
+    "title": "Mechanical Insulators"
   },
   {
     "job_zone": 2,
@@ -79639,7 +79639,7 @@
       }
     ],
     "soc_code": "47-2161.00",
-    "title": "Plasterers & Stucco Masons"
+    "title": "Plasterers"
   },
   {
     "job_zone": 2,
@@ -81042,7 +81042,7 @@
       }
     ],
     "soc_code": "47-2171.00",
-    "title": "Reinforcing Iron & Rebar Workers"
+    "title": "Rebar Workers"
   },
   {
     "job_zone": 2,
@@ -87894,7 +87894,7 @@
       }
     ],
     "soc_code": "47-2221.00",
-    "title": "Structural Iron and Steel Workers"
+    "title": "Iron & Steel Workers"
   },
   {
     "job_zone": 2,
@@ -91768,7 +91768,7 @@
       }
     ],
     "soc_code": "47-4011.00",
-    "title": "Construction Inspectors"
+    "title": "Building Inspectors"
   },
   {
     "job_zone": 3,
@@ -93550,7 +93550,7 @@
       }
     ],
     "soc_code": "47-4021.00",
-    "title": "Elevator & Escalator Installers"
+    "title": "Elevator Installers"
   },
   {
     "job_zone": 2,
@@ -97338,7 +97338,7 @@
       }
     ],
     "soc_code": "47-4051.00",
-    "title": "Highway Maintenance Workers"
+    "title": "Highway Maintenance"
   },
   {
     "job_zone": 2,
@@ -98995,7 +98995,7 @@
       }
     ],
     "soc_code": "47-4061.00",
-    "title": "Rail-Track Laying Equipment"
+    "title": "Rail-Track Operators"
   },
   {
     "job_zone": 2,
@@ -102808,7 +102808,7 @@
       }
     ],
     "soc_code": "49-3042.00",
-    "title": "Mobile Heavy Equipment Mechanics"
+    "title": "Heavy Equip. Mechanics"
   },
   {
     "job_zone": 3,
@@ -106291,7 +106291,7 @@
       }
     ],
     "soc_code": "49-9021.00",
-    "title": "HVAC Mechanics & Installers"
+    "title": "HVAC Mechanics"
   },
   {
     "job_zone": 2,
@@ -111542,7 +111542,7 @@
       }
     ],
     "soc_code": "49-9051.00",
-    "title": "Power-Line Installers & Repairers"
+    "title": "Power-Line Installers"
   },
   {
     "job_zone": 3,
@@ -114725,7 +114725,7 @@
       }
     ],
     "soc_code": "49-9071.00",
-    "title": "General Maintenance Workers"
+    "title": "General Maintenance"
   },
   {
     "job_zone": 2,
@@ -118694,7 +118694,7 @@
       }
     ],
     "soc_code": "51-4121.00",
-    "title": "Welders, Cutters, & Solderers"
+    "title": "Welders & Solderers"
   },
   {
     "job_zone": 3,
@@ -120495,7 +120495,7 @@
       }
     ],
     "soc_code": "53-7021.00",
-    "title": "Crane & Tower Operators"
+    "title": "Crane Operators"
   },
   {
     "job_zone": 2,
@@ -121762,6 +121762,6 @@
       }
     ],
     "soc_code": "53-7041.00",
-    "title": "Hoist & Winch Operators"
+    "title": "Hoist Operators"
   }
 ]

--- a/data/stakeholder/additions/onet_codes.json
+++ b/data/stakeholder/additions/onet_codes.json
@@ -21,7 +21,7 @@
     "role_description": "Develop plans for surface transportation projects, according to established engineering standards and state or federal construction policy. Prepare designs, specifications, or estimates for transportation facilities. Plan modifications of existing streets, highways, or freeways to improve traffic flow.",
     "sector": "Construction Managers",
     "soc_code": "17-2051.01",
-    "title": "Transportation Engineers"
+    "title": "Transport Engineers"
   },
   {
     "role_description": "Plan and design structures, such as private residences, office buildings, theaters, factories, and other structural property.",
@@ -51,25 +51,25 @@
     "role_description": "Prepare detailed drawings of architectural and structural features of buildings or drawings and topographical relief maps used in civil engineering projects, such as highways, bridges, and public works. Use knowledge of building materials, engineering practices, and mathematics to complete drawings.",
     "sector": "Construction Managers",
     "soc_code": "17-3011.00",
-    "title": "Architectural and Civil Drafters"
+    "title": "Arch. & Civil Drafters"
   },
   {
     "role_description": "Apply theory and principles of civil engineering in planning, designing, and overseeing construction and maintenance of structures and facilities under the direction of engineering staff or physical scientists.",
     "sector": "Construction Managers",
     "soc_code": "17-3022.00",
-    "title": "Civil Engineering Technicians"
+    "title": "Civil Eng. Technicians"
   },
   {
     "role_description": "Cut away dead or excess branches from trees or shrubs to maintain right-of-way for roads, sidewalks, or utilities, or to improve appearance, health, and value of tree. Prune or treat trees or shrubs using handsaws, hand pruners, clippers, and power pruners. Works off the ground in the tree canopy and may use truck-mounted lifts.",
     "sector": "Heavy Highway Construction",
     "soc_code": "37-3013.00",
-    "title": "Tree Trimmers & Pruners"
+    "title": "Tree Trimmers"
   },
   {
     "role_description": "Drive logging tractor or wheeled vehicle equipped with one or more accessories, such as bulldozer blade, frontal shear, grapple, logging arch, cable winches, hoisting rack, or crane boom, to fell tree, to skid, load, unload, or stack logs, or to pull stumps or clear brush. Includes operating grapple loaders and self-propelled log loaders and unloaders at a camp, landing, or mill.",
     "sector": "Heavy Highway Construction",
     "soc_code": "45-4022.00",
-    "title": "Logging Equipment Operators"
+    "title": "Logging Operators"
   },
   {
     "role_description": "Construct, assemble, maintain, and repair stationary steam boilers and boiler house auxiliaries. Align structures or plate sections to assemble boiler frame tanks or vats, following blueprints. Work involves use of hand and power tools, plumb bobs, levels, wedges, dogs, or turnbuckles. Assist in testing assembled vessels. Direct cleaning of boilers and boiler furnaces. Inspect and repair boiler fittings, such as safety valves, regulators, automatic-control mechanisms, water columns, and auxiliary machines.",
@@ -81,7 +81,7 @@
     "role_description": "Lay and bind building materials, such as brick, structural tile, concrete block, cinder block, glass block, and terra-cotta block, with mortar and other substances, to construct or repair walls, partitions, arches, sewers, and other structures.",
     "sector": "Building Construction",
     "soc_code": "47-2021.00",
-    "title": "Brickmasons & Blockmasons"
+    "title": "Brick & Blockmasons"
   },
   {
     "role_description": "Build stone structures, such as piers, walls, and abutments. Lay walks, curbstones, or special types of masonry for vats, tanks, and floors.",
@@ -105,7 +105,7 @@
     "role_description": "Scrape and sand wooden floors to smooth surfaces using floor scraper and floor sanding machine, and apply coats of finish.",
     "sector": "Building Construction",
     "soc_code": "47-2043.00",
-    "title": "Floor Sanders & Finishers"
+    "title": "Floor Finishers"
   },
   {
     "role_description": "Apply hard tile, stone, and comparable materials to walls, floors, ceilings, countertops, and roof decks.",
@@ -117,13 +117,13 @@
     "role_description": "Smooth and finish surfaces of poured concrete, such as floors, walks, sidewalks, roads, or curbs using a variety of hand and power tools. Align forms for sidewalks, curbs, or gutters; patch voids; and use saws to cut expansion joints.",
     "sector": "Building Construction",
     "soc_code": "47-2051.00",
-    "title": "Cement Masons & Finishers"
+    "title": "Cement Masons"
   },
   {
     "role_description": "Apply a mixture of cement, sand, pigment, or marble chips to floors, stairways, and cabinet fixtures to fashion durable and decorative surfaces.",
     "sector": "Building Construction",
     "soc_code": "47-2053.00",
-    "title": "Terrazzo Workers & Finishers"
+    "title": "Terrazzo Finishers"
   },
   {
     "role_description": "Perform tasks involving physical labor at construction sites. May operate hand and power tools of all types: air hammers, earth tampers, cement mixers, small mechanical hoists, surveying and measuring equipment, and a variety of other equipment and instruments. May clean and prepare sites, dig trenches, set braces to support the sides of excavations, erect scaffolding, and clean up rubble, debris, and other waste materials. May assist other craft workers.",
@@ -147,7 +147,7 @@
     "role_description": "Line and cover structures with insulating materials. May work with batt, roll, or blown insulation materials.",
     "sector": "Building Construction",
     "soc_code": "47-2131.00",
-    "title": "Insulation Workers, Envelope"
+    "title": "Envelope Insulators"
   },
   {
     "role_description": "Paint walls, equipment, buildings, bridges, and other structural surfaces, using brushes, rollers, and spray guns. May remove old paint to prepare surface prior to painting. May mix colors or oils to obtain desired color or consistency.",
@@ -159,7 +159,7 @@
     "role_description": "Apply interior or exterior plaster, cement, stucco, or similar materials. May also set ornamental plaster.",
     "sector": "Building Construction",
     "soc_code": "47-2161.00",
-    "title": "Plasterers & Stucco Masons"
+    "title": "Plasterers"
   },
   {
     "role_description": "Cover roofs of structures with shingles, slate, asphalt, aluminum, wood, or related materials. May spray roofs, sidings, and walls with material to bind, seal, insulate, or soundproof sections of structures.",
@@ -183,7 +183,7 @@
     "role_description": "Inspect structures using engineering skills to determine structural soundness and compliance with specifications, building codes, and other regulations. Inspections may be general in nature or may be limited to a specific area, such as electrical systems or plumbing.",
     "sector": "Construction Managers",
     "soc_code": "47-4011.00",
-    "title": "Construction Inspectors"
+    "title": "Building Inspectors"
   },
   {
     "role_description": "Erect and repair fences and fence gates, using hand and power tools.",
@@ -201,13 +201,13 @@
     "role_description": "Diagnose, adjust, repair, or overhaul mobile mechanical, hydraulic, and pneumatic equipment, such as cranes, bulldozers, graders, and conveyors, used in construction, logging, and mining.",
     "sector": "Heavy Highway Construction",
     "soc_code": "49-3042.00",
-    "title": "Mobile Heavy Equipment Mechanics"
+    "title": "Heavy Equip. Mechanics"
   },
   {
     "role_description": "Install or repair heating, central air conditioning, HVAC, or refrigeration systems, including oil burners, hot-air furnaces, and heating stoves.",
     "sector": "Building Construction",
     "soc_code": "49-9021.00",
-    "title": "HVAC Mechanics & Installers"
+    "title": "HVAC Mechanics"
   },
   {
     "role_description": "Install, dismantle, or move machinery and heavy equipment according to layout plans, blueprints, or other drawings.",
@@ -219,13 +219,13 @@
     "role_description": "Install or repair cables or wires used in electrical power or distribution systems. May erect poles and light or heavy duty transmission towers.",
     "sector": "Building Construction",
     "soc_code": "49-9051.00",
-    "title": "Power-Line Installers & Repairers"
+    "title": "Power-Line Installers"
   },
   {
     "role_description": "Perform work involving the skills of two or more maintenance or craft occupations to keep machines, mechanical equipment, or the structure of a building in repair. Duties may involve pipe fitting; HVAC maintenance; insulating; welding; machining; carpentry; repairing electrical or mechanical equipment; installing, aligning, and balancing new equipment; and repairing buildings, floors, or stairs.",
     "sector": "Building Construction",
     "soc_code": "49-9071.00",
-    "title": "General Maintenance Workers"
+    "title": "General Maintenance"
   },
   {
     "role_description": "Set up or repair rigging for construction projects, manufacturing plants, logging yards, ships and shipyards, or for the entertainment industry.",
@@ -237,18 +237,18 @@
     "role_description": "Use hand-welding, flame-cutting, hand-soldering, or brazing equipment to weld or join metal components or to fill holes, indentations, or seams of fabricated metal products.",
     "sector": "Building Construction",
     "soc_code": "51-4121.00",
-    "title": "Welders, Cutters, & Solderers"
+    "title": "Welders & Solderers"
   },
   {
     "role_description": "Operate mechanical boom and cable or tower and cable equipment to lift and move materials, machines, or products in many directions.",
     "sector": "Building Construction",
     "soc_code": "53-7021.00",
-    "title": "Crane & Tower Operators"
+    "title": "Crane Operators"
   },
   {
     "role_description": "Operate or tend hoists or winches to lift and pull loads using power-operated cable equipment.",
     "sector": "Heavy Highway Construction",
     "soc_code": "53-7041.00",
-    "title": "Hoist & Winch Operators"
+    "title": "Hoist Operators"
   }
 ]

--- a/data/stakeholder/additions/onet_codes.json
+++ b/data/stakeholder/additions/onet_codes.json
@@ -21,7 +21,7 @@
     "role_description": "Develop plans for surface transportation projects, according to established engineering standards and state or federal construction policy. Prepare designs, specifications, or estimates for transportation facilities. Plan modifications of existing streets, highways, or freeways to improve traffic flow.",
     "sector": "Construction Managers",
     "soc_code": "17-2051.01",
-    "title": "Transport Engineers"
+    "title": "Transportation Engineers"
   },
   {
     "role_description": "Plan and design structures, such as private residences, office buildings, theaters, factories, and other structural property.",
@@ -63,7 +63,7 @@
     "role_description": "Cut away dead or excess branches from trees or shrubs to maintain right-of-way for roads, sidewalks, or utilities, or to improve appearance, health, and value of tree. Prune or treat trees or shrubs using handsaws, hand pruners, clippers, and power pruners. Works off the ground in the tree canopy and may use truck-mounted lifts.",
     "sector": "Heavy Highway Construction",
     "soc_code": "37-3013.00",
-    "title": "Tree Trimmers"
+    "title": "Tree Trimmers & Pruners"
   },
   {
     "role_description": "Drive logging tractor or wheeled vehicle equipped with one or more accessories, such as bulldozer blade, frontal shear, grapple, logging arch, cable winches, hoisting rack, or crane boom, to fell tree, to skid, load, unload, or stack logs, or to pull stumps or clear brush. Includes operating grapple loaders and self-propelled log loaders and unloaders at a camp, landing, or mill.",
@@ -81,7 +81,7 @@
     "role_description": "Lay and bind building materials, such as brick, structural tile, concrete block, cinder block, glass block, and terra-cotta block, with mortar and other substances, to construct or repair walls, partitions, arches, sewers, and other structures.",
     "sector": "Building Construction",
     "soc_code": "47-2021.00",
-    "title": "Brick & Blockmasons"
+    "title": "Brickmasons & Blockmasons"
   },
   {
     "role_description": "Build stone structures, such as piers, walls, and abutments. Lay walks, curbstones, or special types of masonry for vats, tanks, and floors.",
@@ -105,7 +105,7 @@
     "role_description": "Scrape and sand wooden floors to smooth surfaces using floor scraper and floor sanding machine, and apply coats of finish.",
     "sector": "Building Construction",
     "soc_code": "47-2043.00",
-    "title": "Floor Finishers"
+    "title": "Floor Sanders & Finishers"
   },
   {
     "role_description": "Apply hard tile, stone, and comparable materials to walls, floors, ceilings, countertops, and roof decks.",
@@ -117,7 +117,7 @@
     "role_description": "Smooth and finish surfaces of poured concrete, such as floors, walks, sidewalks, roads, or curbs using a variety of hand and power tools. Align forms for sidewalks, curbs, or gutters; patch voids; and use saws to cut expansion joints.",
     "sector": "Building Construction",
     "soc_code": "47-2051.00",
-    "title": "Cement Masons"
+    "title": "Cement Masons & Finishers"
   },
   {
     "role_description": "Apply a mixture of cement, sand, pigment, or marble chips to floors, stairways, and cabinet fixtures to fashion durable and decorative surfaces.",
@@ -159,7 +159,7 @@
     "role_description": "Apply interior or exterior plaster, cement, stucco, or similar materials. May also set ornamental plaster.",
     "sector": "Building Construction",
     "soc_code": "47-2161.00",
-    "title": "Plasterers"
+    "title": "Plasterers & Stucco Masons"
   },
   {
     "role_description": "Cover roofs of structures with shingles, slate, asphalt, aluminum, wood, or related materials. May spray roofs, sidings, and walls with material to bind, seal, insulate, or soundproof sections of structures.",
@@ -183,7 +183,7 @@
     "role_description": "Inspect structures using engineering skills to determine structural soundness and compliance with specifications, building codes, and other regulations. Inspections may be general in nature or may be limited to a specific area, such as electrical systems or plumbing.",
     "sector": "Construction Managers",
     "soc_code": "47-4011.00",
-    "title": "Building Inspectors"
+    "title": "Construction Inspectors"
   },
   {
     "role_description": "Erect and repair fences and fence gates, using hand and power tools.",
@@ -201,7 +201,7 @@
     "role_description": "Diagnose, adjust, repair, or overhaul mobile mechanical, hydraulic, and pneumatic equipment, such as cranes, bulldozers, graders, and conveyors, used in construction, logging, and mining.",
     "sector": "Heavy Highway Construction",
     "soc_code": "49-3042.00",
-    "title": "Heavy Equip. Mechanics"
+    "title": "Heavy Equipment Mechanics"
   },
   {
     "role_description": "Install or repair heating, central air conditioning, HVAC, or refrigeration systems, including oil burners, hot-air furnaces, and heating stoves.",
@@ -243,12 +243,12 @@
     "role_description": "Operate mechanical boom and cable or tower and cable equipment to lift and move materials, machines, or products in many directions.",
     "sector": "Building Construction",
     "soc_code": "53-7021.00",
-    "title": "Crane Operators"
+    "title": "Crane & Tower Operators"
   },
   {
     "role_description": "Operate or tend hoists or winches to lift and pull loads using power-operated cable equipment.",
     "sector": "Heavy Highway Construction",
     "soc_code": "53-7041.00",
-    "title": "Hoist Operators"
+    "title": "Hoist & Winch Operators"
   }
 ]

--- a/data/stakeholder/reference/onet_codes.json
+++ b/data/stakeholder/reference/onet_codes.json
@@ -31,7 +31,7 @@
   },
   {
     "soc_code": "47-2081.00",
-    "title": "Drywall Installers",
+    "title": "Drywall & Tile Installers",
     "role_description": "Finishing interior office spaces and retail layouts.",
     "sector": "Building Construction"
   },
@@ -55,13 +55,13 @@
   },
   {
     "soc_code": "17-2051.01",
-    "title": "Transport Engineers",
+    "title": "Transportation Engineers",
     "role_description": "Specialized planning for highway systems and traffic flow.",
     "sector": "Heavy Highway Construction"
   },
   {
     "soc_code": "47-2071.00",
-    "title": "Paving Operators",
+    "title": "Paving & Tamping Operators",
     "role_description": "Operating machines that spread and level asphalt or concrete.",
     "sector": "Heavy Highway Construction"
   },
@@ -91,7 +91,7 @@
   },
   {
     "soc_code": "47-2171.00",
-    "title": "Rebar Workers",
+    "title": "Reinforcing Rebar Workers",
     "role_description": "Laying rebar for bridge decks and highway overpasses.",
     "sector": "Heavy Highway Construction"
   },

--- a/data/stakeholder/reference/onet_codes.json
+++ b/data/stakeholder/reference/onet_codes.json
@@ -19,7 +19,7 @@
   },
   {
     "soc_code": "47-2221.00",
-    "title": "Structural Iron and Steel Workers",
+    "title": "Iron & Steel Workers",
     "role_description": "Erecting the steel skeletons of high-rise commercial buildings.",
     "sector": "Building Construction"
   },
@@ -31,19 +31,19 @@
   },
   {
     "soc_code": "47-2081.00",
-    "title": "Drywall & Ceiling Tile Installers",
+    "title": "Drywall Installers",
     "role_description": "Finishing interior office spaces and retail layouts.",
     "sector": "Building Construction"
   },
   {
     "soc_code": "47-2132.00",
-    "title": "Insulation Workers, Mechanical",
+    "title": "Mechanical Insulators",
     "role_description": "Insulating commercial boilers, pipes, and HVAC ducts.",
     "sector": "Building Construction"
   },
   {
     "soc_code": "47-4021.00",
-    "title": "Elevator & Escalator Installers",
+    "title": "Elevator Installers",
     "role_description": "Essential for multi-story commercial structures.",
     "sector": "Building Construction"
   },
@@ -55,13 +55,13 @@
   },
   {
     "soc_code": "17-2051.01",
-    "title": "Transportation Engineers",
+    "title": "Transport Engineers",
     "role_description": "Specialized planning for highway systems and traffic flow.",
     "sector": "Heavy Highway Construction"
   },
   {
     "soc_code": "47-2071.00",
-    "title": "Paving & Tamping Operators",
+    "title": "Paving Operators",
     "role_description": "Operating machines that spread and level asphalt or concrete.",
     "sector": "Heavy Highway Construction"
   },
@@ -73,7 +73,7 @@
   },
   {
     "soc_code": "47-4051.00",
-    "title": "Highway Maintenance Workers",
+    "title": "Highway Maintenance",
     "role_description": "Repairing roads, guardrails, and highway markers.",
     "sector": "Heavy Highway Construction"
   },
@@ -91,13 +91,13 @@
   },
   {
     "soc_code": "47-2171.00",
-    "title": "Reinforcing Iron & Rebar Workers",
+    "title": "Rebar Workers",
     "role_description": "Laying rebar for bridge decks and highway overpasses.",
     "sector": "Heavy Highway Construction"
   },
   {
     "soc_code": "47-4061.00",
-    "title": "Rail-Track Laying Equipment",
+    "title": "Rail-Track Operators",
     "role_description": "Specialized for heavy rail and transit infrastructure.",
     "sector": "Heavy Highway Construction"
   },
@@ -109,13 +109,13 @@
   },
   {
     "soc_code": "13-1082.00",
-    "title": "Project Management Specialists",
+    "title": "Project Specialists",
     "role_description": "Broad management focusing on schedule/budget; often used for \"Project Coordinators.\"",
     "sector": "Construction Managers"
   },
   {
     "soc_code": "11-9041.00",
-    "title": "Architectural & Engineering Managers",
+    "title": "Arch. & Eng. Managers",
     "role_description": "Managing the design-phase and technical engineering teams.",
     "sector": "Construction Managers"
   },

--- a/src/chalkline/collection/collector.py
+++ b/src/chalkline/collection/collector.py
@@ -122,24 +122,27 @@ class Collector:
 
 if __name__ == "__main__":
 
+    EXCLUSIONS = "-home -residential -homeowner -handyman -remodel -remodeling"
+    TRADES     = [
+        "carpenter",
+        "construction",
+        "crane operator",
+        "electrician",
+        "equipment operator",
+        "foreman",
+        "HVAC",
+        "ironworker",
+        "laborer",
+        "mason",
+        "paving",
+        "pipefitter",
+        "plumber",
+        "sheet metal worker",
+        "superintendent",
+        "welder"
+    ]
+
     Collector(
         postings_dir = Path("data") / "postings",
-        search_terms = [
-            "carpenter",
-            "construction",
-            "crane operator",
-            "electrician",
-            "equipment operator",
-            "foreman",
-            "HVAC",
-            "ironworker",
-            "laborer",
-            "mason",
-            "paving",
-            "pipefitter",
-            "plumber",
-            "sheet metal worker",
-            "superintendent",
-            "welder"
-        ]
+        search_terms = [f"{trade} {EXCLUSIONS}" for trade in TRADES]
     ).run()

--- a/src/chalkline/collection/collector.py
+++ b/src/chalkline/collection/collector.py
@@ -31,7 +31,7 @@ class Collector:
         self,
         postings_dir   : Path,
         search_terms   : list[str],
-        results_wanted : int       = 10000,
+        results_wanted : int       = 1000,
         sites          : list[str] = ["indeed"]
     ):
         """
@@ -122,22 +122,39 @@ class Collector:
 
 if __name__ == "__main__":
 
-    EXCLUSIONS = "-home -residential -homeowner -handyman -remodel -remodeling"
+    EXCLUSIONS = (
+        "-home -residential -homeowner -handyman "
+        "-custodian -custodial -janitor -janitorial -housekeeping -laundry "
+        "-cashier -waiter -waitress"
+    )
     TRADES     = [
         "carpenter",
+        "civil engineer",
+        "commercial roofing",
         "construction",
+        "construction inspector",
+        "construction manager",
+        "cost estimator",
         "crane operator",
+        "drywall",
+        "electrical engineer",
         "electrician",
         "equipment operator",
         "foreman",
+        "heavy equipment mechanic",
         "HVAC",
+        "insulator",
         "ironworker",
         "laborer",
         "mason",
+        "mechanical engineer",
+        "millwright",
         "paving",
         "pipefitter",
         "plumber",
+        "project manager construction",
         "sheet metal worker",
+        "solar technician",
         "superintendent",
         "welder"
     ]

--- a/src/chalkline/display/charts.py
+++ b/src/chalkline/display/charts.py
@@ -115,7 +115,7 @@ class Charts:
         return [
             f"Cluster {cid}<br>"
             f"{(c := self.pathway.clusters[cid]).soc_title}<br>"
-            f"Job Zone {c.job_zone} · {c.size} postings"
+            f"Tier {c.wage_tier + 1} · {c.size} postings"
             for cid in node_ids
         ]
 

--- a/src/chalkline/display/schemas.py
+++ b/src/chalkline/display/schemas.py
@@ -341,11 +341,10 @@ class MapGeometry(BaseModel, extra="forbid"):
 
     Owns pixel-level constants for node dimensions, force simulation tuning,
     and text-fit thresholds. The JS renderer receives a `dimensions` payload
-    with the values it needs, while the Python side uses `title_char_limit`
-    for pre-truncation.
+    with the values it needs.
     """
 
-    card_h              : int        = 56
+    card_h              : int        = 66
     card_w              : int        = 200
     circle_r            : int        = 24
     default_wage_range  : list[int]  = [30000, 90000]
@@ -353,7 +352,6 @@ class MapGeometry(BaseModel, extra="forbid"):
     hero_h              : int        = 80
     hero_w              : int        = 280
     pad                 : int        = 50
-    title_char_limit    : int        = 28
     width               : int        = 1800
 
     @property
@@ -361,7 +359,7 @@ class MapGeometry(BaseModel, extra="forbid"):
         """
         Layout constants for the JS force simulation and renderer.
         """
-        return self.model_dump(exclude={"default_wage_range", "title_char_limit"})
+        return self.model_dump(exclude={"default_wage_range"})
 
 
 class MlMetrics(BaseModel, extra="forbid"):

--- a/src/chalkline/display/schemas.py
+++ b/src/chalkline/display/schemas.py
@@ -344,7 +344,7 @@ class MapGeometry(BaseModel, extra="forbid"):
     with the values it needs.
     """
 
-    card_h              : int        = 66
+    card_h              : int        = 60
     card_w              : int        = 200
     circle_r            : int        = 24
     default_wage_range  : list[int]  = [30000, 90000]

--- a/src/chalkline/display/schemas.py
+++ b/src/chalkline/display/schemas.py
@@ -305,22 +305,19 @@ class JobPostingMetrics(BaseModel, extra="forbid"):
         )
 
 
-class JobZoneBreakdown(NamedTuple):
+class WageTierBreakdown(NamedTuple):
     """
-    Cluster counts by Job Zone with cross-tabulated sector breakdown.
+    Cluster counts by wage tier with cross-tabulated sector breakdown.
 
     Groups the two related views the methods tab needs together so they
     travel as one field on `MlMetrics` instead of two parallel fields.
+    Counts are already keyed by display label (`Tier 1`, `Tier 2`, ...) so
+    no separate label mapping is needed at render time, and matrix columns
+    align with `counts.keys()` order.
     """
 
-    counts : dict[int, int]
+    counts : dict[str, int]
     matrix : dict[str, list[int]]
-
-    def labeled_counts(self, names: dict[int, str]) -> dict[str, int]:
-        """
-        Apply a level-to-name map to produce a label-keyed count dict.
-        """
-        return {names[level]: count for level, count in self.counts.items()}
 
 
 class Labels(BaseModel, extra="forbid"):
@@ -333,7 +330,6 @@ class Labels(BaseModel, extra="forbid"):
     """
 
     fallback_location : str
-    job_zones         : dict[int, str]
     spinner_text      : str
     tab_names         : dict[str, str]
     upload_label      : str
@@ -388,12 +384,12 @@ class MlMetrics(BaseModel, extra="forbid"):
     edge_weights       : list[float]
     embed_dim          : int
     embedding_model    : str
-    job_zone           : JobZoneBreakdown
     pairwise_distances : dict[str, list[float]]
     sector_sizes       : dict[str, int]
     silhouette         : SectorRanking
     soc_heatmap        : dict[str, list[float]]
     variance           : VarianceBreakdown
+    wage_tier          : WageTierBreakdown
 
     @property
     def funnel_stages(self) -> dict[str, int]:
@@ -456,12 +452,14 @@ class MlMetrics(BaseModel, extra="forbid"):
         ratio     = pipeline.matcher.svd.explained_variance_ratio_
         brokerage = SectorRanking.from_ranking(clusters, pipeline.graph.brokerage)
 
-        job_zone_counts = Counter(c.job_zone for c in clusters.values())
-        sector_pairs    = Counter((c.sector, c.job_zone) for c in clusters.values())
-        job_zone        = JobZoneBreakdown(
-            counts = (sorted_counts := dict(sorted(job_zone_counts.items()))),
+        tier_label   = lambda t: f"Tier {t + 1}"
+        tier_counts  = Counter(c.wage_tier for c in clusters.values())
+        sector_pairs = Counter((c.sector, c.wage_tier) for c in clusters.values())
+        ordered      = sorted(tier_counts)
+        wage_tier    = WageTierBreakdown(
+            counts = {tier_label(t): tier_counts[t] for t in ordered},
             matrix = {
-                sector: [sector_pairs[sector, level] for level in sorted_counts]
+                sector: [sector_pairs[sector, t] for t in ordered]
                 for sector in clusters.sectors
             }
         )
@@ -478,12 +476,12 @@ class MlMetrics(BaseModel, extra="forbid"):
             edge_weights       = pipeline.graph.edge_weights,
             embed_dim          = pipeline.embed_dim,
             embedding_model    = pipeline.config.embedding_model,
-            job_zone           = job_zone,
             pairwise_distances = clusters.pairwise_distances,
             sector_sizes       = clusters.sector_sizes,
             silhouette         = SectorRanking.from_tuples(clusters.silhouette_scores),
             soc_heatmap        = clusters.soc_heatmap,
-            variance           = VarianceBreakdown.from_svd(ratio)
+            variance           = VarianceBreakdown.from_svd(ratio),
+            wage_tier          = wage_tier
         )
 
 
@@ -782,7 +780,7 @@ class RouteDetail(NamedTuple):
     Joined route data for the Map tab's recipe card.
 
     Holds the source and destination `Cluster` objects for dot-notation
-    access to SOC titles, sectors, Job Zones, and postings. Constructed via
+    access to SOC titles, sectors, wage tiers, and postings. Constructed via
     `from_selection`, which computes credentials per (source, destination)
     pair through the graph's dual-threshold filter, independent of how many
     backbone hops separate the two clusters.

--- a/src/chalkline/display/schemas.py
+++ b/src/chalkline/display/schemas.py
@@ -25,7 +25,8 @@ from chalkline.matching.schemas      import MatchResult, ScoredTask
 from chalkline.pathways.clusters     import Cluster, Clusters
 from chalkline.pathways.graph        import CareerPathwayGraph
 from chalkline.pathways.loaders      import LaborLoader, StakeholderReference
-from chalkline.pathways.schemas      import Credential
+from chalkline.pathways.schemas      import Credential, SelectedCredential
+from chalkline.pathways.selection    import CredentialSelector
 from chalkline.pipeline.encoder      import SentenceEncoder
 from chalkline.pipeline.orchestrator import Chalkline
 
@@ -47,10 +48,71 @@ class CredentialPath(NamedTuple):
     One gap-closure strategy with its credentials and total coverage.
     """
 
-    coverage_floor_met : bool
-    items              : list[PathItem]
-    strategy           : str
-    unique_coverage    : int
+    items           : list[PathItem]
+    strategy        : str
+    unique_coverage : int
+
+    @classmethod
+    def _from_picks(
+        cls,
+        credentials : dict[str, Credential],
+        picks       : list[SelectedCredential],
+        strategy    : str
+    ) -> Self:
+        """
+        Wrap a list of `SelectedCredential` picks into a `CredentialPath`.
+        """
+        return cls(
+            items           = [
+                PathItem.from_credential(credentials[p.label], p.label, p.positions)
+                for p in picks
+            ],
+            strategy        = strategy,
+            unique_coverage = sum(len(p.positions) for p in picks)
+        )
+
+    @classmethod
+    def anchored_from_route(
+        cls,
+        route    : RouteDetail,
+        strategy : str
+    ) -> Self | None:
+        """
+        Anchor-and-complement path for the work-based strategy.
+
+        Selects the apprenticeship most aligned with the destination by
+        `route.task_maxsim`, then runs the Pareto-knee picker on
+        certifications-only with the gap set reduced by what the anchor
+        already covers. Treats apprenticeships as career anchors rather
+        than stackable items, so the user sees one apprenticeship plus
+        supporting certifications instead of multiple full apprenticeships
+        layered together.
+
+        Falls back to a certifications-only stack via `from_route` when
+        the candidate pool contains no apprenticeships or when the
+        destination carries no task-MaxSim signal.
+
+        Args:
+            route    : Route carrying coverage, gap set, and task_maxsim.
+            strategy : Label written onto the returned path.
+        """
+        by_kind     = route.coverage_by_kind
+        apprentices = by_kind.get("apprenticeship", {})
+        if not apprentices or not route.task_maxsim:
+            return cls.from_route(route, strategy, frozenset({"certification"}))
+
+        gap_set     = frozenset(route.gap_indices)
+        anchor      = max(apprentices, key=lambda l: route.task_maxsim.get(l, 0.0))
+        anchor_gaps = frozenset(apprentices[anchor]) & gap_set
+        picks       = (
+            [SelectedCredential(label=anchor, positions=anchor_gaps)]
+            if anchor_gaps else []
+        ) + CredentialSelector(coverage_floor=route.coverage_floor).select_stack(
+            coverage  = by_kind.get("certification", {}),
+            gap_set   = gap_set - anchor_gaps,
+            max_picks = 4
+        )
+        return cls._from_picks(route.credential_map, picks, strategy) if picks else None
 
     @classmethod
     def from_route(
@@ -61,12 +123,11 @@ class CredentialPath(NamedTuple):
         max_picks : int = 5
     ) -> Self | None:
         """
-        Waste-aware credential stack via Pareto-knee selection.
+        Pareto-knee credential stack via `CredentialSelector.select_stack`.
 
-        Filters the route's full coverage to credentials of the requested
-        kinds, delegates to `CredentialSelector.select_stack` for the
-        frontier sweep and knee detection, then wraps the returned picks
-        into `PathItem` instances for shelf rendering.
+        Filters the route's coverage to credentials of the requested kinds
+        and runs the picker, wrapping the returned picks into `PathItem`
+        instances for shelf rendering.
 
         Args:
             route     : Route carrying per-task credential affinities.
@@ -75,30 +136,19 @@ class CredentialPath(NamedTuple):
                         accepts every kind.
             max_picks : Hard cap on stack size.
         """
-        from chalkline.pathways.selection import CredentialSelector
-
-        credentials = route.credential_map
-        coverage    = {
-            label: scored for label, scored in route.coverage.items()
-            if scored and (kinds is None or credentials[label].kind in kinds)
+        by_kind  = route.coverage_by_kind
+        coverage = {
+            label: scored
+            for kind, kind_map in by_kind.items()
+            if kinds is None or kind in kinds
+            for label, scored in kind_map.items()
         }
-        picks, floor_met = CredentialSelector().select_stack(
+        picks = CredentialSelector(coverage_floor=route.coverage_floor).select_stack(
             coverage  = coverage,
             gap_set   = frozenset(route.gap_indices),
             max_picks = max_picks
         )
-        if not picks:
-            return None
-
-        return cls(
-            coverage_floor_met = floor_met,
-            items              = [
-                PathItem.from_credential(credentials[p.label], p.label, p.positions)
-                for p in picks
-            ],
-            strategy        = strategy,
-            unique_coverage = sum(len(p.positions) for p in picks)
-        )
+        return cls._from_picks(route.credential_map, picks, strategy) if picks else None
 
 
 class DatedPoint(NamedTuple):
@@ -214,11 +264,19 @@ class GapCoverage(NamedTuple):
     """
     Gap-closure strategies for a career transition.
 
-    Assembles three candidate paths via the waste-aware Pareto-knee picker,
-    including a work-based stack (apprenticeship + certification), a single
-    bang-for-buck credential (any kind), and a certification-only stack. All
-    three route through the same picker with different kind filters and
-    max_picks caps.
+    Assembles three candidate paths surfaced in the order users encounter
+    them:
+
+    - A single bang-for-buck credential of any kind, picked by Pareto-knee
+    - A certifications-only stack, also picked by Pareto-knee
+    - A work-based stack anchored on the apprenticeship most aligned with
+      the destination by `anchored_from_route`, complemented by
+      certifications
+
+    Apprenticeships are treated as career anchors rather than stackable
+    items, so the user sees one apprenticeship plus supporting
+    certifications instead of multiple full apprenticeships layered
+    together.
     """
 
     paths: list[CredentialPath]
@@ -230,13 +288,11 @@ class GapCoverage(NamedTuple):
         coverage mapping.
         """
         return cls(paths=[path for path in (
-            CredentialPath.from_route(
-                route, "work_based", kinds=frozenset({"apprenticeship", "certification"})
-            ),
             CredentialPath.from_route(route, "biggest", max_picks=1),
             CredentialPath.from_route(
                 route, "certs", kinds=frozenset({"certification"})
-            )
+            ),
+            CredentialPath.anchored_from_route(route, "work_based")
         ) if path])
 
 
@@ -450,12 +506,11 @@ class MlMetrics(BaseModel, extra="forbid"):
         ratio     = pipeline.matcher.svd.explained_variance_ratio_
         brokerage = SectorRanking.from_ranking(clusters, pipeline.graph.brokerage)
 
-        tier_label   = lambda t: f"Tier {t + 1}"
         tier_counts  = Counter(c.wage_tier for c in clusters.values())
         sector_pairs = Counter((c.sector, c.wage_tier) for c in clusters.values())
         ordered      = sorted(tier_counts)
         wage_tier    = WageTierBreakdown(
-            counts = {tier_label(t): tier_counts[t] for t in ordered},
+            counts = {f"Tier {t + 1}": tier_counts[t] for t in ordered},
             matrix = {
                 sector: [sector_pairs[sector, t] for t in ordered]
                 for sector in clusters.sectors
@@ -611,15 +666,11 @@ class PostingProjection(BaseModel, extra="forbid"):
                 float(xy[1])
             ))
 
-        hover, x, y = range(3)
-        cls.series_cache[key] = (result := {
-            label: ScatterSeries(
-                hover = [p[hover] for p in pts],
-                x     = [p[x]     for p in pts],
-                y     = [p[y]     for p in pts]
-            )
-            for label, pts in grouped.items()
-        })
+        result: dict[str, ScatterSeries] = {}
+        for label, pts in grouped.items():
+            hover, x, y = zip(*pts)
+            result[label] = ScatterSeries(hover=list(hover), x=list(x), y=list(y))
+        cls.series_cache[key] = result
         return cls(series=result)
 
 
@@ -795,7 +846,24 @@ class RouteDetail(NamedTuple):
     source           : Cluster
     source_wage      : float | None
 
-    bright_outlook   : bool = False
+    bright_outlook   : bool             = False
+    coverage_floor   : float            = 0.80
+    task_maxsim      : dict[str, float] = {}
+
+    @property
+    def coverage_by_kind(self) -> dict[str, dict[str, dict[int, float]]]:
+        """
+        Coverage map grouped by credential kind, dropping credentials with
+        empty score dicts. Mirrors `credentials_by_kind` for the per-task
+        affinity view so both factory paths in `CredentialPath` share one
+        per-kind split.
+        """
+        credentials = self.credential_map
+        by_kind: dict[str, dict[str, dict[int, float]]] = {}
+        for label, scored in self.coverage.items():
+            if scored:
+                by_kind.setdefault(credentials[label].kind, {})[label] = scored
+        return by_kind
 
     @property
     def credential_map(self) -> dict[str, Credential]:
@@ -842,8 +910,6 @@ class RouteDetail(NamedTuple):
         """
         return len(self.gap_tasks)
 
-
-
     @property
     def gap_indices(self) -> list[int]:
         """
@@ -877,7 +943,6 @@ class RouteDetail(NamedTuple):
         """
         index = {t.name: i for i, t in enumerate(self.destination.tasks)}
         return {index[t.name]: t for t in self.scored_tasks}
-
 
     @property
     def top_gaps(self) -> list[ScoredTask]:
@@ -962,9 +1027,23 @@ class RouteDetail(NamedTuple):
             gap_vectors = np.empty((0, 0))
             coverage    = {}
 
+        cluster_maxsim = pipeline.graph.credential_task_maxsim.get(destination.cluster_id)
+        if cluster_maxsim is None:
+            task_maxsim = {}
+        else:
+            pool_index = {
+                c.label: i for i, c in enumerate(pipeline.graph.credential_pool)
+            }
+            task_maxsim = {
+                c.label: float(cluster_maxsim[pool_index[c.label]])
+                for c in credentials
+                if c.label in pool_index
+            }
+
         return cls(
             bright_outlook   = labor[destination.soc_title].bright_outlook,
             coverage         = coverage,
+            coverage_floor   = pipeline.config.coverage_floor,
             credentials      = credentials,
             destination      = destination,
             destination_wage = destination.wage,
@@ -973,7 +1052,8 @@ class RouteDetail(NamedTuple):
             match_score      = pipeline.matcher.cluster_score(destination.cluster_id),
             scored_tasks     = scored,
             source           = profile,
-            source_wage      = profile.wage
+            source_wage      = profile.wage,
+            task_maxsim      = task_maxsim
         )
 
 

--- a/src/chalkline/display/tabs/map/widget.js
+++ b/src/chalkline/display/tabs/map/widget.js
@@ -193,7 +193,7 @@ export default {
                 pad
             } = dims;
             const W      = el.clientWidth || dims.width;
-            const donutR = 17;
+            const donutR = 20;
 
             /* ── Scales ─────────────────────────────────────────── */
 
@@ -336,7 +336,7 @@ export default {
 
             const dnX = donutR + 10;
             const dnY = cH / 2;
-            addDonut(t1G, dnX, dnY, "donut-label", donutR, 3, 4);
+            addDonut(t1G, dnX, dnY, "donut-label", donutR, 3, 5);
 
             /* Title + italic suffix + stats subtitle (vertically centered) */
             const ttX = dnX + donutR + 8;

--- a/src/chalkline/display/tabs/map/widget.js
+++ b/src/chalkline/display/tabs/map/widget.js
@@ -352,18 +352,23 @@ export default {
                 .text((d) => d.subtitle);
 
             t1G.each(function (d) {
-                const g       = d3.select(this);
-                const lines   = tspanCount(g.select(".node-title"));
-                const blockH  = lines * 13 + (d.suffix ? 13 : 0) + 13;
-                const y0      = (cH - blockH) / 2 + 11;
-                let cursor    = y0;
-                g.select(".node-title").attr("y", cursor);
-                cursor += lines * 13;
+                const g           = d3.select(this);
+                const titleLines  = tspanCount(g.select(".node-title"));
+                const lineH       = 13;
+                const groupGap    = 5;
+                const ascent      = 9;
+                const titleGroupH = (titleLines + (d.suffix ? 1 : 0)) * lineH;
+                const blockH      = titleGroupH + groupGap + lineH;
+                const blockTop    = (cH - blockH) / 2;
+
+                let baseline = blockTop + ascent;
+                g.select(".node-title").attr("y", baseline);
+                baseline += titleLines * lineH;
                 if (d.suffix) {
-                    g.select(".node-suffix").attr("y", cursor + 2);
-                    cursor += 13;
+                    g.select(".node-suffix").attr("y", baseline);
+                    baseline += lineH;
                 }
-                g.select(".node-subtitle").attr("y", cursor + 2);
+                g.select(".node-subtitle").attr("y", baseline + groupGap);
             });
 
             /* ── Hero card ──────────────────────────────────────── */

--- a/src/chalkline/display/tabs/map/widget.js
+++ b/src/chalkline/display/tabs/map/widget.js
@@ -338,21 +338,32 @@ export default {
             const dnY = cH / 2;
             addDonut(t1G, dnX, dnY, "donut-label", donutR, 3, 4);
 
-            /* Title + subtitle (vertically centered as a block) */
+            /* Title + italic suffix + stats subtitle (vertically centered) */
             const ttX = dnX + donutR + 8;
             t1G.append("text").attr("class", "node-title")
                 .attr("x", ttX).attr("y", 0)
                 .text((d) => d.title).call(wrapText, cW - ttX - 6);
+            t1G.filter((d) => d.suffix)
+                .append("text").attr("class", "node-suffix")
+                .attr("x", ttX).attr("y", 0)
+                .text((d) => d.suffix);
             t1G.append("text").attr("class", "node-subtitle")
                 .attr("x", ttX).attr("y", 0)
                 .text((d) => d.subtitle);
 
-            t1G.each(function () {
-                const g     = d3.select(this);
-                const lines = tspanCount(g.select(".node-title"));
-                const y0    = (cH - (lines * 13 + 14)) / 2 + 11;
-                g.select(".node-title").attr("y", y0);
-                g.select(".node-subtitle").attr("y", y0 + lines * 13 + 2);
+            t1G.each(function (d) {
+                const g       = d3.select(this);
+                const lines   = tspanCount(g.select(".node-title"));
+                const blockH  = lines * 13 + (d.suffix ? 13 : 0) + 13;
+                const y0      = (cH - blockH) / 2 + 11;
+                let cursor    = y0;
+                g.select(".node-title").attr("y", cursor);
+                cursor += lines * 13;
+                if (d.suffix) {
+                    g.select(".node-suffix").attr("y", cursor + 2);
+                    cursor += 13;
+                }
+                g.select(".node-subtitle").attr("y", cursor + 2);
             });
 
             /* ── Hero card ──────────────────────────────────────── */

--- a/src/chalkline/display/tabs/map/widget.js
+++ b/src/chalkline/display/tabs/map/widget.js
@@ -1,10 +1,13 @@
 /**
  * Force-directed career pathway map rendered with D3.
  *
- * Nodes positioned by salary-driven force simulation. Tier-1 cards
- * (hop 0-1) show a match donut + title + subtitle. Tier-2 circles
- * (hop 2+) use a progress-ring border. The matched node renders as
- * an enriched hero card within the SVG.
+ * Nodes positioned by salary-driven force simulation, sector y-bands,
+ * and bbox collision. Tier-1 cards show a match donut + title +
+ * subtitle for the strongest matches. Tier-2 circles use a
+ * progress-ring border for the rest of the corpus. Edges fan from
+ * the matched cluster to its tier-1 cards with stroke weight scaled
+ * by match score. The matched node renders as an enriched hero card.
+ * A sector legend pins to the top-right corner.
  *
  * Static styling lives in `app/chalkline.css` under `.cl-pathway-map`.
  */
@@ -169,6 +172,7 @@ export default {
                 dimensions: dims,
                 edges,
                 hero,
+                legend,
                 nodes,
                 wage_range
             } = raw;
@@ -197,12 +201,9 @@ export default {
 
             /* ── Scales ─────────────────────────────────────────── */
 
-            const we = [
-                Math.floor(wage_range[0] / 5000) * 5000,
-                Math.ceil(wage_range[1] / 5000) * 5000
-            ];
-            const xScale = d3.scaleLinear().domain(we)
-                .range([pad + hW / 2 + 20, W - pad - cW / 2 - 10]);
+            const xScale = d3.scaleLinear().domain(wage_range)
+                .range([pad + hW / 2 + 20, W - pad - cW / 2 - 10])
+                .nice();
 
             const sectors = [...new Set(nodes.map((n) => n.sector))].sort();
             const bandH   = (H - 2 * pad - 40) / Math.max(sectors.length, 1);
@@ -262,10 +263,10 @@ export default {
                 .attr("width", "100%")
                 .style("max-height", `${H}px`);
 
-            /* ── Edges (1-hop matched only, uniform style) ──────── */
+            /* ── Edges (matched → tier-1, weighted by match score) ─ */
 
             const edgeSel = svg.selectAll(".edge")
-                .data(sl.filter((e) => eid(e.source) === mid || eid(e.target) === mid))
+                .data(sl)
                 .join("path")
                 .attr("class", "edge")
                 .attr("d", (d) => {
@@ -276,7 +277,7 @@ export default {
                     return `M${s.x},${s.y} Q${mx},${my} ${t.x},${t.y}`;
                 })
                 .attr("stroke", (d) => d.color)
-                .attr("stroke-width", (d) => Math.max(1.5, d.weight * 3))
+                .attr("stroke-width", (d) => Math.max(1.5, d.weight * 6))
                 .attr("opacity", 0.5);
 
             /* ── Tier 2 circles ─────────────────────────────────── */
@@ -418,6 +419,35 @@ export default {
                     .text(heroSub);
             }
 
+            /* ── Legend (top-right corner) ──────────────────────── */
+
+            const lgPad = 12;
+            const lgSw  = 12;
+            const lgRow = 18;
+            const lgW   = 210;
+            const lgH   = lgPad * 2 + legend.length * lgRow;
+            const lgX   = W - pad - lgW;
+            const lgY   = 10;
+
+            const lg = svg.append("g").attr("class", "cl-legend")
+                .attr("transform", `translate(${lgX}, ${lgY})`);
+
+            lg.append("rect").attr("class", "cl-legend-bg")
+                .attr("width", lgW).attr("height", lgH).attr("rx", 6);
+
+            const rows = lg.selectAll(".cl-legend-row")
+                .data(legend).join("g")
+                .attr("class", "cl-legend-row")
+                .attr("transform", (_, i) =>
+                    `translate(0, ${lgPad + i * lgRow + lgRow / 2})`);
+            rows.append("rect").attr("class", "cl-legend-swatch")
+                .attr("x", lgPad).attr("y", -lgSw / 2)
+                .attr("width", lgSw).attr("height", lgSw).attr("rx", 2)
+                .attr("fill", (d) => d.color);
+            rows.append("text").attr("class", "cl-legend-label")
+                .attr("x", lgPad + lgSw + 8).attr("y", 4)
+                .text((d) => d.label);
+
             /* ── Tooltip ────────────────────────────────────────── */
 
             const tip = svg.append("g").attr("class", "cl-tooltip")
@@ -439,12 +469,6 @@ export default {
 
                 const titleLines = tspanCount(tip.select(".tooltip-title"));
                 if (titleLines > 1) y += (titleLines - 1) * lh;
-
-                tip.append("text").attr("class", "tooltip-dim")
-                    .attr("x", p).attr("y", y += lh)
-                    .text(d.hop != null
-                        ? `${d.hop} step${d.hop !== 1 ? "s" : ""} away`
-                        : "Not connected");
 
                 /* Wage bars */
                 const hw = hero.wage;
@@ -507,6 +531,11 @@ export default {
 
         const ro = new ResizeObserver(draw);
         ro.observe(el);
-        for (const t of ["graph_data", "selected_id"]) model.on(`change:${t}`, draw);
+        model.on("change:graph_data", draw);
+        model.on("change:selected_id", () => {
+            const sid = model.get("selected_id");
+            d3.select(el).selectAll(".node, .node-circle")
+                .classed("selected", (d) => d.id === sid);
+        });
     },
 };

--- a/src/chalkline/display/tabs/map/widget.py
+++ b/src/chalkline/display/tabs/map/widget.py
@@ -1,16 +1,17 @@
 """
 Interactive career pathway map rendered with D3 via AnyWidget.
 
-Produces a force-directed node-link diagram where horizontal position
-encodes salary (higher wages drift right), node rendering tiers distinguish
-immediate career paths from distant options, and the matched career renders
-as an enriched hero card integrated into the SVG. Click and hover events
-sync back to Python through traitlets for reactive panel updates in the
-Marimo notebook.
+Produces a force-directed node layout where horizontal position encodes
+salary (higher wages drift right), vertical bands group clusters by
+sector, render tiers separate strong-match suggestions from the rest of
+the corpus, and the matched career anchors the canvas as an enriched
+hero card. Click and hover events sync back to Python through traitlets
+for reactive panel updates in the Marimo notebook.
 """
 
 from anywidget           import AnyWidget
 from json                import dumps
+from kneed               import KneeLocator
 from pathlib             import Path
 from traitlets.traitlets import Int, Unicode
 from typing              import Self
@@ -21,7 +22,51 @@ from chalkline.matching.matcher  import ResumeMatcher
 from chalkline.matching.schemas  import MatchResult
 from chalkline.pathways.clusters import Clusters
 from chalkline.pathways.graph    import CareerPathwayGraph
-from chalkline.pathways.loaders  import LaborLoader
+
+
+def _tier_assignments(
+    cluster_mean : dict[int, float],
+    matched_id   : int
+) -> dict[int, int]:
+    """
+    Render-tier per cluster id for the map widget.
+
+    Tier 1 covers the matched cluster and a stable handful of
+    strong-match neighbors. With more than 10 non-matched candidates,
+    the elbow is clamped to `[10, 15]` so the canvas surfaces a
+    meaningful set of next-step options without flooding. Smaller
+    corpora promote every non-matched cluster, and flat curves fall
+    back to the upper bound.
+
+    Args:
+        cluster_mean : Per-cluster match score in `[0, 1]`, keyed by id.
+        matched_id   : Cluster id rendered as the hero card.
+
+    Returns:
+        Cluster id to tier (1 or 2). Tier 1 includes `matched_id`.
+    """
+    ranked_ids = sorted(
+        cluster_mean.keys() - {matched_id},
+        key     = cluster_mean.__getitem__,
+        reverse = True
+    )
+    scores = list(map(cluster_mean.__getitem__, ranked_ids))
+
+    if len(scores) <= 10:
+        cut = len(scores)
+    elif max(scores) == min(scores):
+        cut = 15
+    else:
+        elbow = KneeLocator(
+            range(len(scores)),
+            scores,
+            curve     = "convex",
+            direction = "decreasing"
+        ).knee
+        cut = max(10, min(15, elbow if elbow is not None else 15))
+
+    tier1 = {matched_id, *ranked_ids[:cut]}
+    return {cid: 1 if cid in tier1 else 2 for cid in cluster_mean}
 
 
 class PathwayMap(AnyWidget):
@@ -45,7 +90,6 @@ class PathwayMap(AnyWidget):
         cls,
         clusters    : Clusters,
         graph       : CareerPathwayGraph,
-        labor       : LaborLoader,
         matched_id  : int,
         matcher     : ResumeMatcher,
         result      : MatchResult,
@@ -56,9 +100,10 @@ class PathwayMap(AnyWidget):
         Serialize the force-directed graph payload as JSON.
 
         Calls the matcher's calibration to obtain per-cluster match
-        percentages, then assembles per-node metadata (wage, sector, tier,
-        display title with collision handling), per-edge metadata, and
-        enriched hero card data for the matched node.
+        percentages, ranks remaining clusters against the matched one to
+        derive tier assignments via `_tier_assignments`, and assembles
+        per-node metadata, hero card data, and a sector legend keyed to
+        the colors actually present on the canvas.
 
         Tier-2 clusters whose median wage falls outside `wage_filter` are
         dropped before rendering. The matched cluster always renders so the
@@ -73,7 +118,6 @@ class PathwayMap(AnyWidget):
         Args:
             clusters    : Fitted cluster container with metadata.
             graph       : Career pathway graph with edges and credentials.
-            labor       : Wage data lookup per SOC title.
             matched_id  : Cluster ID of the user's matched career.
             matcher     : Fitted matcher for per-cluster similarity calibration.
             result      : Resume match result with confidence and reach.
@@ -87,73 +131,73 @@ class PathwayMap(AnyWidget):
         matcher.calibrate_coverage(graph.credential_pool, graph.credential_vectors)
 
         geometry = MapGeometry()
-        hops     = graph.hops_from(matched_id)
 
-        def in_range(wage: float | None, cid: int) -> bool:
-            if cid == matched_id or wage_filter is None:
-                return True
-            if wage is None:
-                return False
-            return wage_filter[0] <= wage <= wage_filter[1]
-
-        nodes = []
-        for cluster in clusters.values():
-            cid  = cluster.cluster_id
-            wage = cluster.wage
-            if not in_range(wage, cid):
-                continue
-
-            hop = hops.get(cid)
-
-            nodes.append({
+        visible = [
+            c for c in clusters.values()
+            if c.cluster_id == matched_id
+            or wage_filter is None
+            or (c.wage is not None and wage_filter[0] <= c.wage <= wage_filter[1])
+        ]
+        tiers = _tier_assignments(
+            {c.cluster_id: cluster_mean[c.cluster_id] for c in visible},
+            matched_id
+        )
+        nodes = [
+            {
                 "color"      : theme.sector_background(cluster.sector),
                 "full_title" : cluster.display_title,
-                "hop"        : hop,
-                "id"         : cid,
-                "match_pct"  : round(100 * cluster_mean.get(cid, 0.0)),
+                "id"         : cluster.cluster_id,
+                "match_pct"  : round(100 * cluster_mean[cluster.cluster_id]),
                 "sector"     : cluster.sector,
                 "subtitle"   : (
-                    f"{cluster.size} postings \u00b7 ${round(wage / 1000)}k"
-                    if wage else f"{cluster.size} postings"
+                    f"{cluster.size} postings \u00b7 ${round(cluster.wage / 1000)}k"
+                    if cluster.wage else f"{cluster.size} postings"
                 ),
                 "suffix"     : (
                     cluster.display_title[len(cluster.soc_title) + 2:-1]
                     if cluster.display_title != cluster.soc_title else ""
                 ),
-                "tier"       : 1 if hop is not None and hop <= 1 else 2,
+                "tier"       : tiers[cluster.cluster_id],
                 "title"      : cluster.soc_title,
-                "wage"       : wage
-            })
-
-        wages    = [n["wage"] for n in nodes if n["wage"]]
-        node_ids = {n["id"] for n in nodes}
+                "wage"       : cluster.wage
+            }
+            for cluster in visible
+        ]
 
         edges = [
             {
-                "color"  : theme.sector_background(clusters[source_id].sector),
-                "source" : source_id,
-                "target" : target_id,
-                "weight" : round(float(data["weight"]), 3)
+                "color"  : n["color"],
+                "source" : matched_id,
+                "target" : n["id"],
+                "weight" : round(cluster_mean[n["id"]], 3)
             }
-            for source_id, target_id, data in graph.graph.edges(data=True)
-            if source_id in node_ids and target_id in node_ids
+            for n in nodes
+            if n["tier"] == 1 and n["id"] != matched_id
         ]
 
-        profile = clusters[matched_id]
+        wages = [n["wage"] for n in nodes if n["wage"]]
 
         hero = {
             "match_color"  : theme.colors["lavender"],
             "n_matches"    : len(result.reach.edges),
-            "sector_color" : theme.sector_background(profile.sector),
-            "size"         : profile.size,
-            "title"        : profile.display_title,
-            "wage"         : profile.wage
+            "sector_color" : theme.sector_background(clusters[matched_id].sector),
+            "size"         : clusters[matched_id].size,
+            "title"        : clusters[matched_id].display_title,
+            "wage"         : clusters[matched_id].wage
         }
+
+        present_sectors = sorted(
+            {n["sector"] for n in nodes} & theme.sectors.keys()
+        )
+        legend = [{"label": "Your Match", "color": theme.colors["lavender"]}] + [
+            {"label": s, "color": theme.sectors[s]} for s in present_sectors
+        ]
 
         return dumps({
             "dimensions" : geometry.dimensions,
             "edges"      : edges,
             "hero"       : hero,
+            "legend"     : legend,
             "nodes"      : nodes,
             "wage_range" : (
                 [min(wages), max(wages)]
@@ -166,7 +210,6 @@ class PathwayMap(AnyWidget):
         cls,
         clusters    : Clusters,
         graph       : CareerPathwayGraph,
-        labor       : LaborLoader,
         matched_id  : int,
         matcher     : ResumeMatcher,
         result      : MatchResult,
@@ -185,7 +228,6 @@ class PathwayMap(AnyWidget):
         Args:
             clusters    : Fitted cluster container with metadata.
             graph       : Career pathway graph with edges and credentials.
-            labor       : Wage data lookup per SOC title.
             matched_id  : Cluster ID of the user's matched career.
             matcher     : Fitted matcher for per-cluster similarity calibration.
             result      : Resume match result with confidence and reach.
@@ -199,7 +241,6 @@ class PathwayMap(AnyWidget):
             graph_data = cls.build_graph_data(
                 clusters    = clusters,
                 graph       = graph,
-                labor       = labor,
                 matched_id  = matched_id,
                 matcher     = matcher,
                 result      = result,

--- a/src/chalkline/display/tabs/map/widget.py
+++ b/src/chalkline/display/tabs/map/widget.py
@@ -116,8 +116,12 @@ class PathwayMap(AnyWidget):
                     f"{cluster.size} postings \u00b7 ${round(wage / 1000)}k"
                     if wage else f"{cluster.size} postings"
                 ),
+                "suffix"     : (
+                    cluster.display_title[len(cluster.soc_title) + 2:-1]
+                    if cluster.display_title != cluster.soc_title else ""
+                ),
                 "tier"       : 1 if hop is not None and hop <= 1 else 2,
-                "title"      : cluster.display_title,
+                "title"      : cluster.soc_title,
                 "wage"       : wage
             })
 

--- a/src/chalkline/display/tabs/methods/content.toml
+++ b/src/chalkline/display/tabs/methods/content.toml
@@ -84,13 +84,13 @@ description = 'Pairwise distances between cluster centroids, grouped by sector. 
 title       = 'Gateway Careers'
 description = 'Career families that bridge the most pathways, sorted by brokerage score. High brokerage means the role is a common stepping stone.'
 
-[sections.job_zone_distribution]
-title       = 'Career Families by Experience Level'
-description = 'How the {n_clusters} career families distribute across O*NET Job Zones, showing whether the corpus is balanced across entry-level, mid-career, and advanced roles.'
+[sections.wage_tier_distribution]
+title       = 'Career Families by Wage Tier'
+description = 'How the {n_clusters} career families distribute across the wage-banded ladder, showing whether the corpus is balanced across entry-level, mid-tier, and senior pay bands.'
 
-[sections.sector_job_zone]
-title       = 'Sector by Experience Level'
-description = 'Joint distribution of career families across sectors and Job Zones. Bright cells indicate concentrations, empty cells reveal gaps in the corpus.'
+[sections.sector_wage_tier]
+title       = 'Sector by Wage Tier'
+description = 'Joint distribution of career families across sectors and wage tiers. Bright cells indicate concentrations, empty cells reveal gaps in the corpus.'
 
 [sections.landscape]
 title       = 'Career Landscape'

--- a/src/chalkline/display/tabs/methods/render.py
+++ b/src/chalkline/display/tabs/methods/render.py
@@ -20,7 +20,7 @@ def methods_tab(ctx: TabContext) -> Html:
     tab         = ctx.content.tab("methods")
     ml          = MlMetrics.from_pipeline(ctx.pipeline)
     template_kw = ml.template_kwargs
-    zone_counts = ml.job_zone.labeled_counts(ctx.content.labels.job_zones)
+    tier_counts = ml.wage_tier.counts
 
     return ctx.layout.stack(
         ctx.layout.overview("overview", tab),
@@ -62,16 +62,16 @@ def methods_tab(ctx: TabContext) -> Html:
         ctx.layout.two_col(
             ctx.layout.panel(ctx.charts.bar(
                 color      = "primary",
-                data       = zone_counts,
+                data       = tier_counts,
                 height     = 320,
                 horizontal = True,
                 title      = tab.chart_labels["clusters_title"]
-            ), "job_zone_distribution", tab),
+            ), "wage_tier_distribution", tab),
             ctx.layout.panel(ctx.charts.heatmap(
-                ml.job_zone.matrix,
-                columns = list(zone_counts),
+                ml.wage_tier.matrix,
+                columns = list(tier_counts),
                 height  = 320
-            ), "sector_job_zone", tab)
+            ), "sector_wage_tier", tab)
         ),
 
         ctx.layout.two_col(

--- a/src/chalkline/display/tabs/shared/content.toml
+++ b/src/chalkline/display/tabs/shared/content.toml
@@ -2,13 +2,6 @@ fallback_location = 'Maine'
 spinner_text      = 'Analyzing your resume...'
 upload_label      = 'Drop a resume PDF here'
 
-[job_zones]
-1 = 'Entry Level'
-2 = 'Some Preparation'
-3 = 'Mid-Career'
-4 = 'Experienced'
-5 = 'Advanced'
-
 [tab_names]
 data    = 'Data'
 map     = 'Map'

--- a/src/chalkline/display/tabs/shared/glossary.toml
+++ b/src/chalkline/display/tabs/shared/glossary.toml
@@ -69,7 +69,7 @@ Identified by clustering sentence embeddings of all {n_postings} postings in the
 term       = 'career pathway'
 definition = '''A possible transition between two career families.
 
-Determined by how similar their job postings are in language and what credentials bridge the gap. Pathways can be *advancement* (*higher Job Zone*) or *lateral* (*same level*).'''
+Determined by how similar their job postings are in language and what credentials bridge the gap. Pathways can be *advancement* (*higher wage tier*) or *lateral* (*same wage tier*).'''
 
 [[terms]]
 term       = 'centroid'
@@ -186,18 +186,6 @@ url        = 'https://en.wikipedia.org/wiki/Hierarchical_clustering'
 url_label  = 'Hierarchical clustering on Wikipedia'
 
 [[terms]]
-term       = 'job zone'
-definition = '''An O*NET **experience level** ranging from 1 to 5.
-
-→ 1: Entry level, little preparation
-→ 2: Some preparation needed
-→ 3: Mid-career, training required
-→ 4: Experienced, specialized training
-→ 5: Advanced, graduate-level'''
-url        = 'https://www.onetonline.org/help/online/zones'
-url_label  = 'Job Zone definitions on O*NET'
-
-[[terms]]
 term       = 'k-means'
 aliases    = ['k-means clustering', 'kmeans', 'K-means']
 definition = '''A **partitioning clustering** algorithm that groups vectors into `k` clusters by iteratively assigning each point to its nearest centroid and recomputing centroids as the mean of their assigned points.
@@ -208,7 +196,7 @@ url_label  = 'k-means clustering on Wikipedia'
 
 [[terms]]
 term       = 'lateral move'
-definition = '''A career transition between two families at the **same Job Zone** (*experience level*).
+definition = '''A career transition between two families at the **same wage tier**.
 
 Lateral moves let you shift specialization without changing seniority, and appear as *horizontal connections* in the career ladder.'''
 
@@ -240,7 +228,7 @@ term       = 'O*NET'
 aliases    = ['Occupational Information Network']
 definition = '''The **Occupational Information Network**, a federal database of standardized occupation data.
 
-Maintained by the U.S. Department of Labor. Provides skills, tasks, wages, outlook, and Job Zone levels for every occupation. Chalkline uses {n_occupations} O*NET occupations spanning Maine construction.'''
+Maintained by the U.S. Department of Labor. Provides skills, tasks, wages, and outlook for every occupation. Chalkline uses {n_occupations} O*NET occupations spanning Maine construction.'''
 url        = 'https://www.onetonline.org/'
 url_label  = 'Browse O*NET OnLine'
 
@@ -366,9 +354,9 @@ url_label  = 'SOC system at BLS'
 
 [[terms]]
 term       = 'stepwise k-NN'
-definition = '''The graph construction method where each career family connects to its **k nearest neighbors** at its own Job Zone (*lateral moves*) and at one level up (*advancement paths*).
+definition = '''The graph construction method where each career family connects to its **k nearest neighbors** at its own wage tier (*lateral moves*) and at the next tier up (*advancement paths*).
 
-The "stepwise" part bounds connections by Job Zone step rather than raw distance, ensuring pathways respect realistic experience progression.'''
+The "stepwise" part bounds connections by wage-tier step rather than raw distance, ensuring pathways respect realistic wage progression.'''
 
 [[terms]]
 term       = 'strength'

--- a/src/chalkline/matching/matcher.py
+++ b/src/chalkline/matching/matcher.py
@@ -11,8 +11,8 @@ Task scoring uses sentence-level chunking with max-pooling so that a
 specific resume line can drive high similarity for a matching task even when
 the document-level mean is diluted by unrelated content. Credential coverage
 uses the same BM25 weighting with per-credential row normalization so the
-downstream waste-aware picker can distinguish narrow certifications from
-broad apprenticeships.
+downstream DPP picker can distinguish narrow certifications from broad
+apprenticeships when computing per-credential gap-coverage strength.
 """
 
 import numpy as np
@@ -242,10 +242,11 @@ class ResumeMatcher:
         mapped to the BM25-weighted cosine affinity on that task.
 
         BM25 weighting produces sharper per-task discrimination than the
-        binary stem gate, so the downstream waste-aware picker can
-        distinguish narrow credentials from broad ones. Per-credential row
-        normalization follows the same pattern as `_task_similarities` to
-        prevent `embedding_text` length bias.
+        binary stem gate, so the downstream DPP picker can distinguish
+        narrow credentials from broad ones when computing each credential's
+        gap-coverage quality. Per-credential row normalization follows the
+        same pattern as `_task_similarities` to prevent `embedding_text`
+        length bias.
 
         Args:
             credentials : Must carry `.stems` and `.vector`, typically from

--- a/src/chalkline/matching/matcher.py
+++ b/src/chalkline/matching/matcher.py
@@ -206,7 +206,7 @@ class ResumeMatcher:
             for c in tasked
         ], axis=None)
         positive = scores[scores > 0]
-        self.credential_threshold = float(np.median(positive)) if positive.size else 0.0
+        self.credential_threshold = float(np.percentile(positive, 75)) if positive.size else 0.0
 
     def cluster_score(self, cluster_id: int) -> float:
         """

--- a/src/chalkline/pathways/clusters.py
+++ b/src/chalkline/pathways/clusters.py
@@ -12,6 +12,10 @@ from collections     import Counter, defaultdict
 from collections.abc import Iterator
 from dataclasses     import dataclass, field
 from functools       import cached_property
+from heapq           import nlargest
+from itertools       import chain
+from math            import log
+from operator        import itemgetter
 from typing          import NamedTuple
 
 from chalkline.collection.schemas import Posting
@@ -62,9 +66,15 @@ class Cluster:
     @cached_property
     def distinctive_tokens(self) -> list[list[str]]:
         """
-        Per-posting bags of lowercased tokens longer than three characters
-        whose Zipf frequency falls below the common-word floor, lazily
-        computed once per session and cached on the instance.
+        Per-posting bags of lowercased alphabetic tokens longer than three
+        characters whose Zipf frequency falls below the common-word floor,
+        lazily computed once per session and cached on the instance.
+
+        Tokenization uses an alphabetic regex rather than whitespace
+        splitting so internal punctuation (curly apostrophes in
+        possessives like `Maine's`, hyphens in compounds, trademark
+        marks) cleanly separates words instead of leaking into token
+        strings.
 
         Display-layer factories that build TF-IDF rankings over postings
         iterate this list to assemble word counters without re-running the
@@ -72,12 +82,12 @@ class Cluster:
         tokenization shared between cross-corpus distinctiveness ranking and
         intra-cluster sub-role labeling.
         """
+        from re       import findall
         from wordfreq import zipf_frequency
         return [
             [
-                w for word in f"{p.title} {p.description}".split()
-                if  len(w := word.strip(".,;:!?()[]\"'").lower()) > 3
-                and zipf_frequency(w, "en") < 5.0
+                w for w in findall(r"[a-zA-Z]{4,}", f"{p.title} {p.description}".lower())
+                if zipf_frequency(w, "en") < 5.0
             ]
             for p in self.postings
         ]
@@ -129,10 +139,6 @@ class Cluster:
             assignments : Per-posting k-means cluster assignment array.
             k           : Number of sub-clusters.
         """
-        from collections import Counter
-        from heapq       import nlargest
-        from math        import log
-
         counts: list[Counter] = [Counter() for _ in range(k)]
         for label, bag in zip(assignments, self.distinctive_tokens):
             counts[label].update(bag)
@@ -203,8 +209,7 @@ class Clusters:
         per-cluster attributes without round-tripping through the parent.
         """
         self.cluster_ids = sorted(self.items)
-        for cid in self.cluster_ids:
-            cluster               = self.items[cid]
+        for cid, cluster in self.items.items():
             cluster.soc_weights   = self.soc_weights[cid]
             cluster.wage          = float(self.cluster_wages[cid])
             cluster.display_title = self.display_titles[cid]
@@ -215,10 +220,9 @@ class Clusters:
         Mean stem count across all task descriptions in the corpus, used as
         the average document length for BM25 length normalization.
         """
-        all_stems = [
-            ts for c in self.values() for ts in c.task_stems
-        ]
-        return float(np.mean([len(s) for s in all_stems]))
+        return float(np.mean([
+            len(ts) for c in self.values() for ts in c.task_stems
+        ]))
 
     @cached_property
     def bm25_idf(self) -> dict[str, float]:
@@ -235,15 +239,10 @@ class Clusters:
         gap by which broad-text apprenticeships accumulated coverage on
         common stems.
         """
-        from math import log
-
         all_stems  = [ts for c in self.values() for ts in c.task_stems]
         all_stems += [c.stems for c in self.credentials]
         n  = len(all_stems)
-        df: dict[str, int] = {}
-        for doc in all_stems:
-            for s in doc:
-                df[s] = df.get(s, 0) + 1
+        df = Counter(chain.from_iterable(all_stems))
 
         return {
             stem: log((n - count + 0.5) / (count + 0.5) + 1)
@@ -266,15 +265,26 @@ class Clusters:
         return cosine_similarity(self.centroids)
 
     @cached_property
+    def centroid_distance_matrix(self) -> np.ndarray:
+        """
+        Pairwise Euclidean distance between cluster centroids in the
+        reduced SVD space. Single source of truth shared by
+        `max_centroid_distance` (resume score normalization denominator)
+        and `pairwise_distances` (per-sector distance distributions).
+        """
+        from sklearn.metrics.pairwise import euclidean_distances
+        return euclidean_distances(self.centroids)
+
+    @cached_property
     def cluster_heatmap(self) -> dict[str, list[float]]:
         """
         Centroid cosine similarity keyed by SOC title for the inter-cluster
         heatmap.
         """
-        return {
-            c.soc_title: row
-            for c, row in zip(self.values(), self.cosine_similarity_matrix)
-        }
+        return dict(zip(
+            (c.soc_title for c in self.values()),
+            self.cosine_similarity_matrix
+        ))
 
     @cached_property
     def cluster_index(self) -> dict[int, int]:
@@ -295,10 +305,8 @@ class Clusters:
         downward and rounded to `wage_round` to match the granularity of the
         source labor records.
         """
-        picks = np.argsort(
-            np.where(self.occupation_wages > 0, self.soc_weights, 0),
-            axis=1
-        )[:, -self.wage_topk:]
+        masked = self.soc_weights * (self.occupation_wages > 0)
+        picks  = np.argpartition(masked, -self.wage_topk, axis=1)[:, -self.wage_topk:]
 
         weights   = np.take_along_axis(self.soc_weights, picks, axis=1)
         weights  /= weights.sum(axis=1, keepdims=True)
@@ -322,34 +330,65 @@ class Clusters:
         rounded floats for heatmap rendering. Derived from `centroid_cosine`
         to share the underlying matrix computation with the graph backbone.
         """
-        return [
-            [round(float(v), 3) for v in row]
-            for row in self.centroid_cosine
-        ]
+        return np.round(self.centroid_cosine, 3).tolist()
 
     @cached_property
     def display_titles(self) -> dict[int, str]:
         """
-        Shortest label per cluster that stays distinct across the corpus.
-
-        Each cluster picks from soc title, modal posting title, then
-        `{soc_title} (#{cluster_id})`. On collision the largest cluster
-        keeps the current level and the rest advance, so one Civil Engineers
-        stays bare while duplicates step forward.
+        Cluster ID to display label, with TF-IDF token suffixes that
+        disambiguate clusters sharing a SOC title. Single-SOC clusters
+        keep the bare title. Cohorts of size `n` retain tokens
+        appearing in 2 to `n - 1` siblings (1 to 1 when `n == 2`) that
+        also clear a Zipf-frequency floor so brand vocabulary drops
+        out before ranking. The suffix is the top-ranked token alone
+        when its score exceeds twice the runner-up's, otherwise both
+        tokens joined by ` · `. Falls back to `#{cluster_id}` when no
+        token survives filtering.
         """
-        cascade = {
-            cid: (c.soc_title, c.modal_title, f"{c.soc_title} (#{cid})")
-            for cid, c in self.items.items()
-        }
-        levels = dict.fromkeys(self.items, 0)
-        for _ in range(3):
-            groups = defaultdict(list)
-            for cid, lvl in levels.items():
-                groups[cascade[cid][lvl]].append(cid)
-            for g in groups.values():
-                for cid in sorted(g, key=lambda c: -self.items[c].size)[1:]:
-                    levels[cid] = min(levels[cid] + 1, 2)
-        return {cid: cascade[cid][lvl] for cid, lvl in levels.items()}
+        from wordfreq import zipf_frequency
+
+        cohorts: dict[str, list[int]] = defaultdict(list)
+        for cid in self.cluster_ids:
+            cohorts[self.items[cid].soc_title].append(cid)
+
+        titles: dict[int, str] = {}
+        for soc, siblings in cohorts.items():
+            if len(siblings) == 1:
+                titles[siblings[0]] = soc
+                continue
+
+            tokens = {
+                cid: Counter(chain.from_iterable(self.items[cid].distinctive_tokens))
+                for cid in siblings
+            }
+            doc_freq    = Counter(chain.from_iterable(tokens.values()))
+            cohort_size = len(siblings)
+            min_df      = 2 if cohort_size >= 3 else 1
+
+            for cid, counter in tokens.items():
+                total = counter.total() or 1
+                top   = nlargest(
+                    2,
+                    (
+                        (w, (c / total) * log(cohort_size / doc_freq[w]))
+                        for w, c in counter.items()
+                        if c >= 2
+                        and min_df <= doc_freq[w] < cohort_size
+                        and zipf_frequency(w, "en") >= 2.5
+                    ),
+                    key=itemgetter(1)
+                )
+                suffix = f"#{cid}"
+                match top:
+                    case [(word, _)]:
+                        suffix = word.title()
+                    case [(winner, hi), (_, lo)] if lo < 0.5 * hi:
+                        suffix = winner.title()
+                    case [(winner, _), (runner_up, _)]:
+                        suffix = f"{winner.title()} · {runner_up.title()}"
+                titles[cid] = f"{soc} ({suffix})"
+
+        return titles
 
     @cached_property
     def job_zone_map(self) -> dict[int, int]:
@@ -375,8 +414,7 @@ class Clusters:
         reduced SVD space. Fixed per-corpus, used as the denominator for
         normalizing resume-to-cluster distances into display match scores.
         """
-        pairs = self.centroids[:, None] - self.centroids[None, :]
-        return float(np.linalg.norm(pairs, axis=2).max())
+        return float(self.centroid_distance_matrix.max())
 
     @cached_property
     def occupation_wages(self) -> np.ndarray:
@@ -396,15 +434,13 @@ class Clusters:
         Euclidean distances between all centroid pairs, grouped by sector of
         the first cluster in each pair.
         """
-        from collections import defaultdict
-        from itertools   import combinations
-        dists = np.linalg.norm(
-            self.centroids[:, None] - self.centroids[None, :], axis=2
-        )
-        result: dict[str, list[float]] = defaultdict(list)
-        for i, j in combinations(range(len(self.cluster_ids)), 2):
-            result[self.sector_array[i]].append(float(dists[i, j]))
-        return dict(result)
+        i, j    = np.triu_indices(len(self.cluster_ids), k=1)
+        sectors = self.sector_array[i]
+        dists   = self.centroid_distance_matrix[i, j]
+        return {
+            s: dists[sectors == s].tolist()
+            for s in np.unique(sectors)
+        }
 
     @property
     def profile_map(self) -> dict[str, dict]:
@@ -426,17 +462,17 @@ class Clusters:
         """
         Sector name per cluster as a numpy array for sklearn APIs.
         """
-        return np.array([self.items[cid].sector for cid in self.cluster_ids])
+        return np.array([c.sector for c in self.values()])
 
     @property
     def sector_sizes(self) -> dict[str, int]:
         """
         Total posting count per sector.
         """
-        return {
-            s: sum(p.size for p in self.values() if p.sector == s)
-            for s in self.sectors
-        }
+        sizes: Counter[str] = Counter()
+        for c in self.values():
+            sizes[c.sector] += c.size
+        return dict(sizes)
 
     @property
     def sectors(self) -> list[str]:
@@ -452,15 +488,12 @@ class Clusters:
         to (title, sector, score) and sorted descending.
         """
         from sklearn.metrics import silhouette_samples
-        scores = np.asarray(
+        scores = np.round(np.asarray(
             silhouette_samples(self.centroids, self.sector_array, metric="cosine")
-        )
+        ), 3)
         return sorted(
-            (
-                (c.soc_title, c.sector, round(float(s), 3))
-                for c, s in zip(self.values(), scores)
-            ),
-            key     = lambda x: x[2],
+            ((c.soc_title, c.sector, float(s)) for c, s in zip(self.values(), scores)),
+            key     = itemgetter(2),
             reverse = True
         )
 
@@ -477,10 +510,10 @@ class Clusters:
         SOC similarity keyed by display label, rounded to three decimals for
         the SOC assignment heatmap.
         """
-        return {
-            c.display_label: [round(float(v), 3) for v in row]
-            for c, row in zip(self.values(), self.soc_similarity)
-        }
+        return dict(zip(
+            (c.display_label for c in self.values()),
+            np.round(self.soc_similarity, 3).tolist()
+        ))
 
     @cached_property
     def soc_weights(self) -> np.ndarray:
@@ -490,10 +523,8 @@ class Clusters:
         weighted wage computation and the runner-up fallback used by
         `display_titles` to differentiate colliding SOC labels.
         """
-        logits  = self.soc_similarity / self.softmax_tau
-        logits -= logits.max(axis=1, keepdims=True)
-        weights = np.exp(logits)
-        return weights / weights.sum(axis=1, keepdims=True)
+        from scipy.special import softmax
+        return softmax(self.soc_similarity / self.softmax_tau, axis=1)
 
     @cached_property
     def vector_map(self) -> dict[int, np.ndarray]:

--- a/src/chalkline/pathways/clusters.py
+++ b/src/chalkline/pathways/clusters.py
@@ -16,6 +16,7 @@ from typing          import NamedTuple
 
 from chalkline.collection.schemas import Posting
 from chalkline.pathways.loaders   import LaborLoader
+from chalkline.pathways.schemas   import Credential
 
 
 @dataclass
@@ -164,6 +165,7 @@ class Clusters:
     """
 
     centroids         : np.ndarray
+    credentials       : list[Credential]
     items             : dict[int, Cluster]
     labor             : LaborLoader
     occupation_titles : list[str]
@@ -221,18 +223,23 @@ class Clusters:
     @cached_property
     def bm25_idf(self) -> dict[str, float]:
         """
-        Inverse document frequency per stem across all task descriptions,
-        using the BM25 IDF variant with smoothing. Stems appearing in many
-        tasks get low weight, suppressing generic verbs like 'prepare' and
-        'use' while amplifying domain-specific terms like 'conduit' and
-        'circuit'.
+        Inverse document frequency per stem across the union of cluster
+        task descriptions and credential descriptions, using the BM25 IDF
+        variant with smoothing.
+
+        Counting both sides of the matching pair surfaces what is rare
+        across the corpus rather than only what is rare across tasks.
+        Boilerplate stems shared by many credentials and many tasks
+        (`technician`, `inspector`, `professional`) get suppressed while
+        specialty stems on either side stay discriminative, narrowing the
+        gap by which broad-text apprenticeships accumulated coverage on
+        common stems.
         """
         from math import log
 
-        all_stems = [
-            ts for c in self.values() for ts in c.task_stems
-        ]
-        n = len(all_stems)
+        all_stems  = [ts for c in self.values() for ts in c.task_stems]
+        all_stems += [c.stems for c in self.credentials]
+        n  = len(all_stems)
         df: dict[str, int] = {}
         for doc in all_stems:
             for s in doc:

--- a/src/chalkline/pathways/clusters.py
+++ b/src/chalkline/pathways/clusters.py
@@ -16,6 +16,7 @@ from heapq           import nlargest
 from itertools       import chain
 from math            import log
 from operator        import itemgetter
+from sklearn.cluster import KMeans
 from typing          import NamedTuple
 
 from chalkline.collection.schemas import Posting
@@ -39,7 +40,6 @@ class Cluster:
 
     cluster_id  : int
     embeddings  : np.ndarray
-    job_zone    : int
     modal_title : str
     postings    : list[Posting]
     sector      : str
@@ -50,17 +50,20 @@ class Cluster:
     soc_weights   : np.ndarray = field(default_factory=lambda: np.empty(0), init=False)
     tasks         : list[Task] = field(default_factory=list)
     wage          : float      = field(default=0.0, init=False)
+    wage_tier     : int        = field(default=0,   init=False)
 
     @property
     def display_label(self) -> str:
         """
         Human-readable cluster identifier for dropdown labels, using the
         collision-resolved `display_title` so duplicate SOCs stay
-        distinguishable in the picker.
+        distinguishable in the picker. The wage tier suffix shows where
+        this family sits in the wage-banded career ladder, 1-indexed for
+        stakeholder readability while internal storage stays 0-indexed.
         """
         return (
             f"Cluster {self.cluster_id}: {self.display_title} "
-            f"(Job Zone {self.job_zone})"
+            f"(Tier {self.wage_tier + 1})"
         )
 
     @cached_property
@@ -179,6 +182,7 @@ class Clusters:
     softmax_tau       : float
     vectors           : np.ndarray
     wage_round        : int
+    wage_tier_count   : int
     wage_topk         : int
 
     cluster_ids: list[int] = field(init=False)
@@ -204,15 +208,19 @@ class Clusters:
     def __post_init__(self):
         """
         Derive sorted cluster IDs for stable iteration order, then fan the
-        softmax-derived `soc_weights`, `wage`, and collision-resolved
-        `display_title` onto each child `Cluster` so downstream callers read
-        per-cluster attributes without round-tripping through the parent.
+        softmax-derived `soc_weights`, `wage`, K-means-derived `wage_tier`,
+        and collision-resolved `display_title` onto each child `Cluster` so
+        downstream callers read per-cluster attributes without round-tripping
+        through the parent. `wage` must be set before `wage_tier_map` is
+        accessed because the partition reads `Cluster.wage` directly.
         """
         self.cluster_ids = sorted(self.items)
         for cid, cluster in self.items.items():
             cluster.soc_weights   = self.soc_weights[cid]
             cluster.wage          = float(self.cluster_wages[cid])
             cluster.display_title = self.display_titles[cid]
+        for cid, tier in self.wage_tier_map.items():
+            self.items[cid].wage_tier = tier
 
     @cached_property
     def bm25_average_length(self) -> float:
@@ -390,13 +398,6 @@ class Clusters:
 
         return titles
 
-    @cached_property
-    def job_zone_map(self) -> dict[int, int]:
-        """
-        Cluster ID to Job Zone for stepwise graph constraints.
-        """
-        return {cid: self.items[cid].job_zone for cid in self.cluster_ids}
-
     @property
     def location_count(self) -> int:
         """
@@ -449,10 +450,10 @@ class Clusters:
         """
         return {
             c.display_label: {
-                "Job Zone"    : c.job_zone,
                 "Modal Title" : c.modal_title,
                 "Sector"      : c.sector,
-                "Size"        : c.size
+                "Size"        : c.size,
+                "Wage Tier"   : c.wage_tier + 1
             }
             for c in self.values()
         }
@@ -530,13 +531,40 @@ class Clusters:
     def vector_map(self) -> dict[int, np.ndarray]:
         """
         Cluster ID to its row in the stacked `vectors` matrix, mirroring the
-        `job_zone_map` lookup pattern so display-layer factories can fetch a
+        `wage_tier_map` lookup pattern so display-layer factories can fetch a
         single cluster's vector without indexing into the row order via
         `cluster_ids.index(...)`. Cached because both `RelevantCredentials`
         and `RelevantJobBoards` look it up per render and the underlying
         matrix never changes after fit.
         """
         return dict(zip(self.cluster_ids, self.vectors))
+
+    @cached_property
+    def wage_tier_map(self) -> dict[int, int]:
+        """
+        Cluster ID to wage tier index, ordered so tier 0 is the lowest mean
+        log wage and tier `wage_tier_count - 1` is the highest. Forms the
+        spine of the career graph in place of O*NET Job Zone, partitioning
+        clusters by what they actually pay rather than by O*NET's preparation
+        ladder.
+
+        K-means on `log(wage)` separates the wage distribution into bands
+        whose boundaries respect the long tail without letting a few
+        high-wage clusters dominate Euclidean distance the way they would in
+        raw-dollar space. Tier indices come from sorting K-means labels by
+        each band's mean log wage, so advancement edges always point toward
+        higher pay.
+        """
+        wages     = np.array([self.items[cid].wage for cid in self.cluster_ids])
+        log_wages = np.log(np.where(wages > 0, wages, 1.0)).reshape(-1, 1)
+        raw       = KMeans(
+            n_clusters   = self.wage_tier_count,
+            n_init       = 10,
+            random_state = 42
+        ).fit_predict(log_wages)
+        order = np.argsort([log_wages[raw == j].mean() for j in range(self.wage_tier_count)])
+        rank  = {old: new for new, old in enumerate(order)}
+        return {cid: rank[int(label)] for cid, label in zip(self.cluster_ids, raw)}
 
     def values(self) -> Iterator[Cluster]:
         """

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -40,8 +40,8 @@ class CareerPathwayGraph:
         clusters               : Cluster map with centroids and vectors.
         credentials            : Typed records with aligned embedding vectors.
         destination_percentile : Top-p threshold for destination affinity.
-        lateral_neighbors      : k for same Job Zone bidirectional edges.
-        upward_neighbors       : k for next Job Zone unidirectional edges.
+        lateral_neighbors      : k for same wage-tier bidirectional edges.
+        upward_neighbors       : k for next wage-tier unidirectional edges.
     """
 
     clusters               : Clusters
@@ -147,26 +147,25 @@ class CareerPathwayGraph:
         Add stepwise k-NN backbone edges to `g`.
 
         Each cluster gets `lateral_neighbors` bidirectional edges to its
-        most similar clusters at the same Job Zone and `upward_neighbors`
-        unidirectional edges to its most similar clusters at the next Job
-        Zone level. The stepwise constraint prevents tier-skipping
-        shortcuts.
+        most similar clusters at the same wage tier and `upward_neighbors`
+        unidirectional edges to its most similar clusters at the next wage
+        tier. The stepwise constraint prevents tier-skipping shortcuts.
         """
-        job_zones = self.clusters.job_zone_map
-        zones     = np.array([job_zones[c] for c in self.node_ids])
-        next_zone = dict(pairwise(sorted(set(zones))))
+        tiers     = self.clusters.wage_tier_map
+        per_node  = np.array([tiers[c] for c in self.node_ids])
+        next_tier = dict(pairwise(sorted(set(per_node))))
 
         for source in self.node_ids:
-            zone      = job_zones[source]
-            lateral   = self.node_ids[(zones == zone) & (self.node_ids > source)]
+            tier      = tiers[source]
+            lateral   = self.node_ids[(per_node == tier) & (self.node_ids > source)]
             proximity = similarity[source, lateral]
 
             for i in np.argsort(-proximity)[:self.lateral_neighbors]:
                 g.add_edge(int(source), int(lateral[i]), weight=float(proximity[i]))
                 g.add_edge(int(lateral[i]), int(source), weight=float(proximity[i]))
 
-            if zone in next_zone:
-                upward    = self.node_ids[zones == next_zone[zone]]
+            if tier in next_tier:
+                upward    = self.node_ids[per_node == next_tier[tier]]
                 proximity = similarity[source, upward]
 
                 for i in np.argsort(-proximity)[:self.upward_neighbors]:
@@ -220,19 +219,19 @@ class CareerPathwayGraph:
         """
         Local reach exploration from a given cluster.
 
-        Returns advancement paths (edges to higher Job Zone clusters) and
-        lateral pivots (edges to same Job Zone clusters) with their per-edge
+        Returns advancement paths (edges to higher wage-tier clusters) and
+        lateral pivots (edges to same wage-tier clusters) with their per-edge
         credential metadata sorted by edge weight.
         """
-        job_zones = self.clusters.job_zone_map
-        zone      = job_zones[cluster_id]
-        edges     = sorted(
+        tiers = self.clusters.wage_tier_map
+        tier  = tiers[cluster_id]
+        edges = sorted(
             (self._edge(cluster_id, t) for t in self.graph.successors(cluster_id)),
             key     = attrgetter("weight"),
             reverse = True
         )
         return Reach(
-            advancement = [e for e in edges if job_zones[e.cluster_id] >  zone],
-            lateral     = [e for e in edges if job_zones[e.cluster_id] == zone]
+            advancement = [e for e in edges if tiers[e.cluster_id] >  tier],
+            lateral     = [e for e in edges if tiers[e.cluster_id] == tier]
         )
 

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -41,6 +41,7 @@ class CareerPathwayGraph:
         credentials            : Typed records with aligned embedding vectors.
         destination_percentile : Top-p threshold for destination affinity.
         lateral_neighbors      : k for same wage-tier bidirectional edges.
+        rrf_k                  : RRF damping constant (Cormack 2009 default).
         upward_neighbors       : k for next wage-tier unidirectional edges.
     """
 
@@ -48,6 +49,7 @@ class CareerPathwayGraph:
     credentials            : list[Credential]
     destination_percentile : int
     lateral_neighbors      : int
+    rrf_k                  : int
     upward_neighbors       : int
 
     @property
@@ -91,6 +93,28 @@ class CareerPathwayGraph:
         if not self.credential_pool:
             return np.empty((0, len(self.clusters.cluster_ids)))
         return cosine_similarity(self.credential_vectors, self.clusters.vectors)
+
+    @cached_property
+    def credential_task_maxsim(self) -> dict[int, np.ndarray]:
+        """
+        Max cosine similarity between each credential and each cluster's
+        O*NET task vectors, keyed by cluster id. Used as the second
+        ranking signal in the RRF candidate filter so destination-aligned
+        credentials surface alongside centroid-aligned ones.
+
+        Only clusters whose nearest occupation contributed Task or DWA
+        elements appear in the dict; clusters without tasks fall back to
+        the centroid signal alone in `credentials_for`.
+        """
+        if not self.credential_pool:
+            return {}
+        return {
+            cid: cosine_similarity(
+                self.credential_vectors, self.clusters[cid].task_matrix
+            ).max(axis=1)
+            for cid in self.clusters.cluster_ids
+            if self.clusters[cid].tasks
+        }
 
     @cached_property
     def credential_vectors(self) -> np.ndarray:
@@ -181,13 +205,16 @@ class CareerPathwayGraph:
 
     def credentials_for(self, target_id: int) -> list[Credential]:
         """
-        Credentials aligned with a specific destination, filtered by the top
-        destination_percentile of cluster-credential cosine similarity and
-        ranked by descending affinity to the target.
+        Credentials aligned with a specific destination, filtered via
+        Reciprocal Rank Fusion over centroid cosine and destination-task
+        MaxSim rankings, then gated to the top `destination_percentile` of
+        the fused score and returned in descending order.
 
-        Career-change recommendations are about destination relevance, so
-        the filter gates only on where the user is going, not on how closely
-        a credential already overlaps with where they are.
+        RRF (Cormack, Clarke, Buettcher 2009) absorbs the score-scale
+        mismatch between centroid cosine and task MaxSim without
+        calibration, letting both signals contribute on equal footing.
+        Falls back to centroid-only ranking when the destination has no
+        task elements.
 
         Args:
             target_id: Cluster ID the user clicked, may equal the matched cluster.
@@ -195,13 +222,21 @@ class CareerPathwayGraph:
         if not (creds := self.credential_pool):
             return []
 
-        similarity     = self.credential_similarity
         t_idx          = self.clusters.cluster_index[target_id]
-        dest_threshold = np.percentile(
-            similarity[:, t_idx], 100 - self.destination_percentile
-        )
-        passing = np.flatnonzero(similarity[:, t_idx] >= dest_threshold)
-        ranked  = passing[np.argsort(-similarity[passing, t_idx])]
+        centroid_score = self.credential_similarity[:, t_idx]
+        task_score     = self.credential_task_maxsim.get(target_id)
+
+        if task_score is None:
+            scores = centroid_score
+        else:
+            rank_centroid = (-centroid_score).argsort().argsort()
+            rank_task     = (-task_score).argsort().argsort()
+            scores        = (1.0 / (self.rrf_k + rank_centroid)
+                           + 1.0 / (self.rrf_k + rank_task))
+
+        threshold = np.percentile(scores, 100 - self.destination_percentile)
+        passing   = np.flatnonzero(scores >= threshold)
+        ranked    = passing[np.argsort(-scores[passing])]
         return [creds[i] for i in ranked]
 
     def hops_from(self, source: int) -> dict[int, int]:

--- a/src/chalkline/pathways/graph.py
+++ b/src/chalkline/pathways/graph.py
@@ -157,15 +157,6 @@ class CareerPathwayGraph:
         """
         return np.array(self.clusters.cluster_ids)
 
-    @cached_property
-    def undirected_graph(self) -> nx.Graph:
-        """
-        Undirected projection of the directed pathway graph, cached so the
-        map widget's `hops_from` BFS materializes the projection once per
-        session.
-        """
-        return self.graph.to_undirected()
-
     def _add_edges(self, g: nx.DiGraph, similarity: np.ndarray):
         """
         Add stepwise k-NN backbone edges to `g`.
@@ -238,17 +229,6 @@ class CareerPathwayGraph:
         passing   = np.flatnonzero(scores >= threshold)
         ranked    = passing[np.argsort(-scores[passing])]
         return [creds[i] for i in ranked]
-
-    def hops_from(self, source: int) -> dict[int, int]:
-        """
-        BFS hop distance from `source` to every reachable cluster.
-
-        Operates on the undirected projection of the directed pathway graph
-        so distance reflects connectivity rather than edge direction. The
-        map widget uses these distances to fade nodes by their proximity to
-        the matched cluster.
-        """
-        return nx.single_source_shortest_path_length(self.undirected_graph, source)
 
     def reach(self, cluster_id: int) -> Reach:
         """

--- a/src/chalkline/pathways/schemas.py
+++ b/src/chalkline/pathways/schemas.py
@@ -217,8 +217,8 @@ class Reach(BaseModel, extra="forbid"):
     """
     Local reach exploration view from the matched cluster.
 
-    Shows advancement paths (edges to higher Job Zone clusters) and lateral
-    pivots (edges to same Job Zone clusters), each with per-edge credential
+    Shows advancement paths (edges to higher wage-tier clusters) and lateral
+    pivots (edges to same wage-tier clusters), each with per-edge credential
     metadata identifying the training that bridges each specific transition.
     """
 

--- a/src/chalkline/pathways/schemas.py
+++ b/src/chalkline/pathways/schemas.py
@@ -235,9 +235,9 @@ class Reach(BaseModel, extra="forbid"):
 
 class SelectedCredential(NamedTuple):
     """
-    One credential in a waste-aware stack with its incremental gap
-    positions, meaning only the gaps this pick newly contributes relative to
-    earlier picks in the same stack.
+    One credential in a picked stack with its incremental gap positions,
+    meaning only the gaps this pick newly contributes relative to earlier
+    picks in the same stack.
     """
 
     label     : str
@@ -263,57 +263,6 @@ class SelectedCredential(NamedTuple):
             label     = label,
             positions = frozenset(task_axis[row_mask].tolist())
         )
-
-
-class SelectorConfig(BaseModel, extra="forbid"):
-    """
-    Tuning for the waste-aware Pareto-knee credential picker.
-
-    `alpha_max` and `alpha_steps` set the resolution of the penalty sweep
-    that builds the Pareto frontier. `coverage_floor` anchors the knee to
-    the eligible high-coverage region and has a direct stakeholder
-    interpretation, namely the minimum fraction of skill gaps a recommended
-    stack must fill when reachable.
-    """
-
-    alpha_max      : float = Field(default=5.0,  gt=0)
-    alpha_steps    : int   = Field(default=100,  ge=2)
-    coverage_floor : float = Field(default=0.80, ge=0, le=1)
-
-    @property
-    def alphas(self) -> list[float]:
-        """
-        Penalty coefficients the selector sweeps when building the Pareto
-        frontier, batched into Python floats via `tolist()` so the caller
-        iterates without per-step numpy conversions.
-        """
-        return np.linspace(0.0, self.alpha_max, self.alpha_steps).tolist()
-
-
-class SelectorFrontier(NamedTuple):
-    """
-    One Pareto-dominant point on the coverage-versus-waste curve.
-
-    `CredentialSelector` sweeps the penalty coefficient across a fixed range
-    and records each greedy run's (gaps_filled, total_reach) footprint with
-    the row indices that produced it. Points dominated on both axes drop
-    before knee detection. `waste` derives from the two stored counts so
-    callers see a single redundancy signal without storing it twice.
-    """
-
-    alpha       : float
-    gaps_filled : int
-    picks       : tuple[int, ...]
-    total_reach : int
-
-    @property
-    def waste(self) -> int:
-        """
-        Total reach across all picks minus the unique gaps they fill,
-        capturing redundant coverage within the stack plus leak onto
-        already-demonstrated tasks.
-        """
-        return self.total_reach - self.gaps_filled
 
 
 class Skill(BaseModel, extra="forbid"):

--- a/src/chalkline/pathways/selection.py
+++ b/src/chalkline/pathways/selection.py
@@ -5,9 +5,8 @@ Two stateless dataclasses whose output drives a final selection against a
 candidate pool. `SOCScorer` enables SOC assignment per cluster via
 ColBERTv2-style late-interaction MaxSim across per-posting and per-task
 embeddings. `CredentialSelector` enables credential-stack selection per
-route via waste-aware Pareto-knee optimization, picking a credential
-combination that maximizes gap coverage with minimum redundant reach onto
-tasks the user already demonstrates.
+route via waste-aware Pareto-knee greedy search, picking a credential
+combination that maximizes gap coverage with minimal redundant reach.
 """
 
 import numpy as np
@@ -17,11 +16,9 @@ from dataclasses           import dataclass, field
 from itertools             import accumulate
 from kneed                 import KneeLocator
 from math                  import ceil
-from operator              import attrgetter
 from sklearn.preprocessing import normalize
 
 from chalkline.pathways.schemas import EncodedOccupation, SelectedCredential
-from chalkline.pathways.schemas import SelectorConfig, SelectorFrontier
 
 
 @dataclass(kw_only=True)
@@ -29,132 +26,107 @@ class CredentialSelector:
     """
     Waste-aware Pareto-knee picker for credential stacks per route.
 
-    Sweeps a penalty coefficient across a fixed range, runs vectorized
-    greedy `Δgaps − α · Δwaste` for each α, keeps the Pareto-dominant
-    points, and selects the knee via the Kneedle algorithm. The coverage
-    floor on `SelectorConfig` anchors the knee to the eligible high-coverage
-    region when the pool can satisfy it, with graceful fallback to the
-    unconstrained efficiency point otherwise.
-
-    Args:
-        config: Sweep resolution, penalty range, and coverage floor.
+    Sweeps α across `[0, 5]` in 100 steps and runs vectorized greedy
+    `Δgaps − α · Δwaste` at each setting. The unique points trace a Pareto
+    frontier on the (gaps_filled, waste) plane, and Kneedle picks the
+    knee where added waste stops buying enough coverage. Stack length is
+    data-driven because the greedy stops once marginal score ≤ 0,
+    yielding a short stack on sparse candidate pools without a tuned cap.
+    The coverage floor anchors the knee to qualifying points when
+    reachable, falling back to the highest-coverage frontier point
+    otherwise.
     """
 
-    config: SelectorConfig = field(default_factory=SelectorConfig)
-
-    def _greedy(
-        self,
-        alpha     : float,
-        gap_mask  : np.ndarray,
-        max_picks : int,
-        reach     : np.ndarray
-    ) -> tuple[list[int], np.ndarray]:
-        """
-        Vectorized greedy for one α, returning pick row indices. Per-column
-        weights fold the penalty into a single `(reach & ~covered) @
-        weights` matmul that scores every active credential in one BLAS
-        sweep, where each gap column contributes +1 and each non-gap column
-        contributes −α; the argmax wins while the marginal score stays
-        positive.
-
-        Args:
-            alpha     : Penalty on new reach onto already-covered tasks.
-            gap_mask  : Boolean flag per `reach` column marking gap tasks.
-            max_picks : Hard cap on stack size.
-            reach     : Boolean matrix, shape `(n_credentials, n_tasks)`.
-        """
-        covered = np.zeros(reach.shape[1], dtype=bool)
-        weights = np.where(gap_mask, 1.0, -alpha)
-        picks   = []
-
-        for _ in range(max_picks):
-            scores = (reach & ~covered) @ weights
-            i      = int(scores.argmax())
-            if scores[i] <= 0:
-                break
-            picks.append(i)
-            covered |= reach[i]
-
-        return picks, covered
+    coverage_floor: float
 
     def select_stack(
         self,
         coverage  : dict[str, dict[int, float]],
         gap_set   : frozenset[int],
         max_picks : int
-    ) -> tuple[list[SelectedCredential], bool]:
+    ) -> list[SelectedCredential]:
         """
-        Waste-aware credential stack anchored to the coverage floor when
-        reachable, with graceful fallback to the efficiency-optimal frontier
-        point otherwise.
+        Pareto-knee credential stack over the candidate coverage map.
 
-        Returns each pick's incremental gap positions for shelf rendering
-        along with a bool signalling whether the floor was met.
+        For `max_picks == 1`, returns the single credential filling the
+        most gaps with ties broken by least waste, bypassing the α sweep
+        because a single pick has no stack-shape tradeoff. Otherwise
+        sweeps α ∈ `[0, 5]` across 100 steps, takes the upper-left Pareto
+        frontier on the (gaps, waste) plane, and runs Kneedle over
+        coverage-floor-eligible points, falling back to the
+        highest-coverage frontier point when none qualify.
 
         Args:
-            coverage  : Credential label to `{task_index: affinity}` over every cluster
-                        task the credential reaches, not just gap tasks.
+            coverage  : Credential label to `{task_index: affinity}` over every
+                        cluster task the credential reaches.
             gap_set   : Task indices the resume has not demonstrated.
             max_picks : Hard cap on stack size.
         """
         coverage = {label: scored for label, scored in coverage.items() if scored}
-        if not coverage or not gap_set:
-            return [], False
+        if not coverage or not gap_set or max_picks <= 0:
+            return []
 
         hits = (
             pd.DataFrame.from_dict(coverage, orient="index")
-              .notna()
+              .sort_index()
               .sort_index(axis=1)
         )
-        reach      = hits.to_numpy()
-        gap_mask   = hits.columns.isin(gap_set)
-        cred_reach = np.count_nonzero(reach, axis=1)
+        cols       = hits.columns.to_numpy()
+        labels     = hits.index.tolist()
+        reach      = hits.notna().to_numpy()
+        gap_mask   = np.isin(cols, list(gap_set))
+        cred_reach = reach.sum(axis=1)
+        per_gaps   = (reach & gap_mask).sum(axis=1)
 
-        seen: dict[tuple[int, int], SelectorFrontier] = {}
-        for alpha in self.config.alphas:
-            indices, covered = self._greedy(alpha, gap_mask, max_picks, reach)
-            point = SelectorFrontier(
-                alpha       = alpha,
-                gaps_filled = int((covered & gap_mask).sum()),
-                picks       = tuple(indices),
-                total_reach = int(cred_reach[indices].sum())
-            )
-            seen.setdefault((point.gaps_filled, point.waste), point)
+        if max_picks == 1:
+            if not per_gaps.any():
+                return []
+            i = np.lexsort((cred_reach - per_gaps, -per_gaps))[0]
+            return [SelectedCredential.from_hits(labels[i], reach[i] & gap_mask, cols)]
 
-        points     = sorted(seen.values(), key=lambda p: (-p.gaps_filled, p.waste))
-        prior_min  = accumulate((p.waste for p in points), min, initial=float("inf"))
-        frontier   = [p for p, m in zip(points, prior_min) if p.waste < m]
-        qualifying = [
-            p for p in frontier 
-            if p.gaps_filled >= ceil(self.config.coverage_floor * len(gap_set))
-        ]
+        points = []
+        for alpha in np.linspace(0.0, 5.0, 100):
+            weights = np.where(gap_mask, 1.0, -alpha)
+            covered = np.zeros(reach.shape[1], dtype=bool)
+            picks   = []
+            for _ in range(max_picks):
+                scores = (reach & ~covered) @ weights
+                i      = scores.argmax()
+                if scores[i] <= 0:
+                    break
+                picks.append(i)
+                covered |= reach[i]
+            gaps_filled = (covered & gap_mask).sum()
+            waste       = cred_reach[picks].sum() - gaps_filled
+            points.append((gaps_filled, picks, waste))
 
-        eligible = qualifying or frontier
-        if len(eligible) < 2:
+        points.sort(key=lambda p: (-p[0], p[2]))
+        prior_min = accumulate((p[2] for p in points), min, initial=float("inf"))
+        frontier  = [p for p, m in zip(points, prior_min) if p[2] < m]
+        floor     = ceil(self.coverage_floor * len(gap_set))
+        eligible  = [p for p in frontier if p[0] >= floor] or frontier
+
+        if len(eligible) == 1:
             chosen = eligible[0]
         else:
-            by_gaps = sorted(eligible, key=attrgetter("gaps_filled"))
+            by_gaps = sorted(eligible, key=lambda p: p[0])
             knee    = KneeLocator(
-                [p.gaps_filled for p in by_gaps],
-                [p.waste       for p in by_gaps],
+                [p[0] for p in by_gaps],
+                [p[2] for p in by_gaps],
                 curve     = "convex",
                 direction = "increasing"
             ).knee
-            chosen  = next((p for p in by_gaps if p.gaps_filled == knee), by_gaps[-1])
+            chosen = next((p for p in by_gaps if p[0] == knee), by_gaps[-1])
 
-        pick_rows = reach[list(chosen.picks)] & gap_mask
-        prior     = np.zeros_like(pick_rows)
-        prior[1:] = np.logical_or.accumulate(pick_rows[:-1], axis=0)
-        gains     = pick_rows & ~prior
-        task_axis = hits.columns.to_numpy()
-        
-        return (
-            [
-                SelectedCredential.from_hits(hits.index[i], row, task_axis)
-                for i, row in zip(chosen.picks, gains)
-            ], 
-            bool(qualifying)
-        )
+        picks_idx = chosen[1]
+        pick_rows = reach[picks_idx] & gap_mask
+        gains     = (pick_rows.cumsum(axis=0) == 1) & pick_rows
+
+        return [
+            SelectedCredential.from_hits(labels[i], row, cols)
+            for i, row in zip(picks_idx, gains)
+            if row.any()
+        ]
 
 
 @dataclass(kw_only=True)
@@ -187,12 +159,12 @@ class SOCScorer:
         a starting-index array for `np.maximum.reduceat` segmentation.
         """
         tasks = [e.tasks for e in self.occupations]
-        if any(t.size == 0 for t in tasks):
+        sizes = np.array([t.shape[0] for t in tasks])
+        if not sizes.all():
             raise ValueError(
                 "SOCScorer requires every occupation to list at least one "
                 "task; empty task matrix found."
             )
-        sizes             = np.array([t.shape[0] for t in tasks])
         self.flat_tasks   = np.vstack(tasks)
         self.owner_starts = np.cumsum(sizes) - sizes
 
@@ -219,12 +191,11 @@ class SOCScorer:
             in sorted assignment-id order and occupation columns in `self.occupations`
             order.
         """
-        postings       = normalize(raw_vectors)
-        per_task       = postings @ self.flat_tasks.T
+        per_task       = normalize(raw_vectors) @ self.flat_tasks.T
         per_occupation = np.maximum.reduceat(per_task, self.owner_starts, axis=1)
 
         return (
             pd.DataFrame(per_occupation)
               .groupby(assignments).mean()
-              .to_numpy().astype(np.float32)
+              .to_numpy(dtype=np.float32)
         )

--- a/src/chalkline/pipeline/orchestrator.py
+++ b/src/chalkline/pipeline/orchestrator.py
@@ -131,6 +131,7 @@ class Chalkline:
                     "lexicons"               : LexiconLoader(config.lexicon_dir),
                     "postings_dir"           : str(config.postings_dir),
                     "random_seed"            : config.random_seed,
+                    "rrf_k"                  : config.rrf_k,
                     "soc_softmax_tau"        : config.soc_softmax_tau,
                     "soc_wage_round"         : config.soc_wage_round,
                     "soc_wage_topk"          : config.soc_wage_topk,

--- a/src/chalkline/pipeline/orchestrator.py
+++ b/src/chalkline/pipeline/orchestrator.py
@@ -106,6 +106,7 @@ class Chalkline:
         )
         display.encoder = encoder
 
+        corpus_path = config.postings_dir / "corpus.json"
         results = (Builder()
             .with_modules(steps)
             .with_adapters(display)
@@ -117,10 +118,24 @@ class Chalkline:
             .execute(
                 final_vars = [f.name for f in fields(Chalkline)],
                 inputs     = {
-                    "config"   : config,
-                    "encoder"  : encoder,
-                    "labor"    : LaborLoader(config.lexicon_dir / "labor.json"),
-                    "lexicons" : LexiconLoader(config.lexicon_dir)
+                    "config"                 : config,
+                    "cluster_count"          : config.cluster_count,
+                    "component_count"        : config.component_count,
+                    "consensus_seeds"        : config.consensus_seeds,
+                    "corpus_mtime"           : corpus_path.stat().st_mtime,
+                    "destination_percentile" : config.destination_percentile,
+                    "encoder"                : encoder,
+                    "labor"                  : LaborLoader(config.lexicon_dir / "labor.json"),
+                    "lateral_neighbors"      : config.lateral_neighbors,
+                    "lexicon_dir"            : str(config.lexicon_dir),
+                    "lexicons"               : LexiconLoader(config.lexicon_dir),
+                    "postings_dir"           : str(config.postings_dir),
+                    "random_seed"            : config.random_seed,
+                    "soc_neighbors"          : config.soc_neighbors,
+                    "soc_softmax_tau"        : config.soc_softmax_tau,
+                    "soc_wage_round"         : config.soc_wage_round,
+                    "soc_wage_topk"          : config.soc_wage_topk,
+                    "upward_neighbors"       : config.upward_neighbors
                 }
             )
         )

--- a/src/chalkline/pipeline/orchestrator.py
+++ b/src/chalkline/pipeline/orchestrator.py
@@ -131,11 +131,11 @@ class Chalkline:
                     "lexicons"               : LexiconLoader(config.lexicon_dir),
                     "postings_dir"           : str(config.postings_dir),
                     "random_seed"            : config.random_seed,
-                    "soc_neighbors"          : config.soc_neighbors,
                     "soc_softmax_tau"        : config.soc_softmax_tau,
                     "soc_wage_round"         : config.soc_wage_round,
                     "soc_wage_topk"          : config.soc_wage_topk,
-                    "upward_neighbors"       : config.upward_neighbors
+                    "upward_neighbors"       : config.upward_neighbors,
+                    "wage_tier_count"        : config.wage_tier_count
                 }
             )
         )

--- a/src/chalkline/pipeline/schemas.py
+++ b/src/chalkline/pipeline/schemas.py
@@ -38,7 +38,9 @@ class PipelineConfig(BaseModel, extra="forbid"):
     cluster_count          : int   = Field(default=25,   ge=2)
     component_count        : int   = Field(default=15,   ge=1)
     consensus_seeds        : int   = Field(default=50,   ge=1, le=200)
-    destination_percentile : int   = Field(default=20,   ge=0, le=100)
+    coverage_floor         : float = Field(default=0.80, ge=0.0, le=1.0)
+    destination_percentile : int   = Field(default=15,   ge=0, le=100)
+    rrf_k                  : int   = Field(default=60,   ge=1)
     embedding_model        : str   = "Alibaba-NLP/gte-base-en-v1.5"
     lateral_neighbors      : int   = Field(default=2,    ge=1)
     random_seed            : int   = Field(default=42,   ge=0)

--- a/src/chalkline/pipeline/schemas.py
+++ b/src/chalkline/pipeline/schemas.py
@@ -35,7 +35,7 @@ class PipelineConfig(BaseModel, extra="forbid"):
     lexicon_dir  : Path
     postings_dir : Path
 
-    cluster_count          : int   = Field(default=20,   ge=2)
+    cluster_count          : int   = Field(default=25,   ge=2)
     component_count        : int   = Field(default=15,   ge=1)
     consensus_seeds        : int   = Field(default=50,   ge=1, le=200)
     destination_percentile : int   = Field(default=20,   ge=0, le=100)

--- a/src/chalkline/pipeline/schemas.py
+++ b/src/chalkline/pipeline/schemas.py
@@ -42,11 +42,11 @@ class PipelineConfig(BaseModel, extra="forbid"):
     embedding_model        : str   = "Alibaba-NLP/gte-base-en-v1.5"
     lateral_neighbors      : int   = Field(default=2,    ge=1)
     random_seed            : int   = Field(default=42,   ge=0)
-    soc_neighbors          : int   = Field(default=3,    ge=1)
     soc_softmax_tau        : float = Field(default=0.02, gt=0.0)
     soc_wage_round         : int   = Field(default=10,   ge=1)
     soc_wage_topk          : int   = Field(default=3,    ge=1)
     upward_neighbors       : int   = Field(default=2,    ge=1)
+    wage_tier_count        : int   = Field(default=5,    ge=2)
 
     @property
     def hamilton_cache_dir(self) -> Path:

--- a/src/chalkline/pipeline/schemas.py
+++ b/src/chalkline/pipeline/schemas.py
@@ -36,7 +36,8 @@ class PipelineConfig(BaseModel, extra="forbid"):
     postings_dir : Path
 
     cluster_count          : int   = Field(default=20,   ge=2)
-    component_count        : int   = Field(default=10,   ge=1)
+    component_count        : int   = Field(default=15,   ge=1)
+    consensus_seeds        : int   = Field(default=50,   ge=1, le=200)
     destination_percentile : int   = Field(default=20,   ge=0, le=100)
     embedding_model        : str   = "Alibaba-NLP/gte-base-en-v1.5"
     lateral_neighbors      : int   = Field(default=2,    ge=1)

--- a/src/chalkline/pipeline/steps.py
+++ b/src/chalkline/pipeline/steps.py
@@ -94,7 +94,6 @@ def clusters(
     cluster_vectors     : np.ndarray,
     corpus              : Corpus,
     credentials         : list[Credential],
-    job_zone_map        : dict[int, int],
     labor               : LaborLoader,
     lexicons            : LexiconLoader,
     nearest_occupations : dict[int, Occupation],
@@ -103,7 +102,8 @@ def clusters(
     soc_softmax_tau     : float,
     soc_tasks           : dict[int, list[Task]],
     soc_wage_round      : int,
-    soc_wage_topk       : int
+    soc_wage_topk       : int,
+    wage_tier_count     : int
 ) -> Clusters:
     """
     Build unified cluster objects from assignments, corpus, and O*NET SOC
@@ -111,9 +111,10 @@ def clusters(
     embedding vector matrices, and per-cluster posting embeddings sliced out
     of `raw_vectors` so display-layer projections never have to re-encode
     the corpus. `Clusters.__post_init__` fans the softmax-derived
-    `soc_weights`, `wage`, and zipf-windowed TF-IDF `display_title` onto
-    each child cluster using the occupation titles, wage vector, and the
-    softmax/wage thresholds threaded through from this step.
+    `soc_weights`, `wage`, K-means-derived `wage_tier`, and zipf-windowed
+    TF-IDF `display_title` onto each child cluster using the occupation
+    titles, wage vector, and the softmax/wage/tier thresholds threaded
+    through from this step.
     """
     items: dict[int, Cluster] = {}
     for cid in sorted(np.unique(assignments).tolist()):
@@ -123,7 +124,6 @@ def clusters(
         items[cid] = Cluster(
             cluster_id  = cid,
             embeddings  = raw_vectors[member_idx],
-            job_zone    = job_zone_map[cid],
             modal_title = Counter(p.title for p in postings).most_common(1)[0][0],
             postings    = postings,
             sector      = nearest.sector,
@@ -142,6 +142,7 @@ def clusters(
         softmax_tau       = soc_softmax_tau,
         vectors           = cluster_vectors,
         wage_round        = soc_wage_round,
+        wage_tier_count   = wage_tier_count,
         wage_topk         = soc_wage_topk
     )
 
@@ -221,25 +222,6 @@ def graph(
         f"{result.edge_count} edges"
     )
     return result
-
-
-def job_zone_map(
-    assignments    : np.ndarray,
-    lexicons       : LexiconLoader,
-    soc_neighbors  : int,
-    soc_similarity : np.ndarray
-) -> dict[int, int]:
-    """
-    Assign Job Zones to clusters via top-k median over the MaxSim similarity
-    ranking produced by `soc_similarity`.
-    """
-    return {
-        cid: int(np.median([
-            lexicons.occupations[i].job_zone
-            for i in np.argsort(soc_similarity[cid])[-soc_neighbors:]
-        ]))
-        for cid in sorted(np.unique(assignments))
-    }
 
 
 def matcher(

--- a/src/chalkline/pipeline/steps.py
+++ b/src/chalkline/pipeline/steps.py
@@ -32,14 +32,35 @@ from chalkline.pipeline.encoder   import SentenceEncoder
 from chalkline.pipeline.schemas   import PipelineConfig
 
 
-def assignments(config: PipelineConfig, coordinates: np.ndarray) -> np.ndarray:
+def assignments(config: PipelineConfig, raw_vectors: np.ndarray) -> np.ndarray:
     """
-    Fit Ward-linkage HAC on SVD coordinates and return label array.
+    Consensus cluster labels via evidence accumulation across
+    `consensus_seeds` independent SVD-then-Ward chains, finalized by
+    average-linkage HAC on the resulting pairwise co-association matrix.
+    Stabilizes membership for postings near fuzzy cluster boundaries that
+    single-seed runs assign inconsistently.
     """
+    normed = normalize(raw_vectors)
+    co     = np.zeros((raw_vectors.shape[0],) * 2, dtype=np.float32)
+    logger.info(
+        f"Consensus clustering: {config.consensus_seeds} seeds at "
+        f"k={config.cluster_count}"
+    )
+    for seed in range(config.consensus_seeds):
+        coordinates = TruncatedSVD(
+            n_components = config.component_count,
+            random_state = seed
+        ).fit_transform(normed)
+        labels = AgglomerativeClustering(
+            linkage    = "ward",
+            n_clusters = config.cluster_count
+        ).fit_predict(coordinates)
+        co += np.equal.outer(labels, labels)
     return AgglomerativeClustering(
-        linkage    = "ward",
+        linkage    = "average",
+        metric     = "precomputed",
         n_clusters = config.cluster_count
-    ).fit_predict(coordinates)
+    ).fit_predict(1.0 - co / config.consensus_seeds)
 
 
 def centroids(assignments: np.ndarray, coordinates: np.ndarray) -> np.ndarray:
@@ -69,6 +90,7 @@ def clusters(
     cluster_vectors     : np.ndarray,
     config              : PipelineConfig,
     corpus              : Corpus,
+    credentials         : list[Credential],
     job_zone_map        : dict[int, int],
     labor               : LaborLoader,
     lexicons            : LexiconLoader,
@@ -106,6 +128,7 @@ def clusters(
 
     return Clusters(
         centroids         = centroids,
+        credentials       = credentials,
         items             = items,
         labor             = labor,
         occupation_titles = [o.title for o in lexicons.occupations],

--- a/src/chalkline/pipeline/steps.py
+++ b/src/chalkline/pipeline/steps.py
@@ -204,6 +204,7 @@ def graph(
     credentials            : list[Credential],
     destination_percentile : int,
     lateral_neighbors      : int,
+    rrf_k                  : int,
     upward_neighbors       : int
 ) -> CareerPathwayGraph:
     """
@@ -215,6 +216,7 @@ def graph(
         credentials            = credentials,
         destination_percentile = destination_percentile,
         lateral_neighbors      = lateral_neighbors,
+        rrf_k                  = rrf_k,
         upward_neighbors       = upward_neighbors
     )
     logger.info(

--- a/src/chalkline/pipeline/steps.py
+++ b/src/chalkline/pipeline/steps.py
@@ -15,6 +15,7 @@ from collections                 import Counter
 from hamilton.function_modifiers import extract_fields, tag
 from json                        import loads
 from loguru                      import logger
+from pathlib                     import Path
 from sklearn.cluster             import AgglomerativeClustering
 from sklearn.decomposition       import TruncatedSVD
 from sklearn.preprocessing       import normalize
@@ -29,10 +30,14 @@ from chalkline.pathways.schemas   import Credential, EncodedOccupation, Occupati
 from chalkline.pathways.schemas   import SkillType
 from chalkline.pathways.selection import SOCScorer
 from chalkline.pipeline.encoder   import SentenceEncoder
-from chalkline.pipeline.schemas   import PipelineConfig
 
 
-def assignments(config: PipelineConfig, raw_vectors: np.ndarray) -> np.ndarray:
+def assignments(
+    cluster_count   : int,
+    component_count : int,
+    consensus_seeds : int,
+    raw_vectors     : np.ndarray
+) -> np.ndarray:
     """
     Consensus cluster labels via evidence accumulation across
     `consensus_seeds` independent SVD-then-Ward chains, finalized by
@@ -43,24 +48,23 @@ def assignments(config: PipelineConfig, raw_vectors: np.ndarray) -> np.ndarray:
     normed = normalize(raw_vectors)
     co     = np.zeros((raw_vectors.shape[0],) * 2, dtype=np.float32)
     logger.info(
-        f"Consensus clustering: {config.consensus_seeds} seeds at "
-        f"k={config.cluster_count}"
+        f"Consensus clustering: {consensus_seeds} seeds at k={cluster_count}"
     )
-    for seed in range(config.consensus_seeds):
+    for seed in range(consensus_seeds):
         coordinates = TruncatedSVD(
-            n_components = config.component_count,
+            n_components = component_count,
             random_state = seed
         ).fit_transform(normed)
         labels = AgglomerativeClustering(
             linkage    = "ward",
-            n_clusters = config.cluster_count
+            n_clusters = cluster_count
         ).fit_predict(coordinates)
         co += np.equal.outer(labels, labels)
     return AgglomerativeClustering(
         linkage    = "average",
         metric     = "precomputed",
-        n_clusters = config.cluster_count
-    ).fit_predict(1.0 - co / config.consensus_seeds)
+        n_clusters = cluster_count
+    ).fit_predict(1.0 - co / consensus_seeds)
 
 
 def centroids(assignments: np.ndarray, coordinates: np.ndarray) -> np.ndarray:
@@ -88,7 +92,6 @@ def clusters(
     assignments         : np.ndarray,
     centroids           : np.ndarray,
     cluster_vectors     : np.ndarray,
-    config              : PipelineConfig,
     corpus              : Corpus,
     credentials         : list[Credential],
     job_zone_map        : dict[int, int],
@@ -97,7 +100,10 @@ def clusters(
     nearest_occupations : dict[int, Occupation],
     raw_vectors         : np.ndarray,
     soc_similarity      : np.ndarray,
-    soc_tasks           : dict[int, list[Task]]
+    soc_softmax_tau     : float,
+    soc_tasks           : dict[int, list[Task]],
+    soc_wage_round      : int,
+    soc_wage_topk       : int
 ) -> Clusters:
     """
     Build unified cluster objects from assignments, corpus, and O*NET SOC
@@ -105,9 +111,9 @@ def clusters(
     embedding vector matrices, and per-cluster posting embeddings sliced out
     of `raw_vectors` so display-layer projections never have to re-encode
     the corpus. `Clusters.__post_init__` fans the softmax-derived
-    `soc_weights`, `wage`, and asymmetrically-resolved `display_title` onto
-    each child cluster using the occupation titles, wage vector, and config
-    thresholds threaded through from this step.
+    `soc_weights`, `wage`, and zipf-windowed TF-IDF `display_title` onto
+    each child cluster using the occupation titles, wage vector, and the
+    softmax/wage thresholds threaded through from this step.
     """
     items: dict[int, Cluster] = {}
     for cid in sorted(np.unique(assignments).tolist()):
@@ -133,29 +139,34 @@ def clusters(
         labor             = labor,
         occupation_titles = [o.title for o in lexicons.occupations],
         soc_similarity    = soc_similarity,
-        softmax_tau       = config.soc_softmax_tau,
+        softmax_tau       = soc_softmax_tau,
         vectors           = cluster_vectors,
-        wage_round        = config.soc_wage_round,
-        wage_topk         = config.soc_wage_topk
+        wage_round        = soc_wage_round,
+        wage_topk         = soc_wage_topk
     )
 
 
-def corpus(config: PipelineConfig) -> Corpus:
+def corpus(corpus_mtime: float, postings_dir: str) -> Corpus:
     """
     Load the posting corpus from the configured directory.
+
+    `corpus_mtime` is threaded through so Hamilton's content-addressed
+    cache invalidates this node when `corpus.json` changes on disk, since
+    the path alone doesn't reflect file writes. `postings_dir` arrives as
+    a string so Hamilton's input hasher can fingerprint it, then converts
+    to `Path` here for filesystem operations.
 
     Raises:
         FileNotFoundError: When no valid postings exist.
     """
-    if not (postings := CorpusStorage(config.postings_dir).load()):
-        raise FileNotFoundError(
-            f"No postings found in {config.postings_dir}"
-        )
+    path = Path(postings_dir)
+    if not (postings := CorpusStorage(path).load()):
+        raise FileNotFoundError(f"No postings found in {path}")
     return Corpus({p.id: p for p in postings})
 
 
 @tag(batch_label="credentials")
-def credentials(config: PipelineConfig, encoder: SentenceEncoder) -> list[Credential]:
+def credentials(encoder: SentenceEncoder, lexicon_dir: str) -> list[Credential]:
     """
     Load the curated credential catalog, encode with the sentence
     transformer, and attach vectors to each credential instance.
@@ -163,9 +174,10 @@ def credentials(config: PipelineConfig, encoder: SentenceEncoder) -> list[Creden
     The curated `credentials.json` stores kind-specific extras inside a
     `metadata` object per record; the loader threads that through directly
     so apprenticeship RAPIDS codes, program URLs, and other type-specific
-    fields reach the display layer intact.
+    fields reach the display layer intact. `lexicon_dir` arrives as a
+    string for Hamilton input hashing and is wrapped in `Path` here.
     """
-    raw     = loads((config.lexicon_dir / "credentials.json").read_bytes())
+    raw     = loads((Path(lexicon_dir) / "credentials.json").read_bytes())
     records = [
         Credential(
             embedding_text = entry["embedding_text"],
@@ -187,9 +199,11 @@ def credentials(config: PipelineConfig, encoder: SentenceEncoder) -> list[Creden
 
 
 def graph(
-    clusters    : Clusters,
-    config      : PipelineConfig,
-    credentials : list[Credential]
+    clusters               : Clusters,
+    credentials            : list[Credential],
+    destination_percentile : int,
+    lateral_neighbors      : int,
+    upward_neighbors       : int
 ) -> CareerPathwayGraph:
     """
     Build the career pathway graph with stepwise k-NN backbone and on-demand
@@ -198,9 +212,9 @@ def graph(
     result = CareerPathwayGraph(
         clusters               = clusters,
         credentials            = credentials,
-        destination_percentile = config.destination_percentile,
-        lateral_neighbors      = config.lateral_neighbors,
-        upward_neighbors       = config.upward_neighbors
+        destination_percentile = destination_percentile,
+        lateral_neighbors      = lateral_neighbors,
+        upward_neighbors       = upward_neighbors
     )
     logger.info(
         f"Career graph: {result.graph.number_of_nodes()} nodes, "
@@ -211,8 +225,8 @@ def graph(
 
 def job_zone_map(
     assignments    : np.ndarray,
-    config         : PipelineConfig,
     lexicons       : LexiconLoader,
+    soc_neighbors  : int,
     soc_similarity : np.ndarray
 ) -> dict[int, int]:
     """
@@ -222,7 +236,7 @@ def job_zone_map(
     return {
         cid: int(np.median([
             lexicons.occupations[i].job_zone
-            for i in np.argsort(soc_similarity[cid])[-config.soc_neighbors:]
+            for i in np.argsort(soc_similarity[cid])[-soc_neighbors:]
         ]))
         for cid in sorted(np.unique(assignments))
     }
@@ -274,14 +288,18 @@ def raw_vectors(corpus: Corpus, encoder: SentenceEncoder) -> np.ndarray:
     "coordinates" : np.ndarray,
     "svd"         : TruncatedSVD
 })
-def reduction(config: PipelineConfig, raw_vectors: np.ndarray) -> dict:
+def reduction(
+    component_count : int,
+    random_seed     : int,
+    raw_vectors     : np.ndarray
+) -> dict:
     """
     L2-normalize raw embeddings, fit TruncatedSVD, and expose both the
     reduced coordinates and the fitted SVD for resume projection.
     """
     svd = TruncatedSVD(
-        n_components = config.component_count,
-        random_state = config.random_seed
+        n_components = component_count,
+        random_state = random_seed
     )
     return {
         "coordinates" : svd.fit_transform(normalize(raw_vectors)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,6 +294,7 @@ def pathway_graph(
         credentials            = credentials,
         destination_percentile = 20,
         lateral_neighbors      = 2,
+        rrf_k                  = 60,
         upward_neighbors       = 2
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,25 @@ Shared test fixtures for the Chalkline test suite.
 Fixtures form an embedding pipeline chain where each step's output is
 independently tappable by any test module:
 
-    corpus → raw_vectors → unit_vectors → coordinates → assignments
-                                  ↓                          ↓
-                   encoded_occupations → job_zone_map → clusters → graph
-                                                                     ↓
-                           credentials ────────────────────────→ matcher
-                                                                     ↓
-                                    reference → charts
+    raw_vectors ─→ unit_vectors ─→ coordinates ─→ assignments
+                         │              │              │
+                         ↓              ↓              ↓
+                        svd        centroids    cluster_vectors
+                                                       │
+              credentials ───→ clusters ←── labor ─────┘
+                                  │
+                       ┌──────────┴──────────┐
+                       ↓                     ↓
+                 pathway_graph         resume_matcher
+                       │                     │
+                       ↓                     ↓
+                    charts             match_result
 """
 
 import numpy as np
 
 from datetime              import date
+from json                  import dumps
 from pathlib               import Path
 from pydantic              import TypeAdapter
 from pytest                import fixture
@@ -115,13 +122,16 @@ def second_posting() -> Posting:
 @fixture
 def labor(tmp_path: Path) -> LaborLoader:
     """
-    Empty `LaborLoader` backed by an `[]` file so every SOC title resolves
-    to a default-valued `LaborRecord` with null wage. Tests do not depend
-    on real wage values, so the empty loader keeps `Clusters` construction
-    self-contained without fixture data.
+    Synthetic labor data with monotonically increasing wages keyed to the
+    test occupation titles `Occupation 0`..`Occupation N-1`, so that
+    `Clusters.wage_tier_map` produces deterministic tier indices for graph
+    fixtures rather than degenerating on identical zero wages.
     """
     path = tmp_path / "labor.json"
-    path.write_text("[]")
+    path.write_text(dumps([
+        {"soc_title": f"Occupation {cid}", "annual_median": 40000 + cid * 20000}
+        for cid in range(CLUSTER_COUNT)
+    ]))
     return LaborLoader(path)
 
 
@@ -190,7 +200,6 @@ def clusters(
     centroids       : np.ndarray,
     cluster_vectors : np.ndarray,
     credentials     : list[Credential],
-    job_zone_map    : dict[int, int],
     labor           : LaborLoader,
     unit_vectors    : np.ndarray
 ) -> Clusters:
@@ -205,7 +214,6 @@ def clusters(
         cid: Cluster(
             cluster_id  = cid,
             embeddings  = unit_vectors[assignments == cid],
-            job_zone    = job_zone_map[cid],
             modal_title = f"Title {cid}",
             postings    = [],
             sector      = f"Sector {cid % 2}",
@@ -228,6 +236,7 @@ def clusters(
         softmax_tau       = 0.02,
         vectors           = cluster_vectors,
         wage_round        = 10,
+        wage_tier_count   = 2,
         wage_topk         = 3
     )
 
@@ -270,23 +279,6 @@ def credentials() -> list[Credential]:
         )
         for i in range(10)
     ]
-
-
-@fixture
-def job_zone_map(cluster_ids: list[int]) -> dict[int, int]:
-    """
-    Deterministic Job Zone assignment for synthetic clusters.
-
-    Spreads clusters across Job Zones 2-4 to exercise stepwise k-NN lateral and
-    upward edge logic. Production uses top-3 median cosine against O*NET,
-    but tests use fixed values to avoid coupling to fixture occupation
-    count.
-    """
-    job_zone_values = [2, 2, 3, 4]
-    return {
-        cluster_id: job_zone_values[idx % len(job_zone_values)]
-        for idx, cluster_id in enumerate(cluster_ids)
-    }
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from chalkline.pathways.clusters  import Cluster, Clusters, Task
 from chalkline.pathways.graph     import CareerPathwayGraph
 from chalkline.pathways.loaders   import LaborLoader, StakeholderReference
 from chalkline.pathways.schemas   import Credential
+from chalkline.pipeline.schemas   import PipelineConfig
 
 
 CLUSTER_COUNT   = 4
@@ -188,6 +189,7 @@ def clusters(
     assignments     : np.ndarray,
     centroids       : np.ndarray,
     cluster_vectors : np.ndarray,
+    credentials     : list[Credential],
     job_zone_map    : dict[int, int],
     labor           : LaborLoader,
     unit_vectors    : np.ndarray
@@ -218,6 +220,7 @@ def clusters(
     }
     return Clusters(
         centroids         = centroids,
+        credentials       = credentials,
         items             = items,
         labor             = labor,
         occupation_titles = titles,
@@ -300,6 +303,22 @@ def pathway_graph(
         destination_percentile = 20,
         lateral_neighbors      = 2,
         upward_neighbors       = 2
+    )
+
+
+@fixture
+def pipeline_config(tmp_path: Path) -> PipelineConfig:
+    """
+    Pipeline config wired with the test-suite constants and a `tmp_path` for
+    both lexicon and postings directories. Tests that need a different field
+    override it via `model_copy(update={...})`.
+    """
+    return PipelineConfig(
+        cluster_count   = CLUSTER_COUNT,
+        component_count = COMPONENT_COUNT,
+        consensus_seeds = 3,
+        lexicon_dir     = tmp_path,
+        postings_dir    = tmp_path
     )
 
 

--- a/tests/display/test_map.py
+++ b/tests/display/test_map.py
@@ -1,0 +1,60 @@
+"""
+Tests for the map widget tier assignment over the match-percent curve.
+
+Covers the three branches of `_tier_assignments` (small corpora, flat
+curves, kneed elbow) and the matched-always-tier-1 invariant that
+drives hero card rendering.
+"""
+
+from chalkline.display.tabs.map.widget import _tier_assignments
+
+
+class TestTierAssignments:
+    """
+    Branch coverage for the elbow-clamped tier picker.
+    """
+
+    def test_empty_input_returns_empty(self):
+        """
+        No clusters yields no tier assignments.
+        """
+        assert _tier_assignments({}, matched_id=0) == {}
+
+    def test_few_candidates_promote_everyone(self):
+        """
+        With 10 or fewer non-matched candidates, every cluster lands
+        in tier 1 because there is nothing to hide.
+        """
+        scores = {i: 0.9 - 0.05 * i for i in range(8)}
+        tiers  = _tier_assignments(scores, matched_id=0)
+        assert all(t == 1 for t in tiers.values())
+
+    def test_flat_curve_caps_at_fifteen(self):
+        """
+        A flat match curve with more than 10 candidates bypasses
+        kneed and uses the upper bound, capping tier 1 at 16
+        (matched plus 15 others).
+        """
+        scores = {i: 0.5 for i in range(20)}
+        tiers  = _tier_assignments(scores, matched_id=0)
+        assert sum(t == 1 for t in tiers.values()) == 16
+
+    def test_matched_always_tier_one(self):
+        """
+        The matched cluster is always tier 1 even when its score
+        sits below the elbow over remaining candidates.
+        """
+        scores = {0: 0.05, 1: 0.9, 2: 0.85, 3: 0.4, 4: 0.1}
+        tiers  = _tier_assignments(scores, matched_id=0)
+        assert tiers[0] == 1
+
+    def test_sharp_elbow_floors_at_ten(self):
+        """
+        A curve whose elbow falls below 10 still promotes 10
+        non-matched neighbors so the canvas does not feel sparse.
+        """
+        scores = {0: 1.0}
+        for i in range(1, 20):
+            scores[i] = 0.9 if i <= 3 else 0.05
+        tiers = _tier_assignments(scores, matched_id=0)
+        assert sum(t == 1 for t in tiers.values()) == 11

--- a/tests/display/test_schemas.py
+++ b/tests/display/test_schemas.py
@@ -85,7 +85,6 @@ class TestMapGeometry:
         """
         dims = MapGeometry().dimensions
         assert "default_wage_range" not in dims
-        assert "title_char_limit" not in dims
 
     def test_dimensions_includes_layout(self):
         """

--- a/tests/matching/test_matcher.py
+++ b/tests/matching/test_matcher.py
@@ -200,7 +200,6 @@ class TestResumeMatcher:
         empty = Cluster(
             cluster_id  = 999,
             embeddings  = np.empty((0, 4)),
-            job_zone    = 1,
             modal_title = "Empty",
             postings    = [],
             sector      = "Test",
@@ -245,7 +244,6 @@ class TestResumeMatcher:
         cluster = Cluster(
             cluster_id  = 777,
             embeddings  = np.random.RandomState(55).randn(3, 16).astype(np.float32),
-            job_zone    = 2,
             modal_title = "Test",
             postings    = postings,
             sector      = "Test",
@@ -272,7 +270,6 @@ class TestResumeMatcher:
         solo = Cluster(
             cluster_id  = 888,
             embeddings  = vec,
-            job_zone    = 2,
             modal_title = "Solo",
             postings    = [],
             sector      = "Test",

--- a/tests/pathways/test_clusters.py
+++ b/tests/pathways/test_clusters.py
@@ -91,6 +91,23 @@ class TestClusters:
             for j in range(n):
                 assert matrix[i][j] == matrix[j][i]
 
+    def test_display_titles_disambiguate_duplicates(self, clusters: Clusters):
+        """
+        Clusters sharing a SOC title receive distinguishing TF-IDF
+        suffixes while clusters with a unique SOC title keep the bare
+        title unchanged.
+        """
+        titles_by_soc: dict[str, list[str]] = {}
+        for cid, label in clusters.display_titles.items():
+            titles_by_soc.setdefault(clusters[cid].soc_title, []).append(label)
+
+        for soc, labels in titles_by_soc.items():
+            if len(labels) == 1:
+                assert labels[0] == soc
+            else:
+                assert all(label.startswith(f"{soc} (") for label in labels)
+                assert len(set(labels)) == len(labels)
+
     def test_getitem(self, clusters: Clusters):
         """
         Bracket access returns the `Cluster` with the matching ID.

--- a/tests/pathways/test_clusters.py
+++ b/tests/pathways/test_clusters.py
@@ -20,14 +20,14 @@ class TestCluster:
 
     def test_display_label_format(self, clusters: Clusters):
         """
-        Display label includes the cluster ID, SOC title, and Job
-        Zone for human-readable dropdown labels.
+        Display label includes the cluster ID, SOC title, and 1-indexed
+        wage tier for human-readable dropdown labels.
         """
         cluster = clusters[clusters.cluster_ids[0]]
         label   = cluster.display_label
         assert f"Cluster {cluster.cluster_id}" in label
         assert cluster.soc_title in label
-        assert f"Job Zone {cluster.job_zone}" in label
+        assert f"Tier {cluster.wage_tier + 1}" in label
 
     def test_sub_role_labels_k1_fallback(self, clusters: Clusters):
         """
@@ -53,7 +53,8 @@ class TestClusters:
         "cluster_heatmap",
         "pairwise_distances",
         "soc_heatmap",
-        "vector_map"
+        "vector_map",
+        "wage_tier_map"
     ])
     def test_cached_property_stable(self, clusters: Clusters, prop: str):
         """
@@ -121,14 +122,6 @@ class TestClusters:
         Iteration yields cluster IDs in sorted order.
         """
         assert list(clusters) == sorted(clusters.cluster_ids)
-
-    def test_job_zone_map_coverage(self, clusters: Clusters):
-        """
-        `job_zone_map` has an entry for every cluster ID and values
-        match the underlying `Cluster.job_zone` attributes.
-        """
-        for cid in clusters.cluster_ids:
-            assert clusters.job_zone_map[cid] == clusters[cid].job_zone
 
     def test_len(self, clusters: Clusters):
         """

--- a/tests/pathways/test_graph.py
+++ b/tests/pathways/test_graph.py
@@ -63,19 +63,6 @@ class TestCareerPathwayGraph:
         for w in pathway_graph.edge_weights:
             assert -1 <= w <= 1
 
-    def test_hops_from_self_distance(
-        self,
-        cluster_ids   : list[int],
-        pathway_graph : CareerPathwayGraph
-    ):
-        """
-        Hops from a node to itself is zero, and all reachable nodes
-        carry non-negative integer distances.
-        """
-        distances = pathway_graph.hops_from(cluster_ids[0])
-        assert distances[cluster_ids[0]] == 0
-        assert all(d >= 0 for d in distances.values())
-
     def test_no_credentials_builds_graph(self, clusters: Clusters):
         """
         A graph with no credentials still builds a valid backbone, and

--- a/tests/pathways/test_graph.py
+++ b/tests/pathways/test_graph.py
@@ -86,6 +86,7 @@ class TestCareerPathwayGraph:
             credentials            = [],
             destination_percentile = 20,
             lateral_neighbors      = 2,
+            rrf_k                  = 60,
             upward_neighbors       = 2
         )
         assert graph.graph.number_of_edges() > 0

--- a/tests/pathways/test_graph.py
+++ b/tests/pathways/test_graph.py
@@ -3,7 +3,7 @@ Validate career pathway graph construction and per-pair credential
 filtering from synthetic embedding fixtures.
 
 Tests focus on invariants that would silently corrupt downstream
-reach exploration if broken, including edge directionality, Job Zone
+reach exploration if broken, including edge directionality, wage-tier
 ordering, backbone connectivity, and the dual-threshold credential
 filter.
 """
@@ -91,22 +91,19 @@ class TestCareerPathwayGraph:
         assert graph.graph.number_of_edges() > 0
         assert graph.credentials_for(clusters.cluster_ids[-1]) == []
 
-    def test_reach_types(
-        self,
-        job_zone_map  : dict[int, int],
-        pathway_graph : CareerPathwayGraph
-    ):
+    def test_reach_types(self, pathway_graph: CareerPathwayGraph):
         """
-        Reach advancement edges point to higher Job Zone clusters and
-        lateral edges point to same Job Zone clusters.
+        Reach advancement edges point to higher wage-tier clusters and
+        lateral edges point to same wage-tier clusters.
         """
+        tiers = pathway_graph.clusters.wage_tier_map
         for cluster_id in pathway_graph.clusters:
             reach       = pathway_graph.reach(cluster_id)
-            source_zone = job_zone_map[cluster_id]
+            source_tier = tiers[cluster_id]
             for edge in reach.advancement:
-                assert job_zone_map[edge.cluster_id] > source_zone
+                assert tiers[edge.cluster_id] > source_tier
             for edge in reach.lateral:
-                assert job_zone_map[edge.cluster_id] == source_zone
+                assert tiers[edge.cluster_id] == source_tier
 
     def test_reach_weight_order(self, pathway_graph: CareerPathwayGraph):
         """
@@ -119,22 +116,19 @@ class TestCareerPathwayGraph:
                 weights = [e.weight for e in edges]
                 assert weights == sorted(weights, reverse=True)
 
-    def test_upward_stepwise(
-        self,
-        job_zone_map  : dict[int, int],
-        pathway_graph : CareerPathwayGraph
-    ):
+    def test_upward_stepwise(self, pathway_graph: CareerPathwayGraph):
         """
-        Upward edges connect only to the next Job Zone level, never
+        Upward edges connect only to the next wage-tier level, never
         skipping tiers.
         """
-        levels    = sorted(set(job_zone_map.values()))
-        next_zone = dict(zip(levels, levels[1:]))
+        tiers     = pathway_graph.clusters.wage_tier_map
+        levels    = sorted(set(tiers.values()))
+        next_tier = dict(zip(levels, levels[1:]))
 
         for source, target in pathway_graph.graph.edges():
-            source_zone = job_zone_map[source]
-            target_zone = job_zone_map[target]
-            if target_zone > source_zone:
-                assert target_zone == next_zone[source_zone]
+            source_tier = tiers[source]
+            target_tier = tiers[target]
+            if target_tier > source_tier:
+                assert target_tier == next_tier[source_tier]
 
 

--- a/tests/pathways/test_selection.py
+++ b/tests/pathways/test_selection.py
@@ -3,8 +3,8 @@ Tests for candidate-set selection algorithms over the pathways domain.
 
 Validates `SOCScorer` MaxSim semantics (a pooled-vector baseline would
 silently misrank specialty SOCs against cluster centroids) and the
-waste-aware Pareto-knee credential picker's coverage floor, fallback,
-and determinism guarantees.
+waste-aware Pareto-knee credential picker's coverage behavior, edge
+cases, and determinism guarantees.
 """
 
 import numpy as np
@@ -12,8 +12,7 @@ import numpy as np
 from pytest                import fixture, mark, raises
 from sklearn.preprocessing import normalize
 
-from chalkline.pathways.schemas   import EncodedOccupation, Occupation, Skill
-from chalkline.pathways.schemas   import SelectorConfig, SelectorFrontier, SkillType
+from chalkline.pathways.schemas   import EncodedOccupation, Occupation, Skill, SkillType
 from chalkline.pathways.selection import CredentialSelector, SOCScorer
 
 
@@ -45,8 +44,8 @@ def encoded_occupations() -> list[EncodedOccupation]:
         EncodedOccupation(
             occupation = make_occupation("Beta",    ["b1", "b2", "b3"]),
             tasks      = normalize(np.array([
-                [0, 1.0, 0,   0], 
-                [0, 0.8, 0.2, 0], 
+                [0, 1.0, 0,   0],
+                [0, 0.8, 0.2, 0],
                 [0, 0.5, 0.5, 0]
             ]))
         ),
@@ -57,26 +56,253 @@ def encoded_occupations() -> list[EncodedOccupation]:
     ]
 
 
+@fixture
+def selector() -> CredentialSelector:
+    """
+    Default-config picker, reused across tests.
+    """
+    return CredentialSelector(coverage_floor=0.80)
+
+
+class TestCredentialSelector:
+    """
+    Validate waste-aware Pareto-knee selection across edge cases that
+    would silently misrank credential stacks.
+    """
+
+    @mark.parametrize(
+        "coverage, gap_set, max_picks",
+        [
+            ({},                              frozenset({0}),    3),
+            ({"A": {0: 0.5}},                 frozenset(),       3),
+            ({"A": {0: 0.5}, "B": {1: 0.5}},  frozenset({0, 1}), 0)
+        ],
+        ids=["empty_coverage", "empty_gap_set", "zero_max_picks"]
+    )
+    def test_degenerate_inputs_return_empty(
+        self,
+        selector  : CredentialSelector,
+        coverage  : dict[str, dict[int, float]],
+        gap_set   : frozenset[int],
+        max_picks : int
+    ):
+        """
+        Empty pool, empty gap set, and a zero pick cap each short-circuit
+        to an empty list rather than raising or producing a phantom stack.
+        """
+        assert selector.select_stack(
+            coverage  = coverage,
+            gap_set   = gap_set,
+            max_picks = max_picks
+        ) == []
+
+    def test_determinism_across_runs(self, selector: CredentialSelector):
+        """
+        Repeated calls on identical input return identical picks. The
+        Pareto-knee greedy must not introduce hidden randomness.
+        """
+        coverage  = {
+            "A": {0: 0.5, 1: 0.5},
+            "B": {1: 0.5, 2: 0.5},
+            "C": {2: 0.5, 3: 0.5}
+        }
+        gap_set   = frozenset({0, 1, 2, 3})
+        max_picks = 3
+        first  = selector.select_stack(coverage=coverage, gap_set=gap_set, max_picks=max_picks)
+        second = selector.select_stack(coverage=coverage, gap_set=gap_set, max_picks=max_picks)
+        assert first == second
+
+    def test_drops_picks_with_zero_unique_gain(self, selector: CredentialSelector):
+        """
+        A credential whose gap coverage is fully subsumed by an
+        already-picked credential adds no unique gap and should not
+        appear in the output, even if it sits on the alpha-sweep frontier
+        for some intermediate setting.
+        """
+        picks = selector.select_stack(
+            coverage  = {
+                "A": {0: 0.5, 1: 0.5, 2: 0.5},
+                "B": {0: 0.4, 1: 0.4}
+            },
+            gap_set   = frozenset({0, 1, 2, 3}),
+            max_picks = 2
+        )
+        assert {pick.label for pick in picks} == {"A"}
+
+    def test_high_floor_forces_full_coverage(self):
+        """
+        A near-100% coverage floor forces the picker past intermediate
+        knee points to the highest-coverage frontier point. Two
+        credentials together cover all four gaps; either alone covers
+        only two, so the floor disqualifies single-pick frontier points.
+        """
+        picks = CredentialSelector(coverage_floor=0.99).select_stack(
+            coverage  = {
+                "A": {0: 0.5, 1: 0.5},
+                "B": {2: 0.5, 3: 0.5}
+            },
+            gap_set   = frozenset({0, 1, 2, 3}),
+            max_picks = 2
+        )
+        assert {pick.label for pick in picks} == {"A", "B"}
+
+    def test_incremental_positions_are_non_overlapping(
+        self,
+        selector : CredentialSelector
+    ):
+        """
+        Each pick's gap positions cover only the gaps it newly
+        contributes, never double-counting a gap covered by an earlier
+        pick in the same stack.
+        """
+        picks = selector.select_stack(
+            coverage  = {"A": {0: 0.5, 1: 0.5}, "B": {1: 0.5, 2: 0.5}},
+            gap_set   = frozenset({0, 1, 2}),
+            max_picks = 2
+        )
+        seen = set()
+        for pick in picks:
+            assert not (pick.positions & seen)
+            seen |= pick.positions
+
+    def test_incremental_positions_restricted_to_gaps(
+        self,
+        selector : CredentialSelector
+    ):
+        """
+        Each pick's gained positions report only gap tasks, never
+        leaking onto already-demonstrated tasks the credential also
+        happens to reach.
+        """
+        picks = selector.select_stack(
+            coverage  = {"A": {0: 0.5, 5: 0.5}, "B": {1: 0.5, 6: 0.5}},
+            gap_set   = frozenset({0, 1}),
+            max_picks = 2
+        )
+        for pick in picks:
+            assert pick.positions <= {0, 1}
+
+    def test_low_floor_admits_knee_pick(self):
+        """
+        A relaxed coverage floor allows the picker to settle at the
+        Pareto knee even when more credentials could push coverage
+        higher. With a 0% floor and a single high-coverage credential
+        whose alternative pair contributes only marginal extra reach,
+        the knee selects the single credential.
+        """
+        picks = CredentialSelector(coverage_floor=0.0).select_stack(
+            coverage  = {
+                "A": {0: 0.5, 1: 0.5, 2: 0.5},
+                "B": {3: 0.5}
+            },
+            gap_set   = frozenset({0, 1, 2, 3}),
+            max_picks = 2
+        )
+        assert "A" in {pick.label for pick in picks}
+
+    def test_picks_two_disjoint_credentials(self, selector: CredentialSelector):
+        """
+        Two non-overlapping credentials should both surface when together
+        they cover a wider portion of the gap set than either alone.
+        """
+        picks = selector.select_stack(
+            coverage  = {
+                "A": {0: 0.6, 1: 0.5, 2: 0.4},
+                "B": {3: 0.5, 4: 0.6}
+            },
+            gap_set   = frozenset({0, 1, 2, 3, 4}),
+            max_picks = 3
+        )
+        assert {pick.label for pick in picks} == {"A", "B"}
+
+    def test_scored_but_empty_dicts_excluded(self, selector: CredentialSelector):
+        """
+        Credentials with empty score dicts drop from the pool rather
+        than appearing as zero-reach picks.
+        """
+        picks = selector.select_stack(
+            coverage  = {"A": {0: 0.5}, "B": {}, "C": {1: 0.5}},
+            gap_set   = frozenset({0, 1}),
+            max_picks = 3
+        )
+        assert "B" not in {pick.label for pick in picks}
+
+    def test_single_pick_breaks_ties_by_least_waste(self, selector: CredentialSelector):
+        """
+        When two credentials cover the same gap count, the single-pick
+        path prefers the one reaching fewer non-gap tasks.
+        """
+        picks = selector.select_stack(
+            coverage  = {
+                "narrow": {0: 0.5, 1: 0.5},
+                "broad":  {0: 0.5, 1: 0.5, 9: 0.5, 10: 0.5}
+            },
+            gap_set   = frozenset({0, 1}),
+            max_picks = 1
+        )
+        assert [pick.label for pick in picks] == ["narrow"]
+
+    def test_single_pick_picks_max_gap_credential(self, selector: CredentialSelector):
+        """
+        For `max_picks == 1` the picker returns the credential filling
+        the most gaps, never a low-coverage low-waste alternative. The
+        Pareto-knee machinery would otherwise settle at the curve's
+        elbow, which on a single-pick decision lands at lower coverage
+        than the user's "single best credential" intuition.
+        """
+        picks = selector.select_stack(
+            coverage  = {
+                "high":  {0: 0.5, 1: 0.5, 2: 0.5, 3: 0.5},
+                "mid":   {0: 0.5, 1: 0.5},
+                "low":   {0: 0.5}
+            },
+            gap_set   = frozenset({0, 1, 2, 3}),
+            max_picks = 1
+        )
+        assert [pick.label for pick in picks] == ["high"]
+
+    def test_unreachable_floor_falls_back_to_highest_coverage(self):
+        """
+        When the coverage floor exceeds what any frontier point can
+        reach, the picker falls back to the unconstrained frontier
+        rather than returning empty.
+        """
+        picks = CredentialSelector(coverage_floor=0.99).select_stack(
+            coverage  = {
+                "A": {0: 0.5, 1: 0.5},
+                "B": {2: 0.5}
+            },
+            gap_set   = frozenset({0, 1, 2, 3, 4}),
+            max_picks = 2
+        )
+        assert picks
+        assert {pick.label for pick in picks} <= {"A", "B"}
+
+
 class TestSOCScorer:
     """
     Validate shape, ordering, and numerical correctness of MaxSim output.
     """
 
-    def test_score_shape_and_dtype(
+    def test_score_cluster_order_matches_sorted_ids(
         self,
         encoded_occupations : list[EncodedOccupation]
     ):
         """
-        Output is a `(n_clusters, n_occupations)` float32 matrix.
+        Cluster rows appear in sorted assignment-id order regardless of
+        the order in which posting labels arrive.
         """
-        raw_vectors = np.random.default_rng(0).standard_normal((12, 4)).astype(np.float32)
-        assignments = np.array([0] * 6 + [1] * 6)
+        raw_vectors = np.array([
+            [0, 0, 1.0, 0], [1.0, 0, 0, 0], [0, 0, 1.0, 0], [1.0, 0, 0, 0]
+        ], dtype=np.float32)
+        assignments = np.array([2, 0, 2, 0])
         scores      = SOCScorer(occupations=encoded_occupations).score(
             assignments = assignments,
             raw_vectors = raw_vectors
         )
         assert scores.shape == (2, 3)
-        assert scores.dtype == np.float32
+        assert np.argmax(scores[0]) == 0
+        assert np.argmax(scores[1]) == 2
 
     def test_score_ranks_axis_aligned_postings(
         self,
@@ -99,45 +325,6 @@ class TestSOCScorer:
         assert np.argmax(scores[0]) == 0
         assert np.argmax(scores[1]) == 2
 
-    def test_score_respects_occupation_boundaries(
-        self,
-        encoded_occupations : list[EncodedOccupation]
-    ):
-        """
-        `np.maximum.reduceat` must segment by `owner_starts` so each column
-        reflects only that occupation's tasks. A posting aligned with
-        Beta's task axis should score higher against Beta than against
-        Alpha or Gamma, whose task vectors are orthogonal to it.
-        """
-        raw_vectors = np.array([[0, 1.0, 0, 0]], dtype=np.float32)
-        assignments = np.array([0])
-        scores      = SOCScorer(occupations=encoded_occupations).score(
-            assignments = assignments,
-            raw_vectors = raw_vectors
-        )[0]
-        assert scores[1] > scores[0]
-        assert scores[1] > scores[2]
-
-    def test_score_cluster_order_matches_sorted_ids(
-        self,
-        encoded_occupations : list[EncodedOccupation]
-    ):
-        """
-        Cluster rows appear in sorted assignment-id order regardless of
-        the order in which posting labels arrive.
-        """
-        raw_vectors = np.array([
-            [0, 0, 1.0, 0], [1.0, 0, 0, 0], [0, 0, 1.0, 0], [1.0, 0, 0, 0]
-        ], dtype=np.float32)
-        assignments = np.array([2, 0, 2, 0])
-        scores      = SOCScorer(occupations=encoded_occupations).score(
-            assignments = assignments,
-            raw_vectors = raw_vectors
-        )
-        assert scores.shape == (2, 3)
-        assert np.argmax(scores[0]) == 0
-        assert np.argmax(scores[1]) == 2
-
     def test_score_rejects_empty_task_matrix(self):
         """
         `SOCScorer` refuses to construct when any occupation contributes
@@ -157,177 +344,37 @@ class TestSOCScorer:
         with raises(ValueError, match="at least one task"):
             SOCScorer(occupations=occupations)
 
-
-class TestSelectorFrontier:
-    """
-    Validate the `waste` property derives correctly from stored counts.
-    """
-
-    def test_waste_is_total_minus_filled(self):
-        """
-        `waste` equals `total_reach - gaps_filled` for any valid point.
-        """
-        point = SelectorFrontier(alpha=0.3, gaps_filled=7, picks=(0, 1), total_reach=12)
-        assert point.waste == 5
-
-    def test_waste_zero_when_perfectly_efficient(self):
-        """
-        A stack whose reach lands entirely on gaps has zero waste.
-        """
-        point = SelectorFrontier(alpha=0.0, gaps_filled=4, picks=(3,), total_reach=4)
-        assert point.waste == 0
-
-
-@fixture
-def selector() -> CredentialSelector:
-    """
-    Default-config picker, reused across tests that do not exercise
-    `coverage_floor` tuning.
-    """
-    return CredentialSelector()
-
-
-class TestCredentialSelector:
-    """
-    Validate waste-aware selection under the Pareto-knee + coverage-floor
-    rule across edge cases that would silently misrank credential stacks.
-    """
-
-    def test_floor_met_when_coverage_reachable(self, selector: CredentialSelector):
-        """
-        A pool that can reach 100% coverage satisfies the 80% floor and
-        returns `floor_met=True`.
-        """
-        picks, floor_met = selector.select_stack(
-            coverage  = {
-                "A": {0: 0.6, 1: 0.5, 2: 0.4},
-                "B": {3: 0.5, 4: 0.6}
-            },
-            gap_set   = frozenset({0, 1, 2, 3, 4}),
-            max_picks = 3
-        )
-        assert floor_met
-        assert {label for label, _ in picks} == {"A", "B"}
-
-    def test_floor_missed_falls_back_to_best(self, selector: CredentialSelector):
-        """
-        When no stack can reach the floor, `floor_met=False` and the
-        returned stack is whatever the frontier knee selects from the
-        unconstrained Pareto curve.
-        """
-        picks, floor_met = selector.select_stack(
-            coverage  = {"A": {0: 0.5}, "B": {1: 0.5}},
-            gap_set   = frozenset(range(10)),
-            max_picks = 3
-        )
-        assert floor_met is False
-        assert len(picks) <= 3
-
-    @mark.parametrize(
-        "coverage, gap_set, max_picks",
-        [
-            ({},                              frozenset({0}),    3),
-            ({"A": {0: 0.5}},                 frozenset(),       3),
-            ({"A": {0: 0.5}, "B": {1: 0.5}},  frozenset({0, 1}), 0)
-        ],
-        ids = ["empty_coverage", "empty_gap_set", "zero_max_picks"]
-    )
-    def test_degenerate_inputs_return_empty(
+    def test_score_respects_occupation_boundaries(
         self,
-        selector  : CredentialSelector,
-        coverage  : dict[str, dict[int, float]],
-        gap_set   : frozenset[int],
-        max_picks : int
+        encoded_occupations : list[EncodedOccupation]
     ):
         """
-        Empty pool, empty gap set, and a zero pick cap each short-circuit
-        to `([], False)` rather than raising or producing a phantom stack.
+        `np.maximum.reduceat` must segment by `owner_starts` so each column
+        reflects only that occupation's tasks. A posting aligned with
+        Beta's task axis should score higher against Beta than against
+        Alpha or Gamma, whose task vectors are orthogonal to it.
         """
-        assert selector.select_stack(
-            coverage  = coverage,
-            gap_set   = gap_set,
-            max_picks = max_picks
-        ) == ([], False)
+        raw_vectors = np.array([[0, 1.0, 0, 0]], dtype=np.float32)
+        assignments = np.array([0])
+        scores      = SOCScorer(occupations=encoded_occupations).score(
+            assignments = assignments,
+            raw_vectors = raw_vectors
+        )[0]
+        assert scores[1] > scores[0]
+        assert scores[1] > scores[2]
 
-    def test_scored_but_empty_dicts_excluded(self, selector: CredentialSelector):
-        """
-        Credentials with empty score dicts drop from the pool rather
-        than appearing as zero-reach picks.
-        """
-        picks, _ = selector.select_stack(
-            coverage  = {"A": {0: 0.5}, "B": {}, "C": {1: 0.5}},
-            gap_set   = frozenset({0, 1}),
-            max_picks = 3
-        )
-        assert "B" not in {label for label, _ in picks}
-
-    def test_incremental_positions_are_non_overlapping(
+    def test_score_shape_and_dtype(
         self,
-        selector : CredentialSelector
+        encoded_occupations : list[EncodedOccupation]
     ):
         """
-        Each pick's gap positions cover only the gaps it newly
-        contributes, never double-counting a gap covered by an earlier
-        pick in the same stack.
+        Output is a `(n_clusters, n_occupations)` float32 matrix.
         """
-        picks, _ = selector.select_stack(
-            coverage  = {"A": {0: 0.5, 1: 0.5}, "B": {1: 0.5, 2: 0.5}},
-            gap_set   = frozenset({0, 1, 2}),
-            max_picks = 2
+        raw_vectors = np.random.default_rng(0).standard_normal((12, 4)).astype(np.float32)
+        assignments = np.array([0] * 6 + [1] * 6)
+        scores      = SOCScorer(occupations=encoded_occupations).score(
+            assignments = assignments,
+            raw_vectors = raw_vectors
         )
-        seen = set()
-        for _, positions in picks:
-            assert not (positions & seen)
-            seen |= positions
-
-    def test_incremental_positions_restricted_to_gaps(
-        self,
-        selector : CredentialSelector
-    ):
-        """
-        Each pick's gained positions report only gap tasks, never
-        leaking onto already-demonstrated tasks the credential also
-        happens to reach.
-        """
-        picks, _ = selector.select_stack(
-            coverage  = {"A": {0: 0.5, 5: 0.5}, "B": {1: 0.5, 6: 0.5}},
-            gap_set   = frozenset({0, 1}),
-            max_picks = 2
-        )
-        for _, positions in picks:
-            assert positions <= {0, 1}
-
-    def test_determinism_across_runs(self, selector: CredentialSelector):
-        """
-        Repeated calls on identical input return identical picks. The
-        Kneedle algorithm and the α sweep must not introduce hidden
-        randomness.
-        """
-        payload = dict(
-            coverage  = {"A": {0: 0.5, 1: 0.5}, "B": {1: 0.5, 2: 0.5}, "C": {2: 0.5, 3: 0.5}},
-            gap_set   = frozenset({0, 1, 2, 3}),
-            max_picks = 3
-        )
-        assert selector.select_stack(**payload) == selector.select_stack(**payload)
-
-    @mark.parametrize(
-        "coverage_floor, expected_met",
-        [(0.5, True), (1.0, False)],
-        ids = ["lenient", "strict"]
-    )
-    def test_config_coverage_floor_threshold(
-        self,
-        coverage_floor : float,
-        expected_met   : bool
-    ):
-        """
-        Raising `coverage_floor` tightens the eligible region, so a pool
-        that satisfies 0.5 may fail to satisfy 1.0.
-        """
-        picker = CredentialSelector(config=SelectorConfig(coverage_floor=coverage_floor))
-        _, floor_met = picker.select_stack(
-            coverage  = {"A": {0: 0.5}, "B": {1: 0.5}},
-            gap_set   = frozenset({0, 1, 2, 3}),
-            max_picks = 3
-        )
-        assert floor_met is expected_met
+        assert scores.shape == (2, 3)
+        assert scores.dtype == np.float32

--- a/tests/pipeline/test_steps.py
+++ b/tests/pipeline/test_steps.py
@@ -6,11 +6,47 @@ when fed synthetic fixture data, catching transform contract violations
 that would silently corrupt downstream results.
 """
 
+import numpy as np
+
 from pathlib import Path
 from pytest  import raises
 
 from chalkline.pipeline         import steps
 from chalkline.pipeline.schemas import PipelineConfig
+
+
+class TestAssignments:
+    """
+    Validate consensus clustering node.
+    """
+
+    def test_deterministic(
+        self,
+        pipeline_config : PipelineConfig,
+        raw_vectors     : np.ndarray
+    ):
+        """
+        Identical inputs produce identical labels because the internal seed
+        loop is `range(consensus_seeds)` rather than a sampled subset.
+        """
+        first  = steps.assignments(pipeline_config, raw_vectors)
+        second = steps.assignments(pipeline_config, raw_vectors)
+
+        assert np.array_equal(first, second)
+
+    def test_shape_and_range(
+        self,
+        pipeline_config : PipelineConfig,
+        raw_vectors     : np.ndarray
+    ):
+        """
+        One label per posting, every label inside `[0, cluster_count)`.
+        """
+        labels = steps.assignments(pipeline_config, raw_vectors)
+
+        assert labels.shape == (raw_vectors.shape[0],)
+        assert labels.min() >= 0
+        assert labels.max() < pipeline_config.cluster_count
 
 
 class TestCorpus:

--- a/tests/pipeline/test_steps.py
+++ b/tests/pipeline/test_steps.py
@@ -29,9 +29,18 @@ class TestAssignments:
         Identical inputs produce identical labels because the internal seed
         loop is `range(consensus_seeds)` rather than a sampled subset.
         """
-        first  = steps.assignments(pipeline_config, raw_vectors)
-        second = steps.assignments(pipeline_config, raw_vectors)
-
+        first = steps.assignments(
+            cluster_count   = pipeline_config.cluster_count,
+            component_count = pipeline_config.component_count,
+            consensus_seeds = pipeline_config.consensus_seeds,
+            raw_vectors     = raw_vectors
+        )
+        second = steps.assignments(
+            cluster_count   = pipeline_config.cluster_count,
+            component_count = pipeline_config.component_count,
+            consensus_seeds = pipeline_config.consensus_seeds,
+            raw_vectors     = raw_vectors
+        )
         assert np.array_equal(first, second)
 
     def test_shape_and_range(
@@ -42,7 +51,12 @@ class TestAssignments:
         """
         One label per posting, every label inside `[0, cluster_count)`.
         """
-        labels = steps.assignments(pipeline_config, raw_vectors)
+        labels = steps.assignments(
+            cluster_count   = pipeline_config.cluster_count,
+            component_count = pipeline_config.component_count,
+            consensus_seeds = pipeline_config.consensus_seeds,
+            raw_vectors     = raw_vectors
+        )
 
         assert labels.shape == (raw_vectors.shape[0],)
         assert labels.min() >= 0
@@ -60,7 +74,4 @@ class TestCorpus:
         """
         (tmp_path / "corpus.json").write_text("[]")
         with raises(FileNotFoundError):
-            steps.corpus(PipelineConfig(
-                lexicon_dir  = tmp_path,
-                postings_dir = tmp_path
-            ))
+            steps.corpus(corpus_mtime=0.0, postings_dir=str(tmp_path))


### PR DESCRIPTION
### 📐 Quick Summary

This branch refreshes the production corpus with residential exclusions at scrape time and reshapes the credential layer around Reciprocal Rank Fusion candidate filtering[^1] paired with an anchored Work-First strategy that binds an apprenticeship pick to a Pareto-knee[^2] certification stack on the residual gap set. Adjacent rework replaces the Job Zone preparation-label spine with K-means wage tiers derived from observed posting wages, switches cluster assignment to evidence-accumulation consensus[^3] over **50** SVD+Ward seeds for boundary stability, and re-tiers the map widget by a match-percent elbow with a sector legend.

***

### 🧱 Key Changes

#### Corpus

- Compose residential exclusion tokens onto every trade search term in `src/chalkline/collection/collector.py` via Indeed's `-token` syntax, declared as a single module-level constant
- Expand the trade keyword set from **16** to **29** entries after pilot validation against Maine posting yields
- Strip legacy custodial pollution from `data/postings/corpus.json` and refresh against the new query set with `date_collected` deduplication

#### Clustering

- Switch the `assignments` Hamilton node to evidence-accumulation consensus[^3] over **50** SVD-then-Ward seeds for boundary stability near sector edges
- Add `consensus_seeds` field to `PipelineConfig`, bump `component_count` from 10 to 15, and bump `cluster_count` to **25** to surface Mechanical Engineers and Carpenters as distinct clusters
- Rewrite `display_titles` with TF-IDF top-2 candidates filtered by sibling-relative `doc_freq` window and Zipf floor for cluster disambiguation

#### Wage-Tier Spine

- Add `wage_tier_count` config field defaulted to **5** with K-means partitioning of log wages, exposed as `Clusters.wage_tier_map` cached property ordered low to high by mean log wage
- Switch graph stepwise k-NN backbone and reach exploration to read `wage_tier_map` directly, so advancement reflects observed posting wages rather than O\*NET preparation labels
- Drop `Cluster.job_zone`, the `job_zone_map` Hamilton step, and the `soc_neighbors` config field
- Update glossary, hover text, and methods sections to wage-tier wording

#### Credentials

- Replace destination-affinity cosine threshold in `credentials_for` with Reciprocal Rank Fusion[^1] over centroid cosine and task MaxSim rankings, falling back to centroid-only when the destination has no task elements
- Add `credential_task_maxsim` cached property so the second RRF signal is computed once at fit time
- Add `CredentialPath.anchored_from_route` picking the apprenticeship most aligned with `task_maxsim`, complemented by a Pareto-knee[^2] certification stack on the residual gap set
- Hoist `coverage_floor` and `rrf_k` to `PipelineConfig` as required configuration fields and drop the `SelectorConfig` and `SelectorFrontier` types that duplicated them
- Tighten `destination_percentile` from 20 to 15 for tighter candidate pools
- Raise `credential_threshold` in matcher from median to **75th** percentile of positive task scores so coverage discriminates by term specificity rather than any-overlap

#### Map Widget

- Pick tier-1 cards via Kneedle elbow[^2] on the descending match-percent curve clamped to `[10, 15]`, replacing the BFS-hop neighbor rule that conflated centroid similarity with match strength
- Drop `hops_from` and `undirected_graph` from `CareerPathwayGraph` since no consumer reads centroid-kNN hops anymore
- Redraw matched-to-tier-1 edges in destination sector color with stroke width scaled by match score
- Add Your Match plus on-canvas sectors as a `selection.data().join()` legend pinned to the top-right corner

***

## 🪚 Implementation Notes

### Credential Layer Redesign

The previous destination-affinity cosine threshold could not separate credentials whose centroid similarity to the target was identical but whose per-task MaxSim told different stories, and a single-stack Pareto picker produced two failure modes (*"stack three apprenticeships" or "skip apprenticeships entirely"*) that no scoring tweak resolved structurally.

RRF absorbs the score-scale mismatch between the two ranking signals without calibration, and the anchored Work-First strategy binds apprenticeship selection to a title-aware signal outside the coverage matrix, so an Electricians cluster reliably anchors on the Electrician apprenticeship rather than whichever apprenticeship happened to share two task tokens.

### Wage-Tier Spine

Job Zone tiers came from O\*NET preparation labels assigned to occupations, meaning every cluster carried a discrete tier in `[1, 5]` from SOC metadata regardless of how its postings actually paid. The wage spine derives advancement strictly from observed posting wages, partitioning log wages with K-means (*k=5 by default*) and ordering tiers low to high by mean log wage. Stepwise advancement edges in the graph backbone read `wage_tier_map` directly, so a higher-paying cluster is one tier above its lower-paying siblings whether or not their preparation labels agreed.

### Consensus Clustering

A single SVD-then-Ward run produced unstable cluster boundaries near sector edges because Ward's greedy merging is sensitive to the SVD seed when posting embeddings sit close to a decision surface. The `assignments` node now runs **50** seeded SVD+Ward fits and applies evidence-accumulation consensus[^3] over the resulting co-association matrix, recovering boundaries that hold across reruns.

### Match-Percent Map Tiering

The map's tier-1 cards previously came from a BFS over the centroid-kNN backbone, so a card adjacent to the matched cluster could show **8%** match while a tier-2 outlier showed **35%**, because centroid cosine and BM25-weighted task MaxSim measure different things. Match scores from `ResumeMatcher.calibrate()` now drive the tier rule via Kneedle elbow[^2] on the descending curve, clamped to `[10, 15]` so the canvas always surfaces a meaningful set of next-step options regardless of curve shape. Edges fan from the matched cluster to its tier-1 cards with stroke width scaled by match score, replacing the centroid-similarity edge weights that previously double-rendered the same idea.

***

### 🔩 Related Issues

- Closes #43

***

### 📚 References

[^1]: Cormack, G. V., Clarke, C. L. A., and Buettcher, S. 2009. "Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods." *Proceedings of the 32nd International ACM SIGIR Conference on Research and Development in Information Retrieval*: 758-759. https://doi.org/10.1145/1571941.1572114

[^2]: Satopaa, V., Albrecht, J., Irwin, D., and Raghavan, B. 2011. "Finding a 'Kneedle' in a Haystack: Detecting Knee Points in System Behavior." *31st International Conference on Distributed Computing Systems Workshops*: 166-171. https://doi.org/10.1109/ICDCSW.2011.20

[^3]: Fred, A. L. N. and Jain, A. K. 2005. "Combining Multiple Clusterings Using Evidence Accumulation." *IEEE Transactions on Pattern Analysis and Machine Intelligence* 27(6): 835-850. https://doi.org/10.1109/TPAMI.2005.113